### PR TITLE
Derive the Preferences data directory from a chosen .app

### DIFF
--- a/src/ui/widgets/GameLocationWidget.cpp
+++ b/src/ui/widgets/GameLocationWidget.cpp
@@ -1,4 +1,5 @@
 #include "GameLocationWidget.h"
+#include "state/GameLauncher.h"
 #include "util/GameDataPathResolver.h"
 #include "ui/IconHelper.h"
 #include "ui/Settings.h"
@@ -81,6 +82,7 @@ void GameLocationWidget::setupUI() {
     _executableLayout = new QHBoxLayout();
     _executableLayout->setSpacing(ui::theme::spacing::NORMAL);
     _executableLocationEdit = new QLineEdit();
+    _executableLocationEdit->setObjectName("executableLocationEdit");
     _executableLocationEdit->setPlaceholderText("Path to the Fallout 2 executable (e.g. fallout2.exe)...");
     _executableLayout->addWidget(_executableLocationEdit);
 
@@ -97,6 +99,8 @@ void GameLocationWidget::setupUI() {
     _dataDirectoryLayout = new QHBoxLayout();
     _dataDirectoryLayout->setSpacing(ui::theme::spacing::NORMAL);
     _dataDirectoryEdit = new QLineEdit();
+    _dataDirectoryEdit->setObjectName("dataDirectoryEdit"); // found by name in tests
+
     _dataDirectoryEdit->setPlaceholderText("Folder containing data/ (e.g. .../GOG.com/Fallout 2)...");
     _dataDirectoryEdit->setToolTip(
         "The game folder itself - the one that contains data/, master.dat and the executable.\n"
@@ -168,6 +172,11 @@ std::filesystem::path GameLocationWidget::getDataDirectory() const {
 }
 
 void GameLocationWidget::setDataDirectory(const std::filesystem::path& location) {
+    // A bundle-derived directory outranks anything stored: the setting was never what the engine
+    // read, so restoring it here would just put the stale value back on screen.
+    if (_dataDirectoryEdit->isReadOnly()) {
+        return;
+    }
     _dataDirectoryEdit->setText(QString::fromStdString(location.string()));
 }
 
@@ -178,7 +187,31 @@ void GameLocationWidget::setStatusMessage(const QString& message, const QString&
 }
 
 void GameLocationWidget::onExecutableLocationChanged() {
+    applyBundleDataDirectoryLock();
     Q_EMIT configurationChanged();
+}
+
+void GameLocationWidget::applyBundleDataDirectoryLock() {
+    // A macOS .app fixes the game root itself - the engine chdir's to the bundle's base path on
+    // startup - so for one of those this field cannot influence anything. Show the directory that
+    // will actually be used instead of a value with no effect. Only when the bundle really resolves:
+    // an unreadable Info.plist gives nothing, and there the setting genuinely is used.
+    const std::optional<std::filesystem::path> bundleRoot = macOsBundleDataRoot(getExecutableLocation());
+
+    if (bundleRoot.has_value()) {
+        _dataDirectoryEdit->setReadOnly(true);
+        _dataDirectoryEdit->setText(QString::fromStdString(bundleRoot->string()));
+        _dataDirectoryEdit->setToolTip(tr("Set by the application bundle: Fallout 2 switches to this "
+                                          "directory on startup, so it is the one the map is written to. "
+                                          "Pick a different executable to change it."));
+        _browseDataDirectoryButton->setEnabled(false);
+    } else if (_dataDirectoryEdit->isReadOnly()) {
+        // Moved off a bundle: hand the field back, and drop the value that came from the old one.
+        _dataDirectoryEdit->setReadOnly(false);
+        _dataDirectoryEdit->clear();
+        _dataDirectoryEdit->setToolTip({});
+        _browseDataDirectoryButton->setEnabled(true);
+    }
 }
 
 void GameLocationWidget::onDataDirectoryChanged() {

--- a/src/ui/widgets/GameLocationWidget.cpp
+++ b/src/ui/widgets/GameLocationWidget.cpp
@@ -28,10 +28,12 @@ namespace {
 
     /// Whether a macOS .app actually has a binary to launch (they live in Contents/MacOS).
     bool bundleHasLaunchableBinary(const std::filesystem::path& bundle) {
+        // Stepping the iterator by hand: the range-for form calls the throwing operator++, and this
+        // runs in a Qt slot, where a filesystem_error from an unreadable directory reaches no catch.
         std::error_code ec;
         const std::filesystem::path macosDir = bundle / "Contents" / "MacOS";
-        for (const auto& entry : std::filesystem::directory_iterator(macosDir, ec)) {
-            if (entry.is_regular_file(ec)) {
+        for (std::filesystem::directory_iterator it(macosDir, ec), end; !ec && it != end; it.increment(ec)) {
+            if (it->is_regular_file(ec)) {
                 return true;
             }
         }
@@ -324,7 +326,10 @@ void GameLocationWidget::onAutoDetect() {
         const auto& installation = detectedInstallations.front();
         _executableLocationEdit->setText(QString::fromStdString(installation.path.string()));
         if (const auto dataDirectory = util::resolveGameDataRoot(installation.path)) {
-            _dataDirectoryEdit->setText(QString::fromStdString(dataDirectory->string()));
+            // Through the setter, not the field: setting the executable may already have derived the
+            // directory from a bundle and locked it, and resolveGameDataRoot answers a different
+            // question (where the install lives, not where the engine chdir's to).
+            setDataDirectory(*dataDirectory);
         }
 
         setStatusMessage(QString("Auto-detected installation: %1").arg(QString::fromStdString(installation.description)), "success");

--- a/src/ui/widgets/GameLocationWidget.cpp
+++ b/src/ui/widgets/GameLocationWidget.cpp
@@ -7,6 +7,7 @@
 
 #include <QApplication>
 #include <QFormLayout>
+#include <QSignalBlocker>
 #include <QStandardPaths>
 #include <QFileDialog>
 #include <QDir>
@@ -209,6 +210,11 @@ void GameLocationWidget::applyBundleDataDirectoryLock() {
     // will actually be used instead of a value with no effect. Only when the bundle really resolves:
     // an unreadable Info.plist gives nothing, and there the setting genuinely is used.
     const std::optional<std::filesystem::path> bundleRoot = macOsBundleDataRoot(getExecutableLocation());
+
+    // The edits below are ours, not the user's: onExecutableLocationChanged emits one
+    // configurationChanged for the whole update, and letting the field raise its own would nest a
+    // second dialog refresh inside the first.
+    const QSignalBlocker dataDirectoryBlocker(_dataDirectoryEdit);
 
     if (bundleRoot.has_value()) {
         _dataDirectoryEdit->setReadOnly(true);

--- a/src/ui/widgets/GameLocationWidget.cpp
+++ b/src/ui/widgets/GameLocationWidget.cpp
@@ -25,6 +25,18 @@ namespace {
             || lowercaseFileName.endsWith(".app");
     }
 
+    /// Whether a macOS .app actually has a binary to launch (they live in Contents/MacOS).
+    bool bundleHasLaunchableBinary(const std::filesystem::path& bundle) {
+        std::error_code ec;
+        const std::filesystem::path macosDir = bundle / "Contents" / "MacOS";
+        for (const auto& entry : std::filesystem::directory_iterator(macosDir, ec)) {
+            if (entry.is_regular_file(ec)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     bool directoryHasFalloutExecutable(const std::filesystem::path& dir) {
         static constexpr std::array<const char*, 8> kExecutableNames = {
             "fallout2.exe", "Fallout2.exe", "fallout2", "Fallout2",
@@ -320,15 +332,25 @@ void GameLocationWidget::onAutoDetect() {
     }
 }
 
+void GameLocationWidget::validateSelection() {
+    validateGameLocation(_executableLocationEdit->text().trimmed());
+}
+
 void GameLocationWidget::validateGameLocation(const QString& gamePath) {
     const std::filesystem::path path(gamePath.toStdString());
 
-    if (std::filesystem::is_regular_file(path)) {
+    if (!std::filesystem::exists(path)) {
+        setStatusMessage("Warning: Selected path does not exist.", "error");
+        return;
+    }
+
+    // A macOS .app is a directory, but it is an executable choice rather than an installation
+    // folder: its binary sits in Contents/MacOS, so the installation check can never pass on one
+    // and every bundle was reported as "may not be a valid Fallout 2 installation".
+    if (std::filesystem::is_regular_file(path) || path.extension() == ".app") {
         validateExecutableFile(path);
     } else if (std::filesystem::is_directory(path)) {
         validateInstallDirectory(path);
-    } else {
-        setStatusMessage("Warning: Selected path does not exist.", "error");
     }
 }
 
@@ -336,6 +358,11 @@ void GameLocationWidget::validateExecutableFile(const std::filesystem::path& pat
     const QString fileName = QString::fromStdString(path.filename().string()).toLower();
     if (!looksLikeFalloutExecutable(fileName)) {
         setStatusMessage("Warning: Selected file may not be a valid Fallout 2 executable.", "warning");
+        return;
+    }
+    // Any .app satisfies the name test, so check a bundle can actually be launched.
+    if (path.extension() == ".app" && !bundleHasLaunchableBinary(path)) {
+        setStatusMessage("Warning: Selected application bundle contains no executable.", "warning");
         return;
     }
 

--- a/src/ui/widgets/GameLocationWidget.cpp
+++ b/src/ui/widgets/GameLocationWidget.cpp
@@ -38,6 +38,12 @@ namespace {
         return false;
     }
 
+    /// The data-directory field's own explanation, restored whenever a bundle stops driving it.
+    const char* dataDirectoryHelp() {
+        return "The game folder itself - the one that contains data/, master.dat and the executable.\n"
+               "Not the data folder inside it.";
+    }
+
     bool directoryHasFalloutExecutable(const std::filesystem::path& dir) {
         static constexpr std::array<const char*, 8> kExecutableNames = {
             "fallout2.exe", "Fallout2.exe", "fallout2", "Fallout2",
@@ -113,11 +119,8 @@ void GameLocationWidget::setupUI() {
     _dataDirectoryLayout->setSpacing(ui::theme::spacing::NORMAL);
     _dataDirectoryEdit = new QLineEdit();
     _dataDirectoryEdit->setObjectName("dataDirectoryEdit"); // found by name in tests
-
     _dataDirectoryEdit->setPlaceholderText("Folder containing data/ (e.g. .../GOG.com/Fallout 2)...");
-    _dataDirectoryEdit->setToolTip(
-        "The game folder itself - the one that contains data/, master.dat and the executable.\n"
-        "Not the data folder inside it.");
+    _dataDirectoryEdit->setToolTip(dataDirectoryHelp());
     _dataDirectoryLayout->addWidget(_dataDirectoryEdit);
 
     _browseDataDirectoryButton = new QPushButton("Browse...");
@@ -227,7 +230,7 @@ void GameLocationWidget::applyBundleDataDirectoryLock() {
         // Moved off a bundle: hand the field back, and drop the value that came from the old one.
         _dataDirectoryEdit->setReadOnly(false);
         _dataDirectoryEdit->clear();
-        _dataDirectoryEdit->setToolTip({});
+        _dataDirectoryEdit->setToolTip(dataDirectoryHelp());
         _browseDataDirectoryButton->setEnabled(true);
     }
 }

--- a/src/ui/widgets/GameLocationWidget.h
+++ b/src/ui/widgets/GameLocationWidget.h
@@ -32,6 +32,9 @@ public:
     std::filesystem::path getDataDirectory() const;
     void setDataDirectory(const std::filesystem::path& location);
 
+    /// Re-runs validation on the current executable selection and updates the status line.
+    void validateSelection();
+
     // Status updates
     void setStatusMessage(const QString& message, const QString& styleClass = "normal");
 

--- a/src/ui/widgets/GameLocationWidget.h
+++ b/src/ui/widgets/GameLocationWidget.h
@@ -49,6 +49,8 @@ private slots:
 private:
     void setupUI();
     void setupConnections();
+    /// Derives the data directory from a macOS .app and locks the field, or releases it again.
+    void applyBundleDataDirectoryLock();
     void validateGameLocation(const QString& gamePath);
     void validateExecutableFile(const std::filesystem::path& path);
     void validateInstallDirectory(const std::filesystem::path& path);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -107,6 +107,8 @@ add_executable(qt_tests
     # GameLauncher is an app-layer Qt class, so its ddraw.ini test links gecko::app.
     qt/test_ddraw_ini.cpp
     qt/test_game_launcher.cpp
+    # Preferences: a macOS .app fixes the game root, so the data-directory field follows it.
+    qt/test_game_location_widget.cpp
     qt/test_palette_model.cpp
     qt/test_object_palette_indexing.cpp
     # PatternSerializer is the editor's Qt (QByteArray/QString) serializer.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -105,6 +105,8 @@ add_executable(qt_tests
     # GameLauncher is an app-layer Qt class, so its ddraw.ini test links gecko::app.
     qt/test_ddraw_ini.cpp
     qt/test_game_launcher.cpp
+    # Preferences: a macOS .app fixes the game root, so the data-directory field follows it.
+    qt/test_game_location_widget.cpp
     qt/test_palette_model.cpp
     qt/test_object_palette_indexing.cpp
     # PatternSerializer is the editor's Qt (QByteArray/QString) serializer.

--- a/tests/qt/test_game_location_widget.cpp
+++ b/tests/qt/test_game_location_widget.cpp
@@ -15,8 +15,8 @@ namespace {
 
 // Read-only state is not exposed on the widget's API, so reach the field by objectName - by
 // position would silently follow a reordered layout onto the wrong edit.
-QLineEdit* dataDirectoryEdit(GameLocationWidget& widget) {
-    auto* edit = widget.findChild<QLineEdit*>("dataDirectoryEdit");
+const QLineEdit* dataDirectoryEdit(const GameLocationWidget& widget) {
+    const QLineEdit* edit = widget.findChild<QLineEdit*>("dataDirectoryEdit");
     REQUIRE(edit != nullptr);
     return edit;
 }
@@ -48,7 +48,7 @@ TEST_CASE("Choosing an .app fills the data directory from it and locks the field
     const std::filesystem::path root = tempDir.path().toStdString();
 
     GameLocationWidget widget;
-    QLineEdit* dataDir = dataDirectoryEdit(widget);
+    const QLineEdit* dataDir = dataDirectoryEdit(widget);
 
     SECTION("A bundle drives the field and takes it out of the user's hands") {
         widget.setExecutableLocation(makeBundle(root, "parent"));
@@ -75,7 +75,8 @@ TEST_CASE("Choosing an .app fills the data directory from it and locks the field
 
         CHECK_FALSE(dataDir->isReadOnly());
         CHECK(widget.getDataDirectory().empty()); // the bundle's value is not left behind
-        CHECK(dataDir->toolTip().isEmpty());
+        // The row explains itself again; releasing it must not leave it with no tooltip at all.
+        CHECK(dataDir->toolTip().contains("contains data/"));
 
         widget.setDataDirectory("/games/fallout2");
         CHECK(widget.getDataDirectory() == std::filesystem::path("/games/fallout2"));
@@ -86,7 +87,7 @@ TEST_CASE("Choosing an .app fills the data directory from it and locks the field
         // empty field would stop the user pointing Play anywhere at all.
         const std::filesystem::path bundle = root / "Broken.app";
         std::filesystem::create_directories(bundle / "Contents");
-        std::ofstream(bundle / "Contents" / "Info.plist") << "bplist00\x01\x02";
+        std::ofstream(bundle / "Contents" / "Info.plist") << "bplist00" << '\x01' << '\x02';
 
         widget.setExecutableLocation(bundle);
 

--- a/tests/qt/test_game_location_widget.cpp
+++ b/tests/qt/test_game_location_widget.cpp
@@ -143,3 +143,34 @@ TEST_CASE("An .app is validated as an executable, not as an installation folder"
         CHECK(lastStatus.contains("installation"));
     }
 }
+
+TEST_CASE("Choosing an executable notifies once, not once per field it touches", "[qt][settings]") {
+    // Deriving the data directory writes to that field, and its own textChanged would raise a
+    // second configurationChanged nested inside the first - the dialog then re-entered its refresh
+    // while still handling the executable change.
+    QTemporaryDir tempDir;
+    REQUIRE(tempDir.isValid());
+    const std::filesystem::path root = tempDir.path().toStdString();
+
+    GameLocationWidget widget;
+    int notifications = 0;
+    QObject::connect(&widget, &GameLocationWidget::configurationChanged, [&notifications] { ++notifications; });
+
+    SECTION("selecting a bundle") {
+        widget.setExecutableLocation(makeBundle(root, "parent"));
+        CHECK(notifications == 1);
+    }
+
+    SECTION("releasing the field again") {
+        widget.setExecutableLocation(makeBundle(root, "parent"));
+        notifications = 0;
+
+        widget.setExecutableLocation(root / "fallout2-ce"); // clears the derived value
+        CHECK(notifications == 1);
+    }
+
+    SECTION("a user editing the data directory still notifies") {
+        widget.setDataDirectory("/games/fallout2");
+        CHECK(notifications == 1); // the field is only silenced while we drive it
+    }
+}

--- a/tests/qt/test_game_location_widget.cpp
+++ b/tests/qt/test_game_location_widget.cpp
@@ -156,8 +156,13 @@ TEST_CASE("Choosing an executable notifies once, not once per field it touches",
     int notifications = 0;
     QObject::connect(&widget, &GameLocationWidget::configurationChanged, [&notifications] { ++notifications; });
 
+    // cppcheck cannot follow a signal to its connected lambda, so it reads `notifications` as never
+    // incremented and calls every comparison below constant. The suppressions say that, rather than
+    // weakening the assertions - counting exactly one notification is the whole point of this case.
+
     SECTION("selecting a bundle") {
         widget.setExecutableLocation(makeBundle(root, "parent"));
+        // cppcheck-suppress knownConditionTrueFalse
         CHECK(notifications == 1);
     }
 
@@ -166,11 +171,13 @@ TEST_CASE("Choosing an executable notifies once, not once per field it touches",
         notifications = 0;
 
         widget.setExecutableLocation(root / "fallout2-ce"); // clears the derived value
+        // cppcheck-suppress knownConditionTrueFalse
         CHECK(notifications == 1);
     }
 
     SECTION("a user editing the data directory still notifies") {
         widget.setDataDirectory("/games/fallout2");
+        // cppcheck-suppress knownConditionTrueFalse
         CHECK(notifications == 1); // the field is only silenced while we drive it
     }
 }

--- a/tests/qt/test_game_location_widget.cpp
+++ b/tests/qt/test_game_location_widget.cpp
@@ -87,7 +87,12 @@ TEST_CASE("Choosing an .app fills the data directory from it and locks the field
         // empty field would stop the user pointing Play anywhere at all.
         const std::filesystem::path bundle = root / "Broken.app";
         std::filesystem::create_directories(bundle / "Contents");
-        std::ofstream(bundle / "Contents" / "Info.plist") << "bplist00" << '\x01' << '\x02';
+        // A real binary plist: the XML reader chokes on it, which is the point. Byte values, not
+        // escapes - the bounded \x{..} form the analyser asks for is C++23.
+        constexpr char kBinaryPlist[] = { 'b', 'p', 'l', 'i', 's', 't', '0', '0', 0x01, 0x02 };
+        std::ofstream plist(bundle / "Contents" / "Info.plist", std::ios::binary);
+        plist.write(kBinaryPlist, sizeof(kBinaryPlist));
+        plist.close();
 
         widget.setExecutableLocation(bundle);
 

--- a/tests/qt/test_game_location_widget.cpp
+++ b/tests/qt/test_game_location_widget.cpp
@@ -1,0 +1,96 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "ui/widgets/GameLocationWidget.h"
+
+#include <QLineEdit>
+#include <QPushButton>
+#include <QTemporaryDir>
+
+#include <filesystem>
+#include <fstream>
+
+using geck::GameLocationWidget;
+
+namespace {
+
+// Read-only state is not exposed on the widget's API, so reach the field by objectName - by
+// position would silently follow a reordered layout onto the wrong edit.
+QLineEdit* dataDirectoryEdit(GameLocationWidget& widget) {
+    auto* edit = widget.findChild<QLineEdit*>("dataDirectoryEdit");
+    REQUIRE(edit != nullptr);
+    return edit;
+}
+
+std::filesystem::path makeBundle(const std::filesystem::path& root, const std::string& baseDirType) {
+    const std::filesystem::path bundle = root / "Fallout II Community Edition.app";
+    std::filesystem::create_directories(bundle / "Contents");
+    std::ofstream(bundle / "Contents" / "Info.plist")
+        << R"(<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>SDL_FILESYSTEM_BASE_DIR_TYPE</key>
+    <string>)"
+        << baseDirType << R"(</string>
+</dict>
+</plist>
+)";
+    return bundle;
+}
+
+} // namespace
+
+TEST_CASE("Choosing an .app fills the data directory from it and locks the field", "[qt][settings]") {
+    // The engine chdir's to the bundle's base path, so for a bundle this setting cannot change
+    // where the map goes. Leaving it editable invites exactly the mistake it cannot correct.
+    QTemporaryDir tempDir;
+    REQUIRE(tempDir.isValid());
+    const std::filesystem::path root = tempDir.path().toStdString();
+
+    GameLocationWidget widget;
+    QLineEdit* dataDir = dataDirectoryEdit(widget);
+
+    SECTION("A bundle drives the field and takes it out of the user's hands") {
+        widget.setExecutableLocation(makeBundle(root, "parent"));
+
+        CHECK(widget.getDataDirectory() == root); // "parent" -> the folder holding the .app
+        CHECK(dataDir->isReadOnly());
+        CHECK_FALSE(dataDir->toolTip().isEmpty()); // says why it cannot be edited
+    }
+
+    SECTION("A stored directory cannot overwrite the bundle's own") {
+        // Preferences restores the executable and then the directory; the saved one is the value
+        // that was being ignored all along, so it must not win.
+        widget.setExecutableLocation(makeBundle(root, "parent"));
+        widget.setDataDirectory("/somewhere/the/engine/never/reads");
+
+        CHECK(widget.getDataDirectory() == root);
+    }
+
+    SECTION("Switching to a plain executable hands the field back") {
+        widget.setExecutableLocation(makeBundle(root, "parent"));
+        REQUIRE(dataDir->isReadOnly());
+
+        widget.setExecutableLocation(root / "fallout2-ce");
+
+        CHECK_FALSE(dataDir->isReadOnly());
+        CHECK(widget.getDataDirectory().empty()); // the bundle's value is not left behind
+        CHECK(dataDir->toolTip().isEmpty());
+
+        widget.setDataDirectory("/games/fallout2");
+        CHECK(widget.getDataDirectory() == std::filesystem::path("/games/fallout2"));
+    }
+
+    SECTION("A bundle whose plist cannot be read leaves the field editable") {
+        // macOsBundleDataRoot yields nothing there, and the setting really is used - locking an
+        // empty field would stop the user pointing Play anywhere at all.
+        const std::filesystem::path bundle = root / "Broken.app";
+        std::filesystem::create_directories(bundle / "Contents");
+        std::ofstream(bundle / "Contents" / "Info.plist") << "bplist00\x01\x02";
+
+        widget.setExecutableLocation(bundle);
+
+        CHECK_FALSE(dataDir->isReadOnly());
+        widget.setDataDirectory("/games/fallout2");
+        CHECK(widget.getDataDirectory() == std::filesystem::path("/games/fallout2"));
+    }
+}

--- a/tests/qt/test_game_location_widget.cpp
+++ b/tests/qt/test_game_location_widget.cpp
@@ -23,7 +23,8 @@ QLineEdit* dataDirectoryEdit(GameLocationWidget& widget) {
 
 std::filesystem::path makeBundle(const std::filesystem::path& root, const std::string& baseDirType) {
     const std::filesystem::path bundle = root / "Fallout II Community Edition.app";
-    std::filesystem::create_directories(bundle / "Contents");
+    std::filesystem::create_directories(bundle / "Contents" / "MacOS");
+    std::ofstream(bundle / "Contents" / "MacOS" / "fallout2-ce") << "binary";
     std::ofstream(bundle / "Contents" / "Info.plist")
         << R"(<?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
@@ -92,5 +93,53 @@ TEST_CASE("Choosing an .app fills the data directory from it and locks the field
         CHECK_FALSE(dataDir->isReadOnly());
         widget.setDataDirectory("/games/fallout2");
         CHECK(widget.getDataDirectory() == std::filesystem::path("/games/fallout2"));
+    }
+}
+
+TEST_CASE("An .app is validated as an executable, not as an installation folder", "[qt][settings]") {
+    // A bundle is a directory, so it used to fall to the installation check, which looks for a
+    // binary sitting directly in the folder - a bundle keeps its own in Contents/MacOS, so every
+    // one of them was reported as "may not be a valid Fallout 2 installation".
+    QTemporaryDir tempDir;
+    REQUIRE(tempDir.isValid());
+    const std::filesystem::path root = tempDir.path().toStdString();
+
+    GameLocationWidget widget;
+    QString lastStatus;
+    QString lastStyle;
+    QObject::connect(&widget, &GameLocationWidget::statusChanged,
+        [&lastStatus, &lastStyle](const QString& message, const QString& styleClass) {
+            lastStatus = message;
+            lastStyle = styleClass;
+        });
+
+    SECTION("A real bundle validates as an executable") {
+        const auto bundle = makeBundle(root, "parent");
+        std::filesystem::create_directories(root / "data"); // "parent" root, as a real install has
+
+        widget.setExecutableLocation(bundle);
+        widget.validateSelection();
+
+        CHECK(lastStyle.toStdString() == "success");
+        CHECK_FALSE(lastStatus.contains("may not be a valid Fallout 2 installation"));
+    }
+
+    SECTION("A bundle with no binary is called out as such") {
+        const std::filesystem::path empty = root / "Empty.app";
+        std::filesystem::create_directories(empty / "Contents");
+
+        widget.setExecutableLocation(empty);
+        widget.validateSelection();
+
+        CHECK(lastStyle.toStdString() == "warning");
+        CHECK(lastStatus.contains("no executable"));
+    }
+
+    SECTION("A plain directory is still checked as an installation") {
+        widget.setExecutableLocation(root);
+        widget.validateSelection();
+
+        CHECK(lastStyle.toStdString() == "warning");
+        CHECK(lastStatus.contains("installation"));
     }
 }


### PR DESCRIPTION
Builds on #131 (merged), which introduced `macOsBundleDataRoot`. Targets `master`.

## Why

#131 made the launcher follow the bundle's own game root, because the engine `chdir`s there on startup regardless of what the editor sets. That leaves Preferences showing an editable "game data directory" that, for an `.app`, cannot affect anything — it looks authoritative and is quietly ignored. That is precisely the mistake that made a placed item appear to vanish: a directory was set by hand, and the map went somewhere the game never reads.

Worth noting the field was only ever *harmful* when set: `Settings::getGameLocation()` already falls back to `executable.parent_path()`, which is the right answer for a `parent`-type bundle. Leaving it blank worked; filling it in broke it.

## What

Selecting an `.app` fills the data directory from its `Info.plist` and makes the field read-only, with a tooltip explaining why and how to change it.

Guards, each covered by a test:

- **Only when the bundle resolves.** An unreadable or binary `Info.plist` yields `nullopt`, and there the setting genuinely is used — locking an empty field would stop Play being pointed anywhere at all.
- **Releasing is clean.** Choosing a plain executable re-enables the field and clears the derived value instead of leaving a stale path behind.
- **A stored directory cannot overwrite a bundle's.** Preferences restores the executable and *then* the directory, so without this the saved value — the one that was being ignored all along — would win on load.

The two line edits gained object names so the test can find the field by name; by position it would silently follow a reordered layout onto the wrong widget.

## Scope

`getGameLocation()` is consumed only by `GameLauncher`; the editor's own resource loading uses `getDataPaths()`. So this affects Play and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
