### PR TITLE
Add a world map view that draws what the game draws

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -220,8 +220,9 @@ Open items:
 - **Corpus / world index** — index `analyze` + the semantic facts across all shipped maps so an
   agent can query *examples* ("how do shipped towns place and wire shopkeepers?") — improves
   generation, not just analysis.
-- **`worldmap.txt`** — the per-position sub-tile *encounter* chances are still unparsed (only
-  the terrain field is kept).
+- **`worldmap.txt`** — the per-position sub-tile *encounter* chances and fill flags are still
+  unparsed (of each subtile line only the terrain is kept; the tile's `art_idx`,
+  `walk_mask_name` and `encounter_difficulty` are read).
 - **`worldmap.msg`** — random-encounter descriptions (`[3000 + 50*tableId + entryId]`,
   fallout2-ce worldmap.cc:3595); runtime-index-tied to the encounter table/entry ordering, so
   not a small add. (Area/city labels turned out to live in map.msg and are already surfaced.)
@@ -232,6 +233,37 @@ Open items:
 
 *(MCP server guard note: per-call cancellation / progress notifications are deliberately not
 planned — the stdio loop is synchronous and tool calls are short.)*
+
+---
+
+# World map
+
+**Shipped (view-only):** `View > World Map` renders the worldmap the way the game draws it —
+the `wrldmp*` tile grid (whose yellow subtile lines are part of the art) with each area's circle
+blended over it. `WorldMapScene` (gecko_core) composes it in **palette-index space** and expands
+to RGBA only at the end, so the markers are pixel-identical to the engine rather than an
+approximation; `util/PaletteBlend` is the port of fallout2-ce's `_buildBlendTable` /
+`_commonGrayTable` / `intensityColorTable`. Also on `gecko-cli map world --render <png>`.
+
+**Guard note — do not re-derive:** `city.txt`'s `world_pos` is measured from the engine's 640x480
+interface window, so a marker's real worldmap position is `world_pos - (WM_VIEW_X, WM_VIEW_Y)` =
+`- (22, 21)`. The engine applies the same bias when drawing and when hit-testing, and the
+hard-coded new-game start position (173, 122) only lands inside Arroyo's circle with it. Asserted
+in `test_city_txt.cpp`.
+
+Open items, roughly in order:
+
+- **Town-map view** — per-area screen from `townmap_art_idx` / `townmap_label_art_idx` (both now
+  parsed) with the `entrance_N` hotspots drawn at their `townX,townY`; double-click already opens
+  an area's first map, this would let you pick *which* entrance.
+- **Overlays** — terrain type, per-subtile encounter chance (needs the unparsed subtile fields,
+  see the worldmap.txt item above), the `.msk` travel masks (1bpp, 44-byte rows; reproduce the
+  engine's own `1 << ((x/8) & 3)` indexing rather than "fixing" it), tile `encounter_difficulty`.
+- **Editing** — drag markers, change size/state/entrances. Writing `city.txt` / `worldmap.txt`
+  should follow the lossless round-trip pattern used for `maps.txt` (`MapsTxtSerializer`): both
+  files are heavily commented and hand-maintained, so a rewrite-from-model would destroy them.
+- **Labels** are Qt text in the engine's green, not the engine's bitmap font — the AAF fonts
+  don't survive being scaled, and the view zooms. Revisit only if 1:1 fidelity is wanted.
 
 ---
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -318,6 +318,11 @@ the running game (day/night, critter wander/AI) is **Large** and probably not wo
   machine (~130 LOC + 3 members) would trim `MainWindow`, but it stays `QDockWidget`/`QAction`-
   bound with no pure testable core. Fold it into the next change that touches dock/panel
   behavior rather than doing it as standalone churn.
+- **Central-page switching.** The central `QStackedWidget` now has three modes (welcome, editor,
+  world map) and `MainWindow` restores them by hand: `_pageBeforeWorldMap`, a silent
+  `clearWorldMapAction()` for the paths that switch pages themselves, and a checkable action whose
+  state has to be kept in step. Correct today, but a fourth mode should not add a fourth ad-hoc
+  restore path — fold it into a small page controller when one arrives.
 
 **Evaluated and intentionally NOT pursued (guard — churn > value):**
 - **PRO/MAP serialization visitor** — the type-specific tails (mixed field widths, optional-on-

--- a/resources/icons.qrc
+++ b/resources/icons.qrc
@@ -37,6 +37,7 @@
         <file alias="actions/view-exits.svg">icons/door-exit.svg</file>
         <file alias="actions/map-edges.svg">icons/tabler/actions/border-all.svg</file>
         <file alias="actions/view-unreachable.svg">icons/tabler/actions/ban.svg</file>
+        <file alias="actions/world-map.svg">icons/tabler/actions/map-pin.svg</file>
         
         <!-- File Types -->
         <file alias="filetypes/map.svg">icons/tabler/filetypes/map-2.svg</file>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -157,6 +157,12 @@ set(GECK_APP_SOURCES
     ui/widgets/AnimationController.cpp
     ui/widgets/WelcomeWidget.h
     ui/widgets/WelcomeWidget.cpp
+
+    # Qt6 UI World map (a view of the game's worldmap data, not of any one map)
+    ui/worldmap/WorldMapView.h
+    ui/worldmap/WorldMapView.cpp
+    ui/worldmap/WorldMapWidget.h
+    ui/worldmap/WorldMapWidget.cpp
     ui/widgets/ProCommonFieldsWidget.h
     ui/widgets/ProCommonFieldsWidget.cpp
     
@@ -432,6 +438,9 @@ add_library(vault STATIC
 
     util/GameDataPathResolver.h
     util/GameDataPathResolver.cpp
+
+    util/PaletteBlend.h
+    util/PaletteBlend.cpp
 )
 
 target_include_directories(vault PUBLIC
@@ -472,6 +481,7 @@ add_library(gecko_resource STATIC
     resource/ResourceInitializer.h
     resource/ResourceInitializer.cpp
 
+    resource/ConfigLoad.h
     resource/MapNameResolver.h
     resource/MapNameResolver.cpp
     resource/MapCompleteness.h
@@ -537,6 +547,8 @@ add_library(gecko_core STATIC
     editor/Hex.cpp
     editor/helper/ObjectQueries.h
     editor/helper/ObjectQueries.cpp
+    editor/worldmap/WorldMapScene.h
+    editor/worldmap/WorldMapScene.cpp
 )
 add_library(gecko::core ALIAS gecko_core)
 
@@ -686,7 +698,6 @@ if(GECK_BUILD_CLI)
         cli/WorldMap.cpp
         cli/WorldEncounters.h
         cli/WorldEncounters.cpp
-        cli/ConfigLoad.h
         cli/GlobalVars.h
         cli/GlobalVars.cpp
         cli/Quests.h

--- a/src/cli/Endings.cpp
+++ b/src/cli/Endings.cpp
@@ -1,6 +1,6 @@
 #include "cli/Endings.h"
 
-#include "cli/ConfigLoad.h"
+#include "resource/ConfigLoad.h"
 #include "cli/GlobalVars.h" // loadGameGam
 #include "format/endgame/EndgameTxt.h"
 #include "format/gam/Gam.h"
@@ -30,7 +30,7 @@ namespace {
 } // namespace
 
 int buildEndings(resource::GameResources& resources, std::ostream& out) {
-    const EndgameTxt endgame = loadConfig<EndgameTxt>(resources, { "data/endgame.txt", "endgame.txt" },
+    const EndgameTxt endgame = resource::loadConfig<EndgameTxt>(resources, { "data/endgame.txt", "endgame.txt" },
         [](const std::string& text) { return parseEndgameTxt(text); });
     if (endgame.endings.empty()) {
         out << "{\"endings\":[],\"stats\":{\"endings\":0}}\n";

--- a/src/cli/MapGraph.cpp
+++ b/src/cli/MapGraph.cpp
@@ -1,6 +1,6 @@
 #include "cli/MapGraph.h"
 
-#include "cli/ConfigLoad.h"
+#include "resource/ConfigLoad.h"
 #include "cli/MapAnalyzer.h" // collectMapExits, listMapPaths, MapExit
 #include "cli/MapLoad.h"     // loadMap
 #include "editor/Reachability.h"
@@ -301,7 +301,7 @@ int buildMapGraph(resource::GameResources& resources, const MapGraphOptions& opt
         return 1;
     }
 
-    const CityTxt city = loadConfig<CityTxt>(resources, { "data/city.txt", "city.txt" },
+    const CityTxt city = resource::loadConfig<CityTxt>(resources, { "data/city.txt", "city.txt" },
         [](const std::string& text) { return parseCityTxt(text); });
     const StringMap areaOf = mapToArea(city, names);
     Nodes nodes;

--- a/src/cli/Quests.cpp
+++ b/src/cli/Quests.cpp
@@ -1,6 +1,6 @@
 #include "cli/Quests.h"
 
-#include "cli/ConfigLoad.h"
+#include "resource/ConfigLoad.h"
 #include "cli/GlobalVars.h" // loadGameGam
 #include "format/gam/Gam.h"
 #include "format/msg/Msg.h"
@@ -44,7 +44,7 @@ namespace {
 } // namespace
 
 int buildQuests(resource::GameResources& resources, std::ostream& out) {
-    const QuestsTxt quests = loadConfig<QuestsTxt>(resources, { "data/quests.txt", "quests.txt" },
+    const QuestsTxt quests = resource::loadConfig<QuestsTxt>(resources, { "data/quests.txt", "quests.txt" },
         [](const std::string& text) { return parseQuestsTxt(text); });
     if (quests.quests.empty()) {
         out << "{\"quests\":[],\"stats\":{\"quests\":0}}\n";

--- a/src/cli/WorldEncounters.cpp
+++ b/src/cli/WorldEncounters.cpp
@@ -1,6 +1,6 @@
 #include "cli/WorldEncounters.h"
 
-#include "cli/ConfigLoad.h"
+#include "resource/ConfigLoad.h"
 #include "format/worldmap/WorldmapTxt.h"
 #include "reader/worldmap/WorldmapTxtReader.h"
 #include "resource/GameResources.h"
@@ -40,7 +40,7 @@ namespace {
 } // namespace
 
 int buildWorldEncounters(resource::GameResources& resources, std::ostream& out) {
-    const WorldmapTxt world = loadConfig<WorldmapTxt>(resources, { "data/worldmap.txt", "worldmap.txt" },
+    const WorldmapTxt world = resource::loadConfig<WorldmapTxt>(resources, { "data/worldmap.txt", "worldmap.txt" },
         [](const std::string& text) { return parseWorldmapTxt(text); });
     if (world.terrains.empty() && world.encounters.empty()) {
         out << "{\"terrains\":[],\"encounters\":[],\"stats\":{\"terrains\":0,\"encounters\":0}}\n";

--- a/src/cli/WorldMap.cpp
+++ b/src/cli/WorldMap.cpp
@@ -1,18 +1,21 @@
 #include "cli/WorldMap.h"
 
-#include "cli/ConfigLoad.h"
+#include "editor/worldmap/WorldMapScene.h"
 #include "format/city/CityTxt.h"
 #include "format/worldmap/WorldmapTxt.h"
 #include "reader/city/CityTxtReader.h"
 #include "reader/worldmap/WorldmapTxtReader.h"
+#include "resource/ConfigLoad.h"
 #include "resource/GameResources.h"
 #include "resource/MapNameResolver.h"
 
+#include <SFML/Graphics/Image.hpp>
 #include <nlohmann/json.hpp>
 
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <iostream>
 #include <ostream>
 #include <string>
 
@@ -109,8 +112,32 @@ namespace {
 
 } // namespace
 
+int renderWorldMap(resource::GameResources& resources, const WorldMapOptions& options, std::ostream& out) {
+    const auto scene = worldmap::WorldMapScene::load(resources);
+    if (!scene) {
+        std::cerr << "error: no worldmap in the mounted data (needs city.txt, worldmap.txt and color.pal)\n";
+        return 1;
+    }
+    scene->setMarkersVisible(options.markers);
+
+    for (const std::string& missing : scene->missingArt()) {
+        std::cerr << "warning: worldmap tile art missing: " << missing << "\n";
+    }
+
+    sf::Image image({ static_cast<unsigned>(scene->width()), static_cast<unsigned>(scene->height()) },
+        scene->pixels().data());
+    if (!image.saveToFile(options.renderPath)) {
+        std::cerr << "error: could not write " << options.renderPath << "\n";
+        return 1;
+    }
+
+    out << "wrote " << options.renderPath << " (" << scene->width() << "x" << scene->height() << "), "
+        << scene->areas().size() << " areas\n";
+    return 0;
+}
+
 int buildWorldMap(resource::GameResources& resources, std::ostream& out) {
-    const CityTxt city = loadConfig<CityTxt>(resources, { "data/city.txt", "city.txt" },
+    const CityTxt city = resource::loadConfig<CityTxt>(resources, { "data/city.txt", "city.txt" },
         [](const std::string& text) { return parseCityTxt(text); });
     if (city.areas.empty()) {
         out << "{\"areas\":[],\"distances\":[],\"stats\":{\"areas\":0}}\n";
@@ -125,7 +152,7 @@ int buildWorldMap(resource::GameResources& resources, std::ostream& out) {
     }
 
     // worldmap.txt is optional here: it enriches areas with terrain + adds terrain-weighted travelCost.
-    const WorldmapTxt world = loadConfig<WorldmapTxt>(resources, { "data/worldmap.txt", "worldmap.txt" },
+    const WorldmapTxt world = resource::loadConfig<WorldmapTxt>(resources, { "data/worldmap.txt", "worldmap.txt" },
         [](const std::string& text) { return parseWorldmapTxt(text); });
 
     const resource::MapNameResolver names(resources); // resolves entrance lookup_names -> .map files

--- a/src/cli/WorldMap.h
+++ b/src/cli/WorldMap.h
@@ -1,12 +1,25 @@
 #pragma once
 
 #include <iosfwd>
+#include <string>
 
 namespace geck::resource {
 class GameResources;
 }
 
 namespace geck::cli {
+
+struct WorldMapOptions {
+    /// When set, the worldmap is also drawn to this PNG instead of only being described as JSON.
+    std::string renderPath;
+    /// Draw the city circles (the engine's translucent green markers). Off gives the bare terrain.
+    bool markers = true;
+};
+
+/// Renders the worldmap exactly as the game draws it — the `art/intrface/wrldmp*` tile grid with the
+/// area circles blended over it through the engine's own palette blend tables — to a PNG. Returns 0
+/// on success. Reports the image size to `out`.
+int renderWorldMap(resource::GameResources& resources, const WorldMapOptions& options, std::ostream& out);
 
 /// The worldmap layer, from data/city.txt: every area (a city / town / encounter location) with its
 /// name, worldmap position, size, known-at-start flag and the maps it contains (its entrances), plus

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -54,6 +54,7 @@ struct CliArgs {
     geck::cli::ReachabilityOptions reach;
     geck::cli::DescribeMapOptions describeMapOpts;
     geck::cli::MapGraphOptions graphOpts;
+    geck::cli::WorldMapOptions worldOpts;
 };
 
 void printUsage(const char* program) {
@@ -119,9 +120,12 @@ void printUsage(const char* program) {
               << "      The exit-grid connectivity graph: how maps link via exit grids WITHIN a location\n"
               << "      (+ worldmap hand-off edges), named via maps.txt/map.msg. Not inter-city travel\n"
               << "      (that's the world map / city.txt). No map arguments = every map.\n"
-              << "  " << program << " map world --data <dir-or-.dat> [--data <...>]\n"
+              << "  " << program << " map world [--render <file.png>] [--no-markers]\n"
+              << "      --data <dir-or-.dat> [--data <...>]\n"
               << "      The worldmap layer from city.txt: every area (location) with its world position,\n"
               << "      size, the maps it contains, and the straight-line distances between all areas.\n"
+              << "      --render draws the worldmap itself to a PNG instead — the wrldmp tile grid with\n"
+              << "      the area circles blended over it the way the engine does; --no-markers omits them.\n"
               << "  " << program << " map encounters --data <dir-or-.dat> [--data <...>]\n"
               << "      The worldmap terrain types and random-encounter group tables from worldmap.txt.\n"
               << "  " << program << " map gvars --data <dir-or-.dat> [--data <...>]\n"
@@ -265,6 +269,7 @@ int consumeArg(const std::vector<std::string>& args, std::size_t i, CliArgs& out
         || (out.render && (arg == "--map" || arg == "--out" || arg == "--elevation" || arg == "--max-dim" || arg == "--crop-hex" || arg == "--crop-extent"))
         || (out.extract && (arg == "--map" || arg == "--out" || arg == "--name" || arg == "--elevation" || arg == "--pids" || arg == "--anchor" || arg == "--radius"))
         || (out.describeScript && (arg == "--index" || arg == "--locale"))
+        || (out.world && arg == "--render")
         || (out.reachability && arg == "--map")
         || (out.describeMap && arg == "--map")
         || (out.dumpGrid && (arg == "--map" || arg == "--elevation"));
@@ -488,7 +493,15 @@ int consumeArg(const std::vector<std::string>& args, std::size_t i, CliArgs& out
         out.graphOpts.maps.push_back(arg);
         return 1;
     }
-    if (out.world) { // world takes no arguments beyond --data (handled above)
+    if (out.world) {
+        if (arg == "--render") {
+            out.worldOpts.renderPath = args[i + 1];
+            return 2;
+        }
+        if (arg == "--no-markers") {
+            out.worldOpts.markers = false;
+            return 1;
+        }
         std::cerr << "error: unexpected argument: " << arg << "\n";
         printUsage(program);
         return 0;
@@ -847,6 +860,9 @@ int main(int argc, char** argv) {
         return geck::cli::buildMapGraph(resources, cli.graphOpts, std::cout);
     }
     if (cli.world) {
+        if (!cli.worldOpts.renderPath.empty()) {
+            return geck::cli::renderWorldMap(resources, cli.worldOpts, std::cout);
+        }
         return geck::cli::buildWorldMap(resources, std::cout);
     }
     if (cli.encounters) {

--- a/src/editor/worldmap/WorldMapScene.cpp
+++ b/src/editor/worldmap/WorldMapScene.cpp
@@ -145,7 +145,49 @@ void WorldMapScene::loadMarkerSprites(resource::GameResources& resources) {
                     = frame->index(static_cast<std::uint16_t>(x), static_cast<std::uint16_t>(y));
             }
         }
+        buildMarkerProfile(sprite);
     }
+}
+
+void WorldMapScene::buildMarkerProfile(Sprite& sprite) const {
+    // Average the tint weight of every pixel at each distance from the centre. The sprites are
+    // drawn circles, so their weight really is a function of radius, and this recovers it without
+    // assuming anything about the shape beyond that.
+    const int buckets = std::max(1, sprite.width / 2);
+    std::vector<double> total(static_cast<std::size_t>(buckets), 0.0);
+    std::vector<int> count(static_cast<std::size_t>(buckets), 0);
+
+    const double centreX = (sprite.width - 1) / 2.0;
+    const double centreY = (sprite.height - 1) / 2.0;
+    const double maxRadius = std::max(1.0, std::min(centreX, centreY));
+
+    for (int y = 0; y < sprite.height; ++y) {
+        for (int x = 0; x < sprite.width; ++x) {
+            const double dx = x - centreX;
+            const double dy = y - centreY;
+            const double radius = std::sqrt(dx * dx + dy * dy);
+            const auto bucket = static_cast<int>(radius / maxRadius * (buckets - 1) + 0.5);
+            if (bucket < 0 || bucket >= buckets) {
+                continue; // the sprite's corners lie outside the circle
+            }
+
+            // Index 0 is transparent, i.e. no tint at all; otherwise the grey level is the weight.
+            const std::uint8_t index = sprite.indices[static_cast<std::size_t>(y) * sprite.width + x];
+            total[static_cast<std::size_t>(bucket)] += index == 0 ? 0.0 : _tables->grayLevel(index) / 7.0;
+            ++count[static_cast<std::size_t>(bucket)];
+        }
+    }
+
+    sprite.profile.assign(static_cast<std::size_t>(buckets), 0.0F);
+    for (std::size_t i = 0; i < sprite.profile.size(); ++i) {
+        if (count[i] > 0) {
+            sprite.profile[i] = static_cast<float>(total[i] / count[i]);
+        }
+    }
+}
+
+const std::vector<float>& WorldMapScene::markerProfile(CityAreaSize size) const {
+    return spriteFor(size).profile;
 }
 
 void WorldMapScene::buildAreas(resource::GameResources& resources) {

--- a/src/editor/worldmap/WorldMapScene.cpp
+++ b/src/editor/worldmap/WorldMapScene.cpp
@@ -1,0 +1,248 @@
+#include "editor/worldmap/WorldMapScene.h"
+
+#include "format/frm/Frame.h"
+#include "format/frm/Frm.h"
+#include "format/pal/Pal.h"
+#include "reader/city/CityTxtReader.h"
+#include "reader/worldmap/WorldmapTxtReader.h"
+#include "resource/ConfigLoad.h"
+#include "resource/GameResources.h"
+#include "resource/MapNameResolver.h"
+
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <sstream>
+
+namespace geck::worldmap {
+
+namespace {
+
+    // The engine's OBJ_TYPE_INTERFACE. Both the worldmap tiles (worldmap.txt art_idx) and the city
+    // circles are interface art, so their LST indices become FIDs with this type byte.
+    constexpr std::uint32_t INTERFACE_FID_TYPE = 6;
+
+    // intrface.lst indices of the small/medium/large city circles: fallout2-ce worldmap.cc builds
+    // them as buildFid(OBJ_TYPE_INTERFACE, 336 + citySize).
+    constexpr int CITY_SPRITE_BASE_INDEX = 336;
+
+    constexpr std::uint32_t interfaceFid(int lstIndex) {
+        return (INTERFACE_FID_TYPE << 24) | static_cast<std::uint32_t>(lstIndex);
+    }
+
+    // The first frame of an FRM as raw palette indices. Every image the worldmap uses is a single
+    // static frame, so there is no direction or animation to pick.
+    const Frame* firstFrame(resource::GameResources& resources, const std::string& artPath) {
+        const Frm* frm = resources.repository().load<Frm>(artPath);
+        if (frm == nullptr || frm->directions().empty()) {
+            return nullptr;
+        }
+        const auto& frames = frm->directions()[0].frames();
+        return frames.empty() ? nullptr : &frames[0];
+    }
+
+} // namespace
+
+std::unique_ptr<WorldMapScene> WorldMapScene::load(resource::GameResources& resources) {
+    auto scene = std::unique_ptr<WorldMapScene>(new WorldMapScene());
+    scene->_city = resource::loadConfig<CityTxt>(resources, { "data/city.txt", "city.txt" },
+        [](const std::string& text) { return parseCityTxt(text); });
+    if (scene->_city.areas.empty()) {
+        spdlog::warn("WorldMapScene: no city.txt with [Area NN] sections in the mounted data");
+        return nullptr;
+    }
+
+    scene->_world = resource::loadConfig<WorldmapTxt>(resources, { "data/worldmap.txt", "worldmap.txt" },
+        [](const std::string& text) { return parseWorldmapTxt(text); });
+
+    const Pal* pal = resources.repository().load<Pal>("color.pal");
+    if (pal == nullptr) {
+        spdlog::warn("WorldMapScene: color.pal is not mounted; cannot draw the worldmap");
+        return nullptr;
+    }
+    scene->_tables.emplace(*pal);
+    scene->_greenBlend.emplace(*scene->_tables, palette::GREEN_RGB);
+    scene->_labelColor = scene->_tables->toRgb888(scene->_tables->fromRgb555(palette::rgb555(palette::GREEN_RGB)));
+
+    if (!scene->rasteriseTiles(resources)) {
+        return nullptr;
+    }
+    scene->buildAreas(resources);
+    scene->composeMarkers();
+    return scene;
+}
+
+bool WorldMapScene::rasteriseTiles(resource::GameResources& resources) {
+    _width = _world.widthPixels();
+    _height = _world.heightPixels();
+    if (_width <= 0 || _height <= 0) {
+        spdlog::warn("WorldMapScene: worldmap.txt has no tile grid ([Tile Data] num_horizontal_tiles)");
+        return false;
+    }
+
+    // Unwritten pixels stay index 0, which the palette maps to black — the same thing the engine
+    // shows for a tile whose art it cannot grab.
+    _terrainIndices.assign(static_cast<std::size_t>(_width) * _height, 0);
+
+    const int columns = _world.numHorizontalTiles;
+    for (std::size_t tile = 0; tile < _world.tiles.size(); ++tile) {
+        const int artIndex = _world.tiles[tile].artIndex;
+        const int originX = static_cast<int>(tile % columns) * WM_TILE_WIDTH;
+        const int originY = static_cast<int>(tile / columns) * WM_TILE_HEIGHT;
+        if (originY >= _height) {
+            break; // a partial trailing row the engine would not show either
+        }
+
+        const std::string artPath = artIndex >= 0 ? resources.frmResolver().resolve(interfaceFid(artIndex)) : std::string();
+        const Frame* frame = artPath.empty() ? nullptr : firstFrame(resources, artPath);
+        if (frame == nullptr) {
+            std::ostringstream missing;
+            missing << "[Tile " << tile << "] art_idx=" << artIndex;
+            if (!artPath.empty()) {
+                missing << " (" << artPath << ")";
+            }
+            _missingArt.push_back(missing.str());
+            continue;
+        }
+
+        const int copyWidth = std::min<int>(frame->width(), _width - originX);
+        const int copyHeight = std::min<int>(frame->height(), _height - originY);
+        for (int y = 0; y < copyHeight; ++y) {
+            std::uint8_t* row = &_terrainIndices[static_cast<std::size_t>(originY + y) * _width + originX];
+            for (int x = 0; x < copyWidth; ++x) {
+                row[x] = frame->index(static_cast<std::uint16_t>(x), static_cast<std::uint16_t>(y));
+            }
+        }
+    }
+
+    if (!_missingArt.empty()) {
+        spdlog::warn("WorldMapScene: {} worldmap tile(s) have no usable art", _missingArt.size());
+    }
+
+    // The city circles are interface art too; load them once for every area to blend against.
+    for (int size = 0; size < static_cast<int>(_sprites.size()); ++size) {
+        const std::string path = resources.frmResolver().resolve(interfaceFid(CITY_SPRITE_BASE_INDEX + size));
+        const Frame* frame = path.empty() ? nullptr : firstFrame(resources, path);
+        if (frame == nullptr) {
+            spdlog::warn("WorldMapScene: city marker art {} is missing", CITY_SPRITE_BASE_INDEX + size);
+            continue;
+        }
+        Sprite& sprite = _sprites[static_cast<std::size_t>(size)];
+        sprite.width = frame->width();
+        sprite.height = frame->height();
+        sprite.indices.resize(static_cast<std::size_t>(sprite.width) * sprite.height);
+        for (int y = 0; y < sprite.height; ++y) {
+            for (int x = 0; x < sprite.width; ++x) {
+                sprite.indices[static_cast<std::size_t>(y) * sprite.width + x]
+                    = frame->index(static_cast<std::uint16_t>(x), static_cast<std::uint16_t>(y));
+            }
+        }
+    }
+
+    return true;
+}
+
+void WorldMapScene::buildAreas(resource::GameResources& resources) {
+    const resource::MapNameResolver names(resources);
+
+    _areas.reserve(_city.areas.size());
+    for (const CityArea& area : _city.areas) {
+        AreaMarker marker;
+        marker.index = area.index;
+        marker.name = area.name;
+        marker.displayName = names.areaName(area.index);
+        marker.size = cityAreaSize(area.size);
+        marker.knownAtStart = area.startOn;
+        marker.locked = area.locked;
+
+        // world_pos is measured from the interface window's origin, so the marker's true place on
+        // the worldmap is that minus where the view sits inside the window.
+        marker.x = area.worldX - WM_VIEW_X;
+        marker.y = area.worldY - WM_VIEW_Y;
+        const Sprite& sprite = _sprites[static_cast<std::size_t>(marker.size)];
+        marker.width = sprite.width;
+        marker.height = sprite.height;
+
+        // The engine only ever samples terrain under the *party*, never under an area, so take the
+        // middle of the circle: standing anywhere inside it counts as being at this area.
+        marker.terrain = _world.terrainAt(marker.x + marker.width / 2, marker.y + marker.height / 2);
+        for (const CityEntrance& entrance : area.entrances) {
+            const std::string mapFile = names.fileNameOfLookup(entrance.map);
+            if (!mapFile.empty()) {
+                marker.mapFiles.push_back(mapFile);
+            }
+        }
+
+        _areas.push_back(std::move(marker));
+    }
+}
+
+bool WorldMapScene::blendMarker(const AreaMarker& area) {
+    const Sprite& sprite = _sprites[static_cast<std::size_t>(area.size)];
+    if (!sprite.valid() || !_greenBlend.has_value()) {
+        return false;
+    }
+
+    // Clip to the canvas; the engine clips to its 450x443 viewport for the same reason.
+    const int startX = std::max(0, -area.x);
+    const int startY = std::max(0, -area.y);
+    const int endX = std::min(sprite.width, _width - area.x);
+    const int endY = std::min(sprite.height, _height - area.y);
+
+    for (int y = startY; y < endY; ++y) {
+        const std::uint8_t* src = &sprite.indices[static_cast<std::size_t>(y) * sprite.width];
+        std::uint8_t* dest = &_indices[static_cast<std::size_t>(area.y + y) * _width + area.x];
+        for (int x = startX; x < endX; ++x) {
+            if (src[x] != 0) { // index 0 is transparent
+                dest[x] = _greenBlend->blendPixel(src[x], dest[x]);
+            }
+        }
+    }
+    return true;
+}
+
+void WorldMapScene::composeMarkers() {
+    _indices = _terrainIndices;
+    if (_markersVisible) {
+        // In area order, so overlapping circles stack the way the engine stacks them.
+        for (const AreaMarker& area : _areas) {
+            blendMarker(area);
+        }
+    }
+    expandToPixels();
+}
+
+void WorldMapScene::expandToPixels() {
+    _pixels.resize(_indices.size() * 4);
+    for (std::size_t i = 0; i < _indices.size(); ++i) {
+        const std::uint32_t rgb = _tables->toRgb888(_indices[i]);
+        _pixels[i * 4] = static_cast<std::uint8_t>(rgb >> 16);
+        _pixels[i * 4 + 1] = static_cast<std::uint8_t>(rgb >> 8);
+        _pixels[i * 4 + 2] = static_cast<std::uint8_t>(rgb);
+        _pixels[i * 4 + 3] = 0xFF;
+    }
+}
+
+void WorldMapScene::setMarkersVisible(bool visible) {
+    if (_markersVisible == visible) {
+        return;
+    }
+    _markersVisible = visible;
+    composeMarkers();
+}
+
+const AreaMarker* WorldMapScene::areaAt(int px, int py) const {
+    for (const AreaMarker& area : _areas) {
+        if (area.contains(px, py)) {
+            return &area;
+        }
+    }
+    return nullptr;
+}
+
+std::string WorldMapScene::terrainAt(int px, int py) const {
+    return _world.terrainAt(px, py);
+}
+
+} // namespace geck::worldmap

--- a/src/editor/worldmap/WorldMapScene.cpp
+++ b/src/editor/worldmap/WorldMapScene.cpp
@@ -31,15 +31,35 @@ namespace {
         return (INTERFACE_FID_TYPE << 24) | static_cast<std::uint32_t>(lstIndex);
     }
 
-    // The first frame of an FRM as raw palette indices. Every image the worldmap uses is a single
-    // static frame, so there is no direction or animation to pick.
-    const Frame* firstFrame(resource::GameResources& resources, const std::string& artPath) {
-        const Frm* frm = resources.repository().load<Frm>(artPath);
-        if (frm == nullptr || frm->directions().empty()) {
+    // The first frame of the interface art at an intrface.lst index, as raw palette indices; every
+    // image the worldmap uses is a single static frame, so there is no direction or animation to
+    // pick. @p artPath receives whatever the FID resolved to, for reporting.
+    //
+    // Both halves of the lookup throw when the mounted data is short of what the worldmap wants:
+    // resolve() on a missing or too-short intrface.lst, load() on a dangling LST entry or an
+    // unreadable FRM. A worldmap is still worth drawing with a tile or two missing, and an editor
+    // must not die of it, so every art lookup funnels through here and reports failure the way the
+    // callers already handle it -- by returning nullptr.
+    const Frame* interfaceFrame(resource::GameResources& resources, int lstIndex, std::string& artPath) {
+        artPath.clear();
+        if (lstIndex < 0) {
             return nullptr;
         }
-        const auto& frames = frm->directions()[0].frames();
-        return frames.empty() ? nullptr : &frames[0];
+        try {
+            artPath = resources.frmResolver().resolve(interfaceFid(lstIndex));
+            if (artPath.empty()) {
+                return nullptr;
+            }
+            const Frm* frm = resources.repository().load<Frm>(artPath);
+            if (frm == nullptr || frm->directions().empty()) {
+                return nullptr;
+            }
+            const auto& frames = frm->directions()[0].frames();
+            return frames.empty() ? nullptr : &frames[0];
+        } catch (const std::exception& error) {
+            spdlog::warn("WorldMapScene: interface art {} could not be loaded: {}", lstIndex, error.what());
+            return nullptr;
+        }
     }
 
 } // namespace
@@ -56,7 +76,16 @@ std::unique_ptr<WorldMapScene> WorldMapScene::load(resource::GameResources& reso
     scene->_world = resource::loadConfig<WorldmapTxt>(resources, { "data/worldmap.txt", "worldmap.txt" },
         [](const std::string& text) { return parseWorldmapTxt(text); });
 
-    const Pal* pal = resources.repository().load<Pal>("color.pal");
+    // Every blend the worldmap does is a lookup through color.pal, so without it there is nothing
+    // to draw. load() throws rather than returning null when the file is not mounted, which is the
+    // common case for a data path that has the text files but no art.
+    const Pal* pal = nullptr;
+    try {
+        pal = resources.repository().load<Pal>("color.pal");
+    } catch (const std::exception& error) {
+        spdlog::warn("WorldMapScene: color.pal could not be loaded ({}); cannot draw the worldmap", error.what());
+        return nullptr;
+    }
     if (pal == nullptr) {
         spdlog::warn("WorldMapScene: color.pal is not mounted; cannot draw the worldmap");
         return nullptr;
@@ -95,8 +124,8 @@ bool WorldMapScene::rasteriseTiles(resource::GameResources& resources) {
             break; // a partial trailing row the engine would not show either
         }
 
-        const std::string artPath = artIndex >= 0 ? resources.frmResolver().resolve(interfaceFid(artIndex)) : std::string();
-        const Frame* frame = artPath.empty() ? nullptr : firstFrame(resources, artPath);
+        std::string artPath;
+        const Frame* frame = interfaceFrame(resources, artIndex, artPath);
         if (frame == nullptr) {
             std::ostringstream missing;
             missing << "[Tile " << tile << "] art_idx=" << artIndex;
@@ -128,10 +157,15 @@ void WorldMapScene::loadMarkerSprites(resource::GameResources& resources) {
     // The city circles are interface art too; load them once for every area to blend against.
     for (std::size_t size = 0; size < _sprites.size(); ++size) {
         const int lstIndex = CITY_SPRITE_BASE_INDEX + static_cast<int>(size);
-        const std::string path = resources.frmResolver().resolve(interfaceFid(lstIndex));
-        const Frame* frame = path.empty() ? nullptr : firstFrame(resources, path);
+        std::string path;
+        const Frame* frame = interfaceFrame(resources, lstIndex, path);
         if (frame == nullptr) {
-            spdlog::warn("WorldMapScene: city marker art {} is missing", lstIndex);
+            // Without its circle a marker has no art, no hit box and no label anchor, so an area of
+            // this size becomes invisible and unclickable. Report it rather than leave the user with
+            // a map that silently ignores every click.
+            std::ostringstream missing;
+            missing << "[Marker " << cityAreaSizeName(static_cast<CityAreaSize>(size)) << "] art_idx=" << lstIndex;
+            _missingArt.push_back(missing.str());
             continue;
         }
 

--- a/src/editor/worldmap/WorldMapScene.cpp
+++ b/src/editor/worldmap/WorldMapScene.cpp
@@ -68,6 +68,7 @@ std::unique_ptr<WorldMapScene> WorldMapScene::load(resource::GameResources& reso
     if (!scene->rasteriseTiles(resources)) {
         return nullptr;
     }
+    scene->loadMarkerSprites(resources);
     scene->buildAreas(resources);
     scene->composeMarkers();
     return scene;
@@ -120,15 +121,21 @@ bool WorldMapScene::rasteriseTiles(resource::GameResources& resources) {
         spdlog::warn("WorldMapScene: {} worldmap tile(s) have no usable art", _missingArt.size());
     }
 
+    return true;
+}
+
+void WorldMapScene::loadMarkerSprites(resource::GameResources& resources) {
     // The city circles are interface art too; load them once for every area to blend against.
-    for (int size = 0; size < static_cast<int>(_sprites.size()); ++size) {
-        const std::string path = resources.frmResolver().resolve(interfaceFid(CITY_SPRITE_BASE_INDEX + size));
+    for (std::size_t size = 0; size < _sprites.size(); ++size) {
+        const int lstIndex = CITY_SPRITE_BASE_INDEX + static_cast<int>(size);
+        const std::string path = resources.frmResolver().resolve(interfaceFid(lstIndex));
         const Frame* frame = path.empty() ? nullptr : firstFrame(resources, path);
         if (frame == nullptr) {
-            spdlog::warn("WorldMapScene: city marker art {} is missing", CITY_SPRITE_BASE_INDEX + size);
+            spdlog::warn("WorldMapScene: city marker art {} is missing", lstIndex);
             continue;
         }
-        Sprite& sprite = _sprites[static_cast<std::size_t>(size)];
+
+        Sprite& sprite = _sprites[size];
         sprite.width = frame->width();
         sprite.height = frame->height();
         sprite.indices.resize(static_cast<std::size_t>(sprite.width) * sprite.height);
@@ -139,8 +146,6 @@ bool WorldMapScene::rasteriseTiles(resource::GameResources& resources) {
             }
         }
     }
-
-    return true;
 }
 
 void WorldMapScene::buildAreas(resource::GameResources& resources) {
@@ -160,7 +165,7 @@ void WorldMapScene::buildAreas(resource::GameResources& resources) {
         // the worldmap is that minus where the view sits inside the window.
         marker.x = area.worldX - WM_VIEW_X;
         marker.y = area.worldY - WM_VIEW_Y;
-        const Sprite& sprite = _sprites[static_cast<std::size_t>(marker.size)];
+        const Sprite& sprite = spriteFor(marker.size);
         marker.width = sprite.width;
         marker.height = sprite.height;
 
@@ -179,12 +184,14 @@ void WorldMapScene::buildAreas(resource::GameResources& resources) {
 }
 
 bool WorldMapScene::blendMarker(const AreaMarker& area) {
-    const Sprite& sprite = _sprites[static_cast<std::size_t>(area.size)];
+    const Sprite& sprite = spriteFor(area.size);
     if (!sprite.valid() || !_greenBlend.has_value()) {
         return false;
     }
 
-    // Clip to the canvas; the engine clips to its 450x443 viewport for the same reason.
+    // Clip to the canvas; the engine clips to its 450x443 viewport for the same reason. Indices are
+    // computed per pixel rather than by offsetting a row pointer by area.x, which would be out of
+    // bounds (and so undefined) for a marker hanging off the left edge.
     const int startX = std::max(0, -area.x);
     const int startY = std::max(0, -area.y);
     const int endX = std::min(sprite.width, _width - area.x);
@@ -192,11 +199,13 @@ bool WorldMapScene::blendMarker(const AreaMarker& area) {
 
     for (int y = startY; y < endY; ++y) {
         const std::uint8_t* src = &sprite.indices[static_cast<std::size_t>(y) * sprite.width];
-        std::uint8_t* dest = &_indices[static_cast<std::size_t>(area.y + y) * _width + area.x];
+        const std::size_t destRow = static_cast<std::size_t>(area.y + y) * _width;
         for (int x = startX; x < endX; ++x) {
-            if (src[x] != 0) { // index 0 is transparent
-                dest[x] = _greenBlend->blendPixel(src[x], dest[x]);
+            if (src[x] == 0) {
+                continue; // index 0 is transparent
             }
+            std::uint8_t& dest = _indices[destRow + static_cast<std::size_t>(area.x + x)];
+            dest = _greenBlend->blendPixel(src[x], dest);
         }
     }
     return true;

--- a/src/editor/worldmap/WorldMapScene.h
+++ b/src/editor/worldmap/WorldMapScene.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 namespace geck::resource {
@@ -51,7 +52,13 @@ struct AreaMarker {
     /// The label the game shows, falling back to the internal name when map.msg has nothing.
     [[nodiscard]] const std::string& label() const { return displayName.empty() ? name : displayName; }
 
+    /// The engine's hit test (`wmMatchWorldPosToArea`), edges included — it compares `<= x + width`,
+    /// so the clickable box really is one pixel wider than the sprite. Kept as-is so clicking here
+    /// picks the same area the game would. A marker with no art has no box at all.
     [[nodiscard]] bool contains(int px, int py) const {
+        if (width <= 0 || height <= 0) {
+            return false;
+        }
         return px >= x && py >= y && px <= x + width && py <= y + height;
     }
 };
@@ -83,11 +90,12 @@ public:
     [[nodiscard]] const std::vector<AreaMarker>& areas() const { return _areas; }
 
     /// The area whose marker covers a worldmap pixel, or nullptr. Matches the engine's rectangular
-    /// hit test (`wmMatchWorldPosToArea`): the lowest-numbered area wins where markers overlap.
+    /// hit test (`wmMatchWorldPosToArea`), which stops at its first hit while walking the area list
+    /// in the order city.txt declares them — so where markers overlap, the earlier section wins.
     [[nodiscard]] const AreaMarker* areaAt(int px, int py) const;
 
-    /// Redraws with markers shown or hidden. Only the marker rectangles are recomputed, so this is
-    /// cheap enough to drive a toggle.
+    /// Redraws with markers shown or hidden. Recomposes the whole canvas (a few milliseconds for
+    /// the shipped 1400x1500 worldmap), which is fine for a toggle.
     void setMarkersVisible(bool visible);
     [[nodiscard]] bool markersVisible() const { return _markersVisible; }
 
@@ -107,6 +115,7 @@ private:
     WorldMapScene() = default;
 
     bool rasteriseTiles(resource::GameResources& resources);
+    void loadMarkerSprites(resource::GameResources& resources);
     void buildAreas(resource::GameResources& resources);
     void composeMarkers();
     void expandToPixels();
@@ -133,6 +142,11 @@ private:
         [[nodiscard]] bool valid() const { return width > 0 && height > 0; }
     };
     std::array<Sprite, 3> _sprites;
+
+    /// The marker art for a city size. The one place the size ordinal is used as an index.
+    [[nodiscard]] const Sprite& spriteFor(CityAreaSize size) const {
+        return _sprites[static_cast<std::size_t>(static_cast<std::underlying_type_t<CityAreaSize>>(size))];
+    }
 
     std::vector<AreaMarker> _areas;
     std::vector<std::string> _missingArt;

--- a/src/editor/worldmap/WorldMapScene.h
+++ b/src/editor/worldmap/WorldMapScene.h
@@ -102,6 +102,17 @@ public:
     /// The engine's `COLOR_GREEN` as RGB, for drawing labels in the same green the circles use.
     [[nodiscard]] std::uint32_t labelColor() const { return _labelColor; }
 
+    /// A marker's radial opacity profile, sampled from the middle of the circle outwards: entry
+    /// `i` covers radius `i / (size() - 1)` of the sprite's half-width, and holds the weight
+    /// (0-1) with which the tint is mixed into the terrain there.
+    ///
+    /// This is the same number the bitmap blend uses. `_buildBlendTable` row `j` computes
+    /// `(tint*j + dest*(7-j)) / 7` per channel — a plain linear interpolation with weight `j/7`,
+    /// where `j` is the sprite pixel's grey level. Reading the profile out lets a renderer draw
+    /// the circle as geometry at any magnification and still land on the engine's colours; only
+    /// the palette quantisation is left behind. Empty when the sprite is missing.
+    [[nodiscard]] const std::vector<float>& markerProfile(CityAreaSize size) const;
+
     /// The terrain name at a worldmap pixel, or "" when the subtile grid isn't loaded.
     [[nodiscard]] std::string terrainAt(int px, int py) const;
 
@@ -114,8 +125,18 @@ public:
 private:
     WorldMapScene() = default;
 
+    /// The three marker sprites (`wrldspr0/1/2.frm`), as raw palette indices with their sizes.
+    struct Sprite {
+        int width = 0;
+        int height = 0;
+        std::vector<std::uint8_t> indices;
+        std::vector<float> profile; ///< see markerProfile()
+        [[nodiscard]] bool valid() const { return width > 0 && height > 0; }
+    };
+
     bool rasteriseTiles(resource::GameResources& resources);
     void loadMarkerSprites(resource::GameResources& resources);
+    void buildMarkerProfile(Sprite& sprite) const;
     void buildAreas(resource::GameResources& resources);
     void composeMarkers();
     void expandToPixels();
@@ -134,13 +155,6 @@ private:
     std::vector<std::uint8_t> _indices;        ///< the working canvas: background + blended markers
     std::vector<std::uint8_t> _pixels;         ///< _indices expanded to RGBA
 
-    /// The three marker sprites (`wrldspr0/1/2.frm`), as raw palette indices with their sizes.
-    struct Sprite {
-        int width = 0;
-        int height = 0;
-        std::vector<std::uint8_t> indices;
-        [[nodiscard]] bool valid() const { return width > 0 && height > 0; }
-    };
     std::array<Sprite, 3> _sprites;
 
     /// The marker art for a city size. The one place the size ordinal is used as an index.

--- a/src/editor/worldmap/WorldMapScene.h
+++ b/src/editor/worldmap/WorldMapScene.h
@@ -9,7 +9,7 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <type_traits>
+#include <tuple>
 #include <vector>
 
 namespace geck::resource {
@@ -116,11 +116,10 @@ public:
     /// The terrain name at a worldmap pixel, or "" when the subtile grid isn't loaded.
     [[nodiscard]] std::string terrainAt(int px, int py) const;
 
-    /// Tile art that could not be resolved or loaded, as `[Tile NN] art_idx=N` descriptions. Empty
-    /// on a clean load; a caller should surface these rather than silently show black tiles.
+    /// Art that could not be resolved or loaded, as `[Tile NN] art_idx=N` / `[Marker size]`
+    /// descriptions. Empty on a clean load; a caller should surface these rather than silently show
+    /// black tiles, or markers that are invisible and so cannot be clicked.
     [[nodiscard]] const std::vector<std::string>& missingArt() const { return _missingArt; }
-
-    [[nodiscard]] const WorldmapTxt& worldmapTxt() const { return _world; }
 
 private:
     WorldMapScene() = default;
@@ -157,9 +156,12 @@ private:
 
     std::array<Sprite, 3> _sprites;
 
-    /// The marker art for a city size. The one place the size ordinal is used as an index.
+    /// The marker art for a city size. The one place the size ordinal is used as an index; the
+    /// enum's three values are exactly the three sprites, which cityAreaSize() guarantees by
+    /// falling back to Large.
     [[nodiscard]] const Sprite& spriteFor(CityAreaSize size) const {
-        return _sprites[static_cast<std::size_t>(static_cast<std::underlying_type_t<CityAreaSize>>(size))];
+        static_assert(static_cast<std::size_t>(CityAreaSize::Large) + 1 == std::tuple_size_v<decltype(_sprites)>);
+        return _sprites[static_cast<std::size_t>(size)];
     }
 
     std::vector<AreaMarker> _areas;

--- a/src/editor/worldmap/WorldMapScene.h
+++ b/src/editor/worldmap/WorldMapScene.h
@@ -1,0 +1,146 @@
+#pragma once
+
+#include "format/city/CityTxt.h"
+#include "format/worldmap/WorldmapTxt.h"
+#include "util/PaletteBlend.h"
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace geck::resource {
+class GameResources;
+}
+
+/// @file
+/// @brief The Fallout 2 worldmap rendered the way the engine draws it, as plain pixel buffers.
+///
+/// The engine composes its worldmap from a grid of 350x300 background tiles (`art/intrface/wrldmp*`,
+/// which already carry the yellow subtile grid) with a translucent green circle blended over every
+/// known area. It does all of that in palette-index space, so this class does too: it rasterises
+/// the tiles into an index canvas, blends the markers into a copy of it through the engine's own
+/// blend tables, and only then expands to RGBA. The result is pixel-identical to the game rather
+/// than an approximation of it.
+///
+/// Qt-free by design — the editor wraps the RGBA buffer in a QImage, and headless callers can write
+/// it straight out.
+///
+/// @see fallout2-ce `worldmap.cc` (`wmInterfaceRefresh`, `wmInterfaceDrawCircleOverlay`)
+
+namespace geck::worldmap {
+
+/// One worldmap area as the view needs it: where its marker sits, what to label it, and enough
+/// context to answer "what is this?" without going back to the raw city.txt.
+struct AreaMarker {
+    int index = -1;          ///< city.txt `[Area NN]`
+    std::string name;        ///< city.txt area_name (internal)
+    std::string displayName; ///< map.msg[1500 + index] (what the game labels it), may be empty
+    CityAreaSize size = CityAreaSize::Large;
+    int x = 0; ///< marker sprite's left edge, in worldmap pixels
+    int y = 0; ///< marker sprite's top edge, in worldmap pixels
+    int width = 0;
+    int height = 0;
+    bool knownAtStart = false;
+    bool locked = false;
+    std::string terrain;               ///< the terrain under the marker, "" if the grid is absent
+    std::vector<std::string> mapFiles; ///< .map files this area's entrances lead to
+
+    /// The label the game shows, falling back to the internal name when map.msg has nothing.
+    [[nodiscard]] const std::string& label() const { return displayName.empty() ? name : displayName; }
+
+    [[nodiscard]] bool contains(int px, int py) const {
+        return px >= x && py >= y && px <= x + width && py <= y + height;
+    }
+};
+
+/// The rasterised worldmap plus its areas.
+///
+/// Construct with @ref load; it returns nullptr when the mounted data has no usable worldmap (no
+/// `city.txt`, or a `worldmap.txt` without the `[Tile NN]` art the background is made of).
+class WorldMapScene {
+public:
+    /// Reads city.txt + worldmap.txt from the mounted data, resolves and rasterises the tile art,
+    /// and blends the area markers. Returns nullptr if the data isn't there.
+    [[nodiscard]] static std::unique_ptr<WorldMapScene> load(resource::GameResources& resources);
+
+    // The cached blend table refers to the tables it was built from, so a scene stays put once
+    // constructed. Callers hold it through the unique_ptr load() hands back.
+    WorldMapScene(const WorldMapScene&) = delete;
+    WorldMapScene& operator=(const WorldMapScene&) = delete;
+    WorldMapScene(WorldMapScene&&) = delete;
+    WorldMapScene& operator=(WorldMapScene&&) = delete;
+    ~WorldMapScene() = default;
+
+    [[nodiscard]] int width() const { return _width; }
+    [[nodiscard]] int height() const { return _height; }
+
+    /// The composed image, 4 bytes per pixel in RGBA order, `width() * height()` pixels.
+    [[nodiscard]] const std::vector<std::uint8_t>& pixels() const { return _pixels; }
+
+    [[nodiscard]] const std::vector<AreaMarker>& areas() const { return _areas; }
+
+    /// The area whose marker covers a worldmap pixel, or nullptr. Matches the engine's rectangular
+    /// hit test (`wmMatchWorldPosToArea`): the lowest-numbered area wins where markers overlap.
+    [[nodiscard]] const AreaMarker* areaAt(int px, int py) const;
+
+    /// Redraws with markers shown or hidden. Only the marker rectangles are recomputed, so this is
+    /// cheap enough to drive a toggle.
+    void setMarkersVisible(bool visible);
+    [[nodiscard]] bool markersVisible() const { return _markersVisible; }
+
+    /// The engine's `COLOR_GREEN` as RGB, for drawing labels in the same green the circles use.
+    [[nodiscard]] std::uint32_t labelColor() const { return _labelColor; }
+
+    /// The terrain name at a worldmap pixel, or "" when the subtile grid isn't loaded.
+    [[nodiscard]] std::string terrainAt(int px, int py) const;
+
+    /// Tile art that could not be resolved or loaded, as `[Tile NN] art_idx=N` descriptions. Empty
+    /// on a clean load; a caller should surface these rather than silently show black tiles.
+    [[nodiscard]] const std::vector<std::string>& missingArt() const { return _missingArt; }
+
+    [[nodiscard]] const WorldmapTxt& worldmapTxt() const { return _world; }
+
+private:
+    WorldMapScene() = default;
+
+    bool rasteriseTiles(resource::GameResources& resources);
+    void buildAreas(resource::GameResources& resources);
+    void composeMarkers();
+    void expandToPixels();
+
+    /// Blends one marker sprite into @p _indices at its position, exactly as
+    /// `_dark_translucent_trans_buf_to_buf` does. Returns false when the sprite is unavailable.
+    bool blendMarker(const AreaMarker& area);
+
+    CityTxt _city;
+    WorldmapTxt _world;
+
+    int _width = 0;
+    int _height = 0;
+
+    std::vector<std::uint8_t> _terrainIndices; ///< the tile background alone, never mutated after load
+    std::vector<std::uint8_t> _indices;        ///< the working canvas: background + blended markers
+    std::vector<std::uint8_t> _pixels;         ///< _indices expanded to RGBA
+
+    /// The three marker sprites (`wrldspr0/1/2.frm`), as raw palette indices with their sizes.
+    struct Sprite {
+        int width = 0;
+        int height = 0;
+        std::vector<std::uint8_t> indices;
+        [[nodiscard]] bool valid() const { return width > 0 && height > 0; }
+    };
+    std::array<Sprite, 3> _sprites;
+
+    std::vector<AreaMarker> _areas;
+    std::vector<std::string> _missingArt;
+
+    std::optional<palette::BlendTables> _tables;
+    std::optional<palette::BlendTable> _greenBlend;
+    std::uint32_t _labelColor = 0x00FF00;
+    bool _markersVisible = true;
+};
+
+} // namespace geck::worldmap

--- a/src/format/city/CityTxt.h
+++ b/src/format/city/CityTxt.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 /// @file
@@ -70,24 +71,26 @@ enum class CityAreaSize {
 
 /// Maps a `size` value (already lowercased by the reader) onto its ordinal. Unknown values fall
 /// back to Large, matching the engine's `wmAreaSlotInit` default.
-inline CityAreaSize cityAreaSize(const std::string& size) {
+inline CityAreaSize cityAreaSize(std::string_view size) {
+    using enum CityAreaSize;
     if (size == "small") {
-        return CityAreaSize::Small;
+        return Small;
     }
     if (size == "medium") {
-        return CityAreaSize::Medium;
+        return Medium;
     }
-    return CityAreaSize::Large;
+    return Large;
 }
 
 /// The engine's own name for a size (`wmAreaSizeStrs`), for display.
 inline const char* cityAreaSizeName(CityAreaSize size) {
+    using enum CityAreaSize;
     switch (size) {
-        case CityAreaSize::Small:
+        case Small:
             return "small";
-        case CityAreaSize::Medium:
+        case Medium:
             return "medium";
-        case CityAreaSize::Large:
+        case Large:
             break;
     }
     return "large";

--- a/src/format/city/CityTxt.h
+++ b/src/format/city/CityTxt.h
@@ -13,13 +13,17 @@
 ///
 /// @verbatim
 /// [Area 00]                ; Arroyo
-/// area_name=Arroyo         ; internal name (the displayed name may also live in worldmap.msg)
+/// area_name=Arroyo         ; internal name (the displayed name comes from map.msg[1500 + index])
 /// world_pos=184,133        ; x,y on the worldmap — the basis for distances between places
 /// start_state=On           ; On = known/visible at game start
 /// size=Medium              ; Small / Medium / Large
+/// townmap_art_idx=156      ; intrface.lst index of the town-map background
+/// townmap_label_art_idx=370; intrface.lst index of the town-map label strip
 /// entrance_0=On,350,275,Arroyo Bridge,-1,-1,3
 /// ;           state, x, y, map (a maps.txt lookup_name), elevation, tile, orientation
 /// @endverbatim
+///
+/// The engine keys its area loop on `townmap_art_idx`: an `[Area NN]` without it ends the list.
 ///
 /// @see fallout2-ce `worldmap.cc` (`wmAreaInit`)
 /// @see https://fallout.wiki/wiki/CITY.TXT_File_Format
@@ -45,13 +49,49 @@ struct CityEntrance {
 /// `wmAreaInit` (fallout2-ce worldmap.cc). The display name may also live in worldmap.msg.
 struct CityArea {
     int index = -1;
-    std::string name;     ///< area_name
-    int worldX = 0;       ///< world_pos x (worldmap position)
-    int worldY = 0;       ///< world_pos y
-    bool startOn = false; ///< start_state On = known/visible at game start
-    std::string size;     ///< small / medium / large
+    std::string name;              ///< area_name
+    int worldX = 0;                ///< world_pos x (worldmap position)
+    int worldY = 0;                ///< world_pos y
+    bool startOn = false;          ///< start_state On = known/visible at game start
+    bool locked = false;           ///< lock_state On = the area cannot become known through play
+    std::string size;              ///< small / medium / large
+    int townMapArtIndex = -1;      ///< townmap_art_idx: intrface.lst index of the town-map background
+    int townMapLabelArtIndex = -1; ///< townmap_label_art_idx: intrface.lst index of its label strip
     std::vector<CityEntrance> entrances;
 };
+
+/// The worldmap circle sizes a `size` key names, in the order the engine's `wmAreaSizeStrs` lists
+/// them — the ordinal picks the marker art (`wrldspr0/1/2.frm`, 12/25/49 pixels square).
+enum class CityAreaSize {
+    Small = 0,
+    Medium = 1,
+    Large = 2,
+};
+
+/// Maps a `size` value (already lowercased by the reader) onto its ordinal. Unknown values fall
+/// back to Large, matching the engine's `wmAreaSlotInit` default.
+inline CityAreaSize cityAreaSize(const std::string& size) {
+    if (size == "small") {
+        return CityAreaSize::Small;
+    }
+    if (size == "medium") {
+        return CityAreaSize::Medium;
+    }
+    return CityAreaSize::Large;
+}
+
+/// The engine's own name for a size (`wmAreaSizeStrs`), for display.
+inline const char* cityAreaSizeName(CityAreaSize size) {
+    switch (size) {
+        case CityAreaSize::Small:
+            return "small";
+        case CityAreaSize::Medium:
+            return "medium";
+        case CityAreaSize::Large:
+            break;
+    }
+    return "large";
+}
 
 /// Parsed `data/city.txt`: the worldmap areas, looked up by their `[Area NN]` index.
 struct CityTxt {

--- a/src/format/city/CityTxt.h
+++ b/src/format/city/CityTxt.h
@@ -24,7 +24,12 @@
 /// ;           state, x, y, map (a maps.txt lookup_name), elevation, tile, orientation
 /// @endverbatim
 ///
-/// The engine keys its area loop on `townmap_art_idx`: an `[Area NN]` without it ends the list.
+/// The engine walks `[Area 00]`, `[Area 01]`, … in order and stops at the first index whose
+/// section is missing or has no `townmap_art_idx` **key** (`wmAreaInit`). The value is not the
+/// test — `townmap_art_idx=-1` is ordinary, and 42 of the Restoration Project's 61 areas carry
+/// it. This reader keeps every `[Area NN]` it finds instead: the model does not record whether a
+/// key was present, and every shipped city.txt is contiguous from 0 with the key on every
+/// section, so the rule has nothing to bite on.
 ///
 /// @see fallout2-ce `worldmap.cc` (`wmAreaInit`)
 /// @see https://fallout.wiki/wiki/CITY.TXT_File_Format

--- a/src/format/pal/Pal.cpp
+++ b/src/format/pal/Pal.cpp
@@ -14,6 +14,10 @@ std::array<uint8_t, Pal::NUM_CONVERSION_VALUES>& Pal::rgbConversionTable() {
     return _rgbConversionTable;
 }
 
+const std::array<uint8_t, Pal::NUM_CONVERSION_VALUES>& Pal::rgbConversionTable() const {
+    return _rgbConversionTable;
+}
+
 void Pal::setRgbConversionTable(const std::array<uint8_t, NUM_CONVERSION_VALUES>& rgbConversionTable) {
     _rgbConversionTable = rgbConversionTable;
 }

--- a/src/format/pal/Pal.h
+++ b/src/format/pal/Pal.h
@@ -26,6 +26,7 @@ public:
     void setPalette(const std::array<Rgb, NUM_PALETTE_COLORS>& value);
 
     std::array<uint8_t, NUM_CONVERSION_VALUES>& rgbConversionTable();
+    const std::array<uint8_t, NUM_CONVERSION_VALUES>& rgbConversionTable() const;
     void setRgbConversionTable(const std::array<uint8_t, NUM_CONVERSION_VALUES>& rgbConversionTable);
 
 private:

--- a/src/format/worldmap/WorldmapTxt.h
+++ b/src/format/worldmap/WorldmapTxt.h
@@ -62,9 +62,26 @@ inline constexpr int WM_SUBTILE_SIZE = 50;
 inline constexpr int SUBTILE_GRID_WIDTH = 7;  // subtile columns per tile (the "row" key index, 0-6)
 inline constexpr int SUBTILE_GRID_HEIGHT = 6; // subtile rows per tile (the "column" key index, 0-5)
 
-/// One worldmap tile's subtile terrain grid, indexed [row][column] to match the engine's
-/// "row_column" keys (row 0-6 across, column 0-5 down).
+// Where the worldmap view sits inside the engine's 640x480 interface window (WM_VIEW_X/WM_VIEW_Y).
+// This matters outside the interface too: city.txt's world_pos is measured from the window origin,
+// not the view's, so a marker's true position on the worldmap is world_pos minus these. fallout2-ce
+// applies the same bias when drawing (wmInterfaceRefresh) and when hit-testing
+// (wmMatchWorldPosToArea), so the two agree.
+inline constexpr int WM_VIEW_X = 22;
+inline constexpr int WM_VIEW_Y = 21;
+
+/// One worldmap tile: its background art plus the subtile terrain grid, indexed [row][column] to
+/// match the engine's "row_column" keys (row 0-6 across, column 0-5 down).
 struct WorldmapTile {
+    /// `art_idx` — an intrface.lst index, i.e. FID `buildFid(OBJ_TYPE_INTERFACE, artIndex)`. The
+    /// shipped tiles resolve to `art/intrface/wrldmp00.frm` … `wrldmp19.frm`, each 350x300 with the
+    /// yellow subtile grid already drawn in. -1 when the section had no art_idx.
+    int artIndex = -1;
+    /// `walk_mask_name` — the stem of a `data/<name>.msk` travel mask (1 bit per pixel, 44-byte
+    /// rows), empty when the tile is walkable throughout.
+    std::string walkMaskName;
+    /// `encounter_difficulty` — added to the tile's encounter difficulty rolls.
+    int encounterDifficulty = 0;
     std::array<std::array<std::string, SUBTILE_GRID_HEIGHT>, SUBTILE_GRID_WIDTH> terrain;
 };
 
@@ -75,6 +92,19 @@ struct WorldmapTxt {
     std::vector<Encounter> encounters;
     std::vector<WorldmapTile> tiles; ///< the worldmap tile grid, indexed by [Tile NN]
     int numHorizontalTiles = 0;      ///< [Tile Data] num_horizontal_tiles (worldmap width, in tiles)
+
+    /// Tile rows, i.e. `tiles.size() / numHorizontalTiles` (the engine's
+    /// `wmMaxTileNum / wmNumHorizontalTiles`). 0 when the tile grid isn't loaded.
+    int numVerticalTiles() const {
+        if (numHorizontalTiles <= 0) {
+            return 0;
+        }
+        return static_cast<int>(tiles.size()) / numHorizontalTiles;
+    }
+
+    /// The whole worldmap's size in pixels — 1400x1500 for the shipped 4x5 grid of 350x300 tiles.
+    int widthPixels() const { return numHorizontalTiles * WM_TILE_WIDTH; }
+    int heightPixels() const { return numVerticalTiles() * WM_TILE_HEIGHT; }
 
     const Encounter* findEncounter(const std::string& name) const {
         for (const auto& encounter : encounters) {

--- a/src/reader/city/CityTxtReader.cpp
+++ b/src/reader/city/CityTxtReader.cpp
@@ -65,6 +65,12 @@ namespace {
             area.startOn = toLower(value) == "on";
         } else if (key == "size") {
             area.size = toLower(value);
+        } else if (key == "lock_state") {
+            area.locked = toLower(value) == "on";
+        } else if (key == "townmap_art_idx") {
+            area.townMapArtIndex = intOr(value, -1);
+        } else if (key == "townmap_label_art_idx") {
+            area.townMapLabelArtIndex = intOr(value, -1);
         } else if (key.rfind("entrance_", 0) == 0) {
             area.entrances.push_back(parseEntrance(value));
         }

--- a/src/reader/worldmap/WorldmapTxtReader.cpp
+++ b/src/reader/worldmap/WorldmapTxtReader.cpp
@@ -38,6 +38,19 @@ namespace {
     // A [Tile NN] subtile line: key "row_column" (row 0-6, column 0-5) -> "terrain, fill, chances, …".
     // We keep the terrain (the first field).
     void applyTileField(WorldmapTile& tile, const std::string& key, const std::string& value) {
+        if (key == "art_idx") {
+            tile.artIndex = intOr(value, -1);
+            return;
+        }
+        if (key == "walk_mask_name") {
+            tile.walkMaskName = value;
+            return;
+        }
+        if (key == "encounter_difficulty") {
+            tile.encounterDifficulty = intOr(value, 0);
+            return;
+        }
+
         const auto underscore = key.find('_');
         if (underscore == std::string::npos) {
             return;

--- a/src/resource/ConfigLoad.h
+++ b/src/resource/ConfigLoad.h
@@ -3,15 +3,16 @@
 #include <initializer_list>
 #include <string>
 
-#include "resource/GameResources.h"
+#include "GameResources.h"
 
-namespace geck::cli {
+namespace geck::resource {
 
 /// Load a Fallout text config (maps.txt / city.txt / worldmap.txt / quests.txt …) by trying each
 /// candidate VFS path in turn and parsing the first that exists with `parse` (a callable taking the
 /// file text and returning T). Returns a default-constructed T when none is mounted, so callers
-/// degrade gracefully. One place for the "data/<x> then <x>, read bytes, parse" idiom the world
-/// tools share.
+/// degrade gracefully. One place for the "data/<x> then <x>, read bytes, parse" idiom shared by the
+/// headless world tools and the editor's worldmap view. (Both candidates are needed: Fallout ships
+/// these under data/, but a data directory mounted at its own root exposes them unprefixed.)
 template <typename T, typename Parse>
 T loadConfig(resource::GameResources& resources, std::initializer_list<const char*> paths, Parse parse) {
     for (const char* path : paths) {
@@ -22,4 +23,4 @@ T loadConfig(resource::GameResources& resources, std::initializer_list<const cha
     return T{};
 }
 
-} // namespace geck::cli
+} // namespace geck::resource

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -2697,6 +2697,15 @@ void MainWindow::showMapBrowserDialog() {
     }
 }
 
+std::string MainWindow::findMountedMapPath(const QString& mapFileName) const {
+    for (const auto& path : _resourcesShared->files().list("*.map")) {
+        if (QString::fromStdString(path.filename().string()).compare(mapFileName, Qt::CaseInsensitive) == 0) {
+            return path.generic_string();
+        }
+    }
+    return {};
+}
+
 void MainWindow::toggleWorldMap(bool show) {
     if (!show) {
         // Back to whatever was showing before — the open map, or the welcome screen if it has since
@@ -2714,19 +2723,17 @@ void MainWindow::toggleWorldMap(bool show) {
     if (_worldMapWidget == nullptr) {
         _worldMapWidget = new WorldMapWidget(*_resourcesShared, this);
         connect(_worldMapWidget, &WorldMapWidget::openMapRequested, this, [this](const QString& mapFileName) {
-            // The worldmap knows areas by .map filename; the loader wants the VFS path, so find the
-            // mounted file whose name matches.
-            for (const auto& path : _resourcesShared->files().list("*.map")) {
-                if (QString::fromStdString(path.filename().string()).compare(mapFileName, Qt::CaseInsensitive) == 0) {
-                    if (_worldMapAction != nullptr) {
-                        _worldMapAction->setChecked(false); // leave the world map for the editor
-                    }
-                    handleMapLoadRequest(path.generic_string(), false);
-                    return;
-                }
+            // The worldmap knows areas by .map filename; the loader wants the VFS path.
+            const std::string mapPath = findMountedMapPath(mapFileName);
+            if (mapPath.empty()) {
+                QtDialogs::showError(this, "Map Not Found",
+                    QString("%1 is not in the mounted game data.").arg(mapFileName));
+                return;
             }
-            QtDialogs::showError(this, "Map Not Found",
-                QString("%1 is not in the mounted game data.").arg(mapFileName));
+            if (_worldMapAction != nullptr) {
+                _worldMapAction->setChecked(false); // leave the world map for the editor
+            }
+            handleMapLoadRequest(mapPath, false);
         });
         _centralStack->addWidget(_worldMapWidget);
     }

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -6,6 +6,7 @@
 #include "util/GameDataPathResolver.h"
 #include "ui/widgets/LoadingWidget.h"
 #include "ui/widgets/WelcomeWidget.h"
+#include "ui/worldmap/WorldMapWidget.h"
 #include "ui/widgets/SFMLWidget.h"
 #include "ui/panels/SelectionPanel.h"
 #include "ui/panels/MapInfoPanel.h"
@@ -517,6 +518,16 @@ void MainWindow::setupMenuBar() {
     updateFillSelectionAction();
 
     _viewMenu = _menuBar->addMenu("&View");
+
+    // The world map is a whole screen rather than a per-map toggle, so it leads the menu and is
+    // separated from the rendering switches below. It needs mounted game data, not an open map.
+    _worldMapAction = _viewMenu->addAction(createIcon(":/icons/actions/world-map.svg"), "&World Map");
+    _worldMapAction->setCheckable(true);
+    _worldMapAction->setShortcut(QKeySequence("Ctrl+Shift+M"));
+    _worldMapAction->setStatusTip("Show the Fallout 2 world map with its area markers");
+    connect(_worldMapAction, &QAction::toggled, this, &MainWindow::toggleWorldMap);
+    _viewMenu->addSeparator();
+
     struct ViewToggleSpec {
         QAction** actionRef;
         const char* iconPath;
@@ -1425,6 +1436,17 @@ void MainWindow::rebuildGameResourcesFromSettings() {
     const std::string loaderErrorMessage = loaderPtr ? loaderPtr->errorMessage() : std::string();
 
     _resourcesShared = std::move(newResources);
+    // The world map holds art and city.txt from the old resources; drop it so the next Show rebuilds
+    // it against the new mounts (and so nothing keeps the retired GameResources alive).
+    if (_worldMapWidget != nullptr) {
+        if (_worldMapAction != nullptr) {
+            _worldMapAction->setChecked(false);
+        }
+        _centralStack->removeWidget(_worldMapWidget);
+        _worldMapWidget->deleteLater();
+        _worldMapWidget = nullptr;
+        _pageBeforeWorldMap = nullptr;
+    }
     rebuildResourcePanels();
     startThumbnailPrewarm(); // new mounts can mean new maps and new source identities
     refreshFileBrowser();
@@ -2673,6 +2695,52 @@ void MainWindow::showMapBrowserDialog() {
     if (!mapPath.isEmpty()) {
         handleMapLoadRequest(mapPath.toStdString(), false);
     }
+}
+
+void MainWindow::toggleWorldMap(bool show) {
+    if (!show) {
+        // Back to whatever was showing before — the open map, or the welcome screen if it has since
+        // been closed and the remembered page is gone.
+        QWidget* target = _pageBeforeWorldMap;
+        if (target == nullptr || _centralStack->indexOf(target) < 0) {
+            target = _currentEditorWidget != nullptr ? static_cast<QWidget*>(_currentEditorWidget)
+                                                     : static_cast<QWidget*>(_welcomeWidget);
+        }
+        _centralStack->setCurrentWidget(target);
+        _pageBeforeWorldMap = nullptr;
+        return;
+    }
+
+    if (_worldMapWidget == nullptr) {
+        _worldMapWidget = new WorldMapWidget(*_resourcesShared, this);
+        connect(_worldMapWidget, &WorldMapWidget::openMapRequested, this, [this](const QString& mapFileName) {
+            // The worldmap knows areas by .map filename; the loader wants the VFS path, so find the
+            // mounted file whose name matches.
+            for (const auto& path : _resourcesShared->files().list("*.map")) {
+                if (QString::fromStdString(path.filename().string()).compare(mapFileName, Qt::CaseInsensitive) == 0) {
+                    if (_worldMapAction != nullptr) {
+                        _worldMapAction->setChecked(false); // leave the world map for the editor
+                    }
+                    handleMapLoadRequest(path.generic_string(), false);
+                    return;
+                }
+            }
+            QtDialogs::showError(this, "Map Not Found",
+                QString("%1 is not in the mounted game data.").arg(mapFileName));
+        });
+        _centralStack->addWidget(_worldMapWidget);
+    }
+
+    // Rendering the whole worldmap takes a moment, so do it on first show and after the data paths
+    // change (reload() is cheap to call again and reports its own failure in place of the map).
+    if (!_worldMapWidget->hasScene()) {
+        QApplication::setOverrideCursor(Qt::WaitCursor);
+        _worldMapWidget->reload();
+        QApplication::restoreOverrideCursor();
+    }
+
+    _pageBeforeWorldMap = _centralStack->currentWidget();
+    _centralStack->setCurrentWidget(_worldMapWidget);
 }
 
 void MainWindow::showStatusMessage(const QString& message) {

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -166,6 +166,7 @@ void MainWindow::setEditorWidget(std::unique_ptr<EditorWidget> editorWidget) {
     _currentEditorWidget = editorWidget.release();
     _centralStack->addWidget(_currentEditorWidget);
     _centralStack->setCurrentWidget(_currentEditorWidget);
+    clearWorldMapAction(); // the map replaced whatever page was showing, world map included
 
     _currentEditorWidget->setMainWindow(this);
     {
@@ -217,6 +218,13 @@ void MainWindow::setupUI() {
     _welcomeWidget = new WelcomeWidget(this);
     connect(_welcomeWidget, &WelcomeWidget::newMapRequested, this, &MainWindow::newMapRequested);
     connect(_welcomeWidget, &WelcomeWidget::browseMapsRequested, this, &MainWindow::showMapBrowserDialog);
+    // Go through the menu action rather than toggleWorldMap() directly, so its checked state keeps
+    // matching what is on screen.
+    connect(_welcomeWidget, &WelcomeWidget::worldMapRequested, this, [this] {
+        if (_worldMapAction != nullptr) {
+            _worldMapAction->setChecked(true);
+        }
+    });
     connect(_welcomeWidget, &WelcomeWidget::preferencesRequested, this, &MainWindow::showPreferences);
     _centralStack->addWidget(_welcomeWidget);
     _centralStack->setCurrentWidget(_welcomeWidget);
@@ -2538,6 +2546,7 @@ void MainWindow::closeCurrentMap() {
     _currentEditorWidget = nullptr;
 
     _centralStack->setCurrentWidget(_welcomeWidget);
+    clearWorldMapAction(); // the welcome screen is showing now, not the world map
 
     // No map is open now: clear the dirty flag and reset the title off the closed map, otherwise the
     // title bar keeps the closed map's name (and a stale "*") while the welcome screen is shown.
@@ -2695,6 +2704,14 @@ void MainWindow::showMapBrowserDialog() {
     if (!mapPath.isEmpty()) {
         handleMapLoadRequest(mapPath.toStdString(), false);
     }
+}
+
+void MainWindow::clearWorldMapAction() {
+    if (_worldMapAction != nullptr && _worldMapAction->isChecked()) {
+        const QSignalBlocker blocker(_worldMapAction);
+        _worldMapAction->setChecked(false);
+    }
+    _pageBeforeWorldMap = nullptr;
 }
 
 std::string MainWindow::findMountedMapPath(const QString& mapFileName) const {

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <string>
 #include <filesystem>
 #include <utility>
 #include <SFML/Window/Event.hpp>
@@ -270,6 +271,10 @@ private:
     void restoreDefaultLayout();
 
     void convertQtEventToSFML(QKeyEvent* qtEvent, sf::Event& sfmlEvent, bool pressed);
+
+    /// The VFS path of a mounted .map with this filename (any case), or "" if none has it. The
+    /// world map identifies an area's maps by filename, while the loader wants a path.
+    [[nodiscard]] std::string findMountedMapPath(const QString& mapFileName) const;
 
     QStackedWidget* _centralStack;
     QTimer* _gameLoopTimer;

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -276,6 +276,10 @@ private:
     /// world map identifies an area's maps by filename, while the loader wants a path.
     [[nodiscard]] std::string findMountedMapPath(const QString& mapFileName) const;
 
+    /// Clears the World Map action for callers that switch the central page themselves (opening or
+    /// closing a map). Silently, so unchecking does not bounce the page back again.
+    void clearWorldMapAction();
+
     QStackedWidget* _centralStack;
     QTimer* _gameLoopTimer;
     std::shared_ptr<resource::GameResources> _resourcesShared;

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -44,6 +44,7 @@ class SFMLWidget;
 class EditorWidget;
 class LoadingWidget;
 class WelcomeWidget;
+class WorldMapWidget;
 class SelectionPanel;
 class MapInfoPanel;
 class ScriptsPanel;
@@ -161,6 +162,8 @@ private slots:
     void showStampPatternDialog();
     void showFillDialog();
     void showMapBrowserDialog();
+    /// Switches the central area between the world map and whatever was showing before it.
+    void toggleWorldMap(bool show);
 
 public slots:
     void showStatusMessage(const QString& message);
@@ -279,6 +282,11 @@ private:
     // Current widgets
     EditorWidget* _currentEditorWidget;
     WelcomeWidget* _welcomeWidget;
+    /// Built the first time the world map is opened — rendering it costs a couple of megabytes and
+    /// most sessions never ask for it.
+    WorldMapWidget* _worldMapWidget = nullptr;
+    /// The stack page to return to when the world map is closed.
+    QWidget* _pageBeforeWorldMap = nullptr;
 
     // Menu items
     QMenuBar* _menuBar;
@@ -385,6 +393,7 @@ private:
     QAction* _showSpatialScriptsAction;
     QAction* _showMapEdgesAction;
     QAction* _showUnreachableAction;
+    QAction* _worldMapAction = nullptr;
     QAction* _mergeOutlinesAction;
     QAction* _edgeScrollAction;
 

--- a/src/ui/widgets/WelcomeWidget.cpp
+++ b/src/ui/widgets/WelcomeWidget.cpp
@@ -62,14 +62,17 @@ void WelcomeWidget::createActionButtons() {
     // File menu's New Map / Browse Maps actions. MainWindow connects these signals to those handlers.
     _newMapButton = new QPushButton(createIcon(":/icons/actions/new.svg"), "New Map", this);
     _browseButton = new QPushButton(createIcon(":/icons/actions/open.svg"), "Browse Maps…", this);
+    // The world map needs mounted game data but no open map, so it belongs on this screen too.
+    _worldMapButton = new QPushButton(createIcon(":/icons/actions/world-map.svg"), "World Map", this);
     _preferencesButton = new QPushButton(createIcon(":/icons/actions/settings.svg"), "Preferences…", this);
-    for (QPushButton* button : { _newMapButton, _browseButton, _preferencesButton }) {
+    for (QPushButton* button : { _newMapButton, _browseButton, _worldMapButton, _preferencesButton }) {
         button->setCursor(Qt::PointingHandCursor);
         button->setMinimumWidth(150);
     }
 
     connect(_newMapButton, &QPushButton::clicked, this, &WelcomeWidget::newMapRequested);
     connect(_browseButton, &QPushButton::clicked, this, &WelcomeWidget::browseMapsRequested);
+    connect(_worldMapButton, &QPushButton::clicked, this, &WelcomeWidget::worldMapRequested);
     connect(_preferencesButton, &QPushButton::clicked, this, &WelcomeWidget::preferencesRequested);
 
     auto* buttonRow = new QHBoxLayout();
@@ -77,6 +80,8 @@ void WelcomeWidget::createActionButtons() {
     buttonRow->addWidget(_newMapButton);
     buttonRow->addSpacing(ui::theme::spacing::NORMAL);
     buttonRow->addWidget(_browseButton);
+    buttonRow->addSpacing(ui::theme::spacing::NORMAL);
+    buttonRow->addWidget(_worldMapButton);
     buttonRow->addSpacing(ui::theme::spacing::NORMAL);
     buttonRow->addWidget(_preferencesButton);
     buttonRow->addStretch();

--- a/src/ui/widgets/WelcomeWidget.h
+++ b/src/ui/widgets/WelcomeWidget.h
@@ -27,6 +27,8 @@ signals:
     void newMapRequested();
     /// The user asked to open the map browser from the welcome screen.
     void browseMapsRequested();
+    /// The user asked to open the world map from the welcome screen.
+    void worldMapRequested();
     /// The user asked to open the preferences dialog from the welcome screen.
     void preferencesRequested();
 
@@ -41,6 +43,7 @@ private:
     QLabel* _versionLabel;
     QPushButton* _newMapButton;
     QPushButton* _browseButton;
+    QPushButton* _worldMapButton;
     QPushButton* _preferencesButton;
 };
 

--- a/src/ui/worldmap/WorldMapView.cpp
+++ b/src/ui/worldmap/WorldMapView.cpp
@@ -48,6 +48,11 @@ namespace {
     // Below the threshold the exact blended bitmap is used, which is what fidelity at 1:1 needs.
     constexpr double VECTOR_MARKER_ZOOM = 1.5;
 
+    // Switching between the two costs a full recompose of the 1400x1500 index canvas, so leave the
+    // vector range a little lower than it is entered. Without the gap a wheel notch that lands on
+    // the threshold recomposes twice per notch.
+    constexpr double VECTOR_MARKER_ZOOM_EXIT = 1.35;
+
 } // namespace
 
 WorldMapView::WorldMapView(QWidget* parent)
@@ -99,13 +104,16 @@ void WorldMapView::setMarkersVisible(bool visible) {
 }
 
 bool WorldMapView::usingVectorMarkers() const {
-    return _markersVisible && _zoom >= VECTOR_MARKER_ZOOM;
+    return _vectorMarkers;
 }
 
 void WorldMapView::syncSceneMarkers() {
+    const double threshold = _vectorMarkers ? VECTOR_MARKER_ZOOM_EXIT : VECTOR_MARKER_ZOOM;
+    _vectorMarkers = _markersVisible && _zoom >= threshold;
+
     // The scene bakes the circles into its bitmap; leave them out whenever the painter is drawing
     // them as geometry, or the two would stack.
-    const bool wantBitmapMarkers = _markersVisible && !usingVectorMarkers();
+    const bool wantBitmapMarkers = _markersVisible && !_vectorMarkers;
     if (!_scene || _scene->markersVisible() == wantBitmapMarkers) {
         return;
     }
@@ -251,7 +259,9 @@ void WorldMapView::drawVectorMarkers(QPainter& painter) const {
 
     for (const worldmap::AreaMarker& area : _scene->areas()) {
         const std::vector<float>& profile = _scene->markerProfile(area.size);
-        if (profile.empty() || area.width <= 0) {
+        // Two stops are the minimum a gradient can interpolate between; a one-bucket profile would
+        // divide by zero below. Only art far smaller than the shipped 12/25/49 px gets there.
+        if (profile.size() < 2 || area.width <= 0) {
             continue;
         }
 
@@ -445,7 +455,10 @@ void WorldMapView::wheelEvent(QWheelEvent* event) {
 }
 
 void WorldMapView::leaveEvent(QEvent* event) {
-    _hovered = nullptr;
+    if (_hovered != nullptr) {
+        _hovered = nullptr;
+        update(); // the pointer kept a label alive through the overlap culling; let it be culled now
+    }
     QWidget::leaveEvent(event);
 }
 
@@ -482,6 +495,10 @@ QString WorldMapView::tooltipFor(const worldmap::AreaMarker& area) const {
     }
     text += QStringLiteral("<br>%1").arg(area.knownAtStart ? QStringLiteral("Known at start")
                                                            : QStringLiteral("Discovered through play"));
+    if (area.locked) {
+        // city.txt lock_state: the engine refuses to reveal the area through normal play.
+        text += QStringLiteral(" &middot; locked");
+    }
     if (!area.mapFiles.empty()) {
         QStringList maps;
         for (const std::string& mapFile : area.mapFiles) {

--- a/src/ui/worldmap/WorldMapView.cpp
+++ b/src/ui/worldmap/WorldMapView.cpp
@@ -1,0 +1,378 @@
+#include "ui/worldmap/WorldMapView.h"
+
+#include "editor/worldmap/WorldMapScene.h"
+#include "ui/theme/ThemeManager.h"
+
+#include <QHelpEvent>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QToolTip>
+#include <QWheelEvent>
+
+#include <algorithm>
+#include <cmath>
+
+namespace geck {
+
+namespace {
+
+    // Low enough that the whole 1400x1500 worldmap still fits a small window.
+    constexpr double MIN_ZOOM = 0.1;
+    constexpr double MAX_ZOOM = 8.0;
+    constexpr double WHEEL_STEP = 1.15;
+
+    // Fitting never magnifies: the art is 8-bit and 1:1 is as large as it is meant to be seen.
+    constexpr double MAX_FIT_ZOOM = 1.0;
+
+    // The engine puts the city name three pixels under its circle (wmInterfaceDrawCircleOverlay).
+    constexpr int LABEL_GAP = 3;
+    constexpr int LABEL_POINT_SIZE = 9;
+
+    // Below this the labels crowd into each other and stop being readable, so they are dropped.
+    constexpr double LABEL_MIN_ZOOM = 0.5;
+
+} // namespace
+
+WorldMapView::WorldMapView(QWidget* parent)
+    : QWidget(parent) {
+    setMouseTracking(true);
+    setFocusPolicy(Qt::StrongFocus);
+    setCursor(Qt::OpenHandCursor);
+    setAutoFillBackground(true);
+
+    QPalette background = palette();
+    background.setColor(QPalette::Window, QColor(ui::theme::colors::SURFACE_DARK));
+    setPalette(background);
+}
+
+WorldMapView::~WorldMapView() = default;
+
+void WorldMapView::setScene(std::shared_ptr<worldmap::WorldMapScene> scene) {
+    _scene = std::move(scene);
+    _selected = nullptr;
+    _hovered = nullptr;
+
+    if (_scene) {
+        // QImage over the scene's buffer: no copy, but the scene has to outlive the image, which
+        // the shared_ptr guarantees. Re-wrapped whenever the scene recomposes (see setMarkersVisible).
+        _image = QImage(_scene->pixels().data(), _scene->width(), _scene->height(),
+            _scene->width() * 4, QImage::Format_RGBA8888);
+    } else {
+        _image = QImage();
+    }
+
+    _fitPending = true;
+    fitIfPending();
+    update();
+}
+
+void WorldMapView::fitIfPending() {
+    if (_fitPending && _scene && width() > 1 && height() > 1) {
+        zoomToFit();
+    }
+}
+
+void WorldMapView::setMarkersVisible(bool visible) {
+    if (!_scene || _scene->markersVisible() == visible) {
+        return;
+    }
+    _scene->setMarkersVisible(visible);
+    // The recompose rewrote the buffer in place; the QImage still points at it, but tell Qt the
+    // pixels changed by rebuilding the wrapper (QImage caches nothing else here).
+    _image = QImage(_scene->pixels().data(), _scene->width(), _scene->height(),
+        _scene->width() * 4, QImage::Format_RGBA8888);
+    update();
+}
+
+void WorldMapView::setLabelsVisible(bool visible) {
+    if (_labelsVisible == visible) {
+        return;
+    }
+    _labelsVisible = visible;
+    update();
+}
+
+QPointF WorldMapView::toWorld(const QPointF& widgetPos) const {
+    return _topLeft + widgetPos / _zoom;
+}
+
+QPointF WorldMapView::toWidget(const QPointF& worldPos) const {
+    return (worldPos - _topLeft) * _zoom;
+}
+
+void WorldMapView::zoomToFit() {
+    if (!_scene || _scene->width() <= 0 || _scene->height() <= 0) {
+        return;
+    }
+    // Stays armed: while the view is fitted, resizing the window refits it. Panning or zooming
+    // disarms it, because from then on the user has chosen what to look at.
+    _fitPending = true;
+    const double fit = std::min(static_cast<double>(width()) / _scene->width(),
+        static_cast<double>(height()) / _scene->height());
+    _zoom = std::clamp(fit, MIN_ZOOM, MAX_FIT_ZOOM);
+    _topLeft = QPointF(0, 0);
+    clampPan();
+    update();
+}
+
+void WorldMapView::zoomToActualSize() {
+    if (!_scene) {
+        return;
+    }
+    _fitPending = false;
+    setZoom(1.0, QPointF(width() / 2.0, height() / 2.0));
+}
+
+void WorldMapView::setZoom(double zoom, const QPointF& anchorWidgetPos) {
+    const double clamped = std::clamp(zoom, MIN_ZOOM, MAX_ZOOM);
+    if (std::abs(clamped - _zoom) < 1e-9) {
+        return;
+    }
+    _fitPending = false; // the user picked a zoom; stop refitting on resize
+    // Keep whatever is under the anchor pinned there.
+    const QPointF anchorWorld = toWorld(anchorWidgetPos);
+    _zoom = clamped;
+    _topLeft = anchorWorld - anchorWidgetPos / _zoom;
+    clampPan();
+    update();
+}
+
+void WorldMapView::clampPan() {
+    if (!_scene) {
+        return;
+    }
+    const double visibleWidth = width() / _zoom;
+    const double visibleHeight = height() / _zoom;
+
+    // When the map is smaller than the view in an axis, centre it rather than pinning it left/top.
+    if (_scene->width() <= visibleWidth) {
+        _topLeft.setX((_scene->width() - visibleWidth) / 2.0);
+    } else {
+        _topLeft.setX(std::clamp(_topLeft.x(), 0.0, _scene->width() - visibleWidth));
+    }
+    if (_scene->height() <= visibleHeight) {
+        _topLeft.setY((_scene->height() - visibleHeight) / 2.0);
+    } else {
+        _topLeft.setY(std::clamp(_topLeft.y(), 0.0, _scene->height() - visibleHeight));
+    }
+}
+
+void WorldMapView::revealArea(int areaIndex) {
+    if (!_scene) {
+        return;
+    }
+    for (const worldmap::AreaMarker& area : _scene->areas()) {
+        if (area.index != areaIndex) {
+            continue;
+        }
+        _fitPending = false; // scrolling to an area is a deliberate view choice
+        _selected = &area;
+        _topLeft = QPointF(area.x + area.width / 2.0 - width() / (2.0 * _zoom),
+            area.y + area.height / 2.0 - height() / (2.0 * _zoom));
+        clampPan();
+        update();
+        Q_EMIT areaSelected(_selected);
+        return;
+    }
+}
+
+void WorldMapView::paintEvent(QPaintEvent* event) {
+    QPainter painter(this);
+    painter.fillRect(rect(), palette().window());
+    if (_image.isNull()) {
+        return;
+    }
+
+    // Nearest-neighbour keeps the 8-bit art crisp when magnified, which is how the game shows it;
+    // smoothing only helps when shrinking below 1:1.
+    painter.setRenderHint(QPainter::SmoothPixmapTransform, _zoom < 1.0);
+
+    const QRectF target(toWidget(QPointF(0, 0)), QSizeF(_image.width() * _zoom, _image.height() * _zoom));
+    painter.drawImage(target, _image);
+
+    if (_labelsVisible && _zoom >= LABEL_MIN_ZOOM) {
+        drawLabels(painter);
+    }
+
+    if (_selected != nullptr) {
+        const QRectF marker(toWidget(QPointF(_selected->x, _selected->y)),
+            QSizeF(_selected->width * _zoom, _selected->height * _zoom));
+        painter.setPen(QPen(QColor(ui::theme::colors::PRIMARY), 2));
+        painter.setBrush(Qt::NoBrush);
+        painter.drawRect(marker.adjusted(-2, -2, 2, 2));
+    }
+
+    Q_UNUSED(event);
+}
+
+void WorldMapView::drawLabels(QPainter& painter) const {
+    const QColor green(QRgb(0xFF000000 | _scene->labelColor()));
+
+    QFont font = painter.font();
+    font.setPointSize(LABEL_POINT_SIZE);
+    painter.setFont(font);
+    const QFontMetrics metrics(font);
+
+    const QRectF visible = rect();
+    for (const worldmap::AreaMarker& area : _scene->areas()) {
+        const QString label = QString::fromStdString(area.label());
+        if (label.isEmpty()) {
+            continue;
+        }
+        // Centred under the circle, as the engine places it.
+        const QPointF anchor = toWidget(QPointF(area.x + area.width / 2.0, area.y + area.height + LABEL_GAP));
+        const int textWidth = metrics.horizontalAdvance(label);
+        const QRectF box(anchor.x() - textWidth / 2.0, anchor.y(), textWidth, metrics.height());
+        if (!visible.intersects(box)) {
+            continue;
+        }
+
+        // The engine draws the name shadowed so it stays legible over bright terrain.
+        painter.setPen(Qt::black);
+        painter.drawText(box.translated(1, 1), Qt::AlignCenter, label);
+        painter.setPen(green);
+        painter.drawText(box, Qt::AlignCenter, label);
+    }
+}
+
+void WorldMapView::resizeEvent(QResizeEvent* event) {
+    QWidget::resizeEvent(event);
+    if (_fitPending) {
+        fitIfPending();
+        return; // zoomToFit() clamps already
+    }
+    clampPan();
+}
+
+void WorldMapView::showEvent(QShowEvent* event) {
+    QWidget::showEvent(event);
+    fitIfPending();
+}
+
+void WorldMapView::mousePressEvent(QMouseEvent* event) {
+    if (event->button() == Qt::LeftButton && _scene) {
+        _panning = true;
+        _dragged = false;
+        _panAnchor = event->pos();
+        _panOrigin = _topLeft;
+        setCursor(Qt::ClosedHandCursor);
+    }
+    QWidget::mousePressEvent(event);
+}
+
+void WorldMapView::mouseMoveEvent(QMouseEvent* event) {
+    if (!_scene) {
+        return;
+    }
+
+    if (_panning) {
+        const QPointF delta = event->position() - QPointF(_panAnchor);
+        if (delta.manhattanLength() > 2) {
+            _dragged = true;
+            _fitPending = false; // the user chose where to look
+        }
+        _topLeft = _panOrigin - delta / _zoom;
+        clampPan();
+        update();
+        return;
+    }
+
+    const QPointF world = toWorld(event->position());
+    const int worldX = static_cast<int>(std::floor(world.x()));
+    const int worldY = static_cast<int>(std::floor(world.y()));
+    const worldmap::AreaMarker* area = _scene->areaAt(worldX, worldY);
+    if (area != _hovered) {
+        _hovered = area;
+        setCursor(area != nullptr ? Qt::PointingHandCursor : Qt::OpenHandCursor);
+    }
+    Q_EMIT hovered(worldX, worldY, area);
+}
+
+void WorldMapView::mouseReleaseEvent(QMouseEvent* event) {
+    if (event->button() == Qt::LeftButton && _panning) {
+        _panning = false;
+        setCursor(_hovered != nullptr ? Qt::PointingHandCursor : Qt::OpenHandCursor);
+
+        // A drag pans; only a click selects.
+        if (!_dragged && _scene) {
+            const QPointF world = toWorld(event->position());
+            _selected = _scene->areaAt(static_cast<int>(std::floor(world.x())),
+                static_cast<int>(std::floor(world.y())));
+            update();
+            Q_EMIT areaSelected(_selected);
+        }
+    }
+    QWidget::mouseReleaseEvent(event);
+}
+
+void WorldMapView::mouseDoubleClickEvent(QMouseEvent* event) {
+    if (event->button() == Qt::LeftButton && _scene) {
+        const QPointF world = toWorld(event->position());
+        const worldmap::AreaMarker* area = _scene->areaAt(static_cast<int>(std::floor(world.x())),
+            static_cast<int>(std::floor(world.y())));
+        if (area != nullptr) {
+            _selected = area;
+            update();
+            Q_EMIT areaActivated(area);
+        }
+    }
+    QWidget::mouseDoubleClickEvent(event);
+}
+
+void WorldMapView::wheelEvent(QWheelEvent* event) {
+    if (!_scene) {
+        return;
+    }
+    const int steps = event->angleDelta().y();
+    if (steps == 0) {
+        return;
+    }
+    setZoom(_zoom * std::pow(WHEEL_STEP, steps / 120.0), event->position());
+    event->accept();
+}
+
+void WorldMapView::leaveEvent(QEvent* event) {
+    _hovered = nullptr;
+    QWidget::leaveEvent(event);
+}
+
+bool WorldMapView::event(QEvent* event) {
+    if (event->type() == QEvent::ToolTip && _scene != nullptr) {
+        auto* help = static_cast<QHelpEvent*>(event);
+        const QPointF world = toWorld(QPointF(help->pos()));
+        const worldmap::AreaMarker* area = _scene->areaAt(static_cast<int>(std::floor(world.x())),
+            static_cast<int>(std::floor(world.y())));
+        if (area != nullptr) {
+            QToolTip::showText(help->globalPos(), tooltipFor(*area), this);
+        } else {
+            QToolTip::hideText();
+        }
+        return true;
+    }
+    return QWidget::event(event);
+}
+
+QString WorldMapView::tooltipFor(const worldmap::AreaMarker& area) const {
+    QString text = QStringLiteral("<b>%1</b>").arg(QString::fromStdString(area.label()));
+    if (area.label() != area.name) {
+        text += QStringLiteral(" <i>(%1)</i>").arg(QString::fromStdString(area.name));
+    }
+    text += QStringLiteral("<br>Area %1 &middot; %2")
+                .arg(area.index)
+                .arg(QString::fromLatin1(cityAreaSizeName(area.size)));
+    if (!area.terrain.empty()) {
+        text += QStringLiteral(" &middot; %1").arg(QString::fromStdString(area.terrain));
+    }
+    text += QStringLiteral("<br>%1").arg(area.knownAtStart ? QStringLiteral("Known at start")
+                                                           : QStringLiteral("Discovered through play"));
+    if (!area.mapFiles.empty()) {
+        QStringList maps;
+        for (const std::string& mapFile : area.mapFiles) {
+            maps << QString::fromStdString(mapFile);
+        }
+        text += QStringLiteral("<br>%1").arg(maps.join(QStringLiteral(", ")));
+    }
+    return text;
+}
+
+} // namespace geck

--- a/src/ui/worldmap/WorldMapView.cpp
+++ b/src/ui/worldmap/WorldMapView.cpp
@@ -6,6 +6,7 @@
 #include <QHelpEvent>
 #include <QMouseEvent>
 #include <QPainter>
+#include <QRadialGradient>
 #include <QToolTip>
 #include <QWheelEvent>
 
@@ -26,10 +27,26 @@ namespace {
 
     // The engine puts the city name three pixels under its circle (wmInterfaceDrawCircleOverlay).
     constexpr int LABEL_GAP = 3;
-    constexpr int LABEL_POINT_SIZE = 9;
 
-    // Below this the labels crowd into each other and stop being readable, so they are dropped.
-    constexpr double LABEL_MIN_ZOOM = 0.5;
+    // Labels grow with the map so they stay anchored to it, but within a readable range: the base
+    // size is what the engine's own font comes to at 1:1.
+    constexpr double LABEL_BASE_POINT_SIZE = 9.0;
+    constexpr int LABEL_MIN_POINT_SIZE = 8;
+    constexpr int LABEL_MAX_POINT_SIZE = 20;
+
+    // Zoomed this far out a label is smaller than the circle it belongs to; overlap culling takes
+    // care of the rest.
+    constexpr double LABEL_MIN_ZOOM = 0.25;
+
+    // Gap a label must keep from its neighbours before it is dropped, in widget pixels.
+    constexpr double LABEL_CLEARANCE = 6.0;
+
+    // Past this magnification the 12/25/49-pixel marker sprites are visibly blocky, so the circles
+    // are drawn as geometry instead. That stays true to the engine: its blend table row j mixes
+    // `(tint*j + dest*(7-j)) / 7`, a linear interpolation with weight j/7, and WorldMapScene hands
+    // that weight out as a radial profile — so the only thing left behind is palette quantisation.
+    // Below the threshold the exact blended bitmap is used, which is what fidelity at 1:1 needs.
+    constexpr double VECTOR_MARKER_ZOOM = 1.5;
 
 } // namespace
 
@@ -73,15 +90,30 @@ void WorldMapView::fitIfPending() {
 }
 
 void WorldMapView::setMarkersVisible(bool visible) {
-    if (!_scene || _scene->markersVisible() == visible) {
+    if (_markersVisible == visible) {
         return;
     }
-    _scene->setMarkersVisible(visible);
+    _markersVisible = visible;
+    syncSceneMarkers();
+    update();
+}
+
+bool WorldMapView::usingVectorMarkers() const {
+    return _markersVisible && _zoom >= VECTOR_MARKER_ZOOM;
+}
+
+void WorldMapView::syncSceneMarkers() {
+    // The scene bakes the circles into its bitmap; leave them out whenever the painter is drawing
+    // them as geometry, or the two would stack.
+    const bool wantBitmapMarkers = _markersVisible && !usingVectorMarkers();
+    if (!_scene || _scene->markersVisible() == wantBitmapMarkers) {
+        return;
+    }
+    _scene->setMarkersVisible(wantBitmapMarkers);
     // The recompose rewrote the buffer in place; the QImage still points at it, but tell Qt the
     // pixels changed by rebuilding the wrapper (QImage caches nothing else here).
     _image = QImage(_scene->pixels().data(), _scene->width(), _scene->height(),
         _scene->width() * 4, QImage::Format_RGBA8888);
-    update();
 }
 
 void WorldMapView::setLabelsVisible(bool visible) {
@@ -112,6 +144,7 @@ void WorldMapView::zoomToFit() {
     _zoom = std::clamp(fit, MIN_ZOOM, MAX_FIT_ZOOM);
     _topLeft = QPointF(0, 0);
     clampPan();
+    syncSceneMarkers();
     update();
 }
 
@@ -134,6 +167,7 @@ void WorldMapView::setZoom(double zoom, const QPointF& anchorWidgetPos) {
     _zoom = clamped;
     _topLeft = anchorWorld - anchorWidgetPos / _zoom;
     clampPan();
+    syncSceneMarkers();
     update();
 }
 
@@ -183,12 +217,16 @@ void WorldMapView::paintEvent(QPaintEvent*) {
         return;
     }
 
-    // Nearest-neighbour keeps the 8-bit art crisp when magnified, which is how the game shows it;
-    // smoothing only helps when shrinking below 1:1.
-    painter.setRenderHint(QPainter::SmoothPixmapTransform, _zoom < 1.0);
+    // The tile art is a rendered relief map, not pixel art, and 1400x1500 is all of it there is —
+    // so interpolate rather than blocking it up, in both directions.
+    painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
 
     const QRectF target(toWidget(QPointF(0, 0)), QSizeF(_image.width() * _zoom, _image.height() * _zoom));
     painter.drawImage(target, _image);
+
+    if (usingVectorMarkers()) {
+        drawVectorMarkers(painter);
+    }
 
     if (_labelsVisible && _zoom >= LABEL_MIN_ZOOM) {
         drawLabels(painter);
@@ -203,33 +241,110 @@ void WorldMapView::paintEvent(QPaintEvent*) {
     }
 }
 
+void WorldMapView::drawVectorMarkers(QPainter& painter) const {
+    const QColor tint(QRgb(0xFF000000 | _scene->labelColor()));
+    const QRectF visible = rect();
+
+    const QPainter::RenderHints hints = painter.renderHints();
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    painter.setPen(Qt::NoPen);
+
+    for (const worldmap::AreaMarker& area : _scene->areas()) {
+        const std::vector<float>& profile = _scene->markerProfile(area.size);
+        if (profile.empty() || area.width <= 0) {
+            continue;
+        }
+
+        const QPointF centre = toWidget(QPointF(area.x + area.width / 2.0, area.y + area.height / 2.0));
+        const double radius = area.width / 2.0 * _zoom;
+        const QRectF box(centre.x() - radius, centre.y() - radius, radius * 2, radius * 2);
+        if (!visible.intersects(box)) {
+            continue;
+        }
+
+        // The profile is the tint weight from the middle outwards, so it maps straight onto a
+        // radial gradient's stops — the bright rim and the softer interior come out of the sprite's
+        // own numbers rather than being invented here.
+        QRadialGradient gradient(centre, radius);
+        for (std::size_t i = 0; i < profile.size(); ++i) {
+            QColor stop = tint;
+            stop.setAlphaF(std::clamp(profile[i], 0.0F, 1.0F));
+            gradient.setColorAt(static_cast<double>(i) / (profile.size() - 1), stop);
+        }
+        painter.setBrush(gradient);
+        painter.drawEllipse(box);
+    }
+
+    painter.setRenderHints(hints);
+}
+
 void WorldMapView::drawLabels(QPainter& painter) const {
     const QColor green(QRgb(0xFF000000 | _scene->labelColor()));
 
     QFont font = painter.font();
-    font.setPointSize(LABEL_POINT_SIZE);
+    font.setPointSize(std::clamp(static_cast<int>(std::lround(LABEL_BASE_POINT_SIZE * _zoom)),
+        LABEL_MIN_POINT_SIZE, LABEL_MAX_POINT_SIZE));
     painter.setFont(font);
     const QFontMetrics metrics(font);
 
-    const QRectF visible = rect();
+    // Several areas share almost the same spot (the special encounters near the coast especially),
+    // so drawing every label turns them into a smear. Lay them out biggest-circle-first and drop
+    // any that would land on one already placed: the important places keep their names, and what
+    // is dropped comes back as you zoom in and the boxes stop touching.
+    struct Placed {
+        QRectF box;
+        QString text;
+    };
+    std::vector<const worldmap::AreaMarker*> order;
+    order.reserve(_scene->areas().size());
     for (const worldmap::AreaMarker& area : _scene->areas()) {
-        const QString label = QString::fromStdString(area.label());
+        order.push_back(&area);
+    }
+    std::stable_sort(order.begin(), order.end(),
+        [this](const worldmap::AreaMarker* a, const worldmap::AreaMarker* b) {
+            // The one the user is pointing at or has picked always keeps its name.
+            const int priorityA = (a == _selected || a == _hovered) ? 1 : 0;
+            const int priorityB = (b == _selected || b == _hovered) ? 1 : 0;
+            if (priorityA != priorityB) {
+                return priorityA > priorityB;
+            }
+            return a->width > b->width;
+        });
+
+    const QRectF visible = rect();
+    std::vector<Placed> placed;
+    placed.reserve(order.size());
+
+    for (const worldmap::AreaMarker* area : order) {
+        const QString label = QString::fromStdString(area->label());
         if (label.isEmpty()) {
             continue;
         }
         // Centred under the circle, as the engine places it.
-        const QPointF anchor = toWidget(QPointF(area.x + area.width / 2.0, area.y + area.height + LABEL_GAP));
+        const QPointF anchor = toWidget(QPointF(area->x + area->width / 2.0, area->y + area->height + LABEL_GAP));
         const int textWidth = metrics.horizontalAdvance(label);
         const QRectF box(anchor.x() - textWidth / 2.0, anchor.y(), textWidth, metrics.height());
         if (!visible.intersects(box)) {
             continue;
         }
 
-        // The engine draws the name shadowed so it stays legible over bright terrain.
+        // Test with a margin, so names that merely touch are culled too: side by side they read as
+        // one run-on string ("Den Den Slave Run Desert") even though the boxes never overlap.
+        const QRectF spaced = box.adjusted(-LABEL_CLEARANCE, -LABEL_CLEARANCE, LABEL_CLEARANCE, LABEL_CLEARANCE);
+        const bool collides = std::any_of(placed.begin(), placed.end(),
+            [&spaced](const Placed& other) { return other.box.intersects(spaced); });
+        if (collides) {
+            continue;
+        }
+        placed.push_back({ box, label });
+    }
+
+    // The engine draws the name shadowed so it stays legible over bright terrain.
+    for (const Placed& entry : placed) {
         painter.setPen(Qt::black);
-        painter.drawText(box.translated(1, 1), Qt::AlignCenter, label);
+        painter.drawText(entry.box.translated(1, 1), Qt::AlignCenter, entry.text);
         painter.setPen(green);
-        painter.drawText(box, Qt::AlignCenter, label);
+        painter.drawText(entry.box, Qt::AlignCenter, entry.text);
     }
 }
 

--- a/src/ui/worldmap/WorldMapView.cpp
+++ b/src/ui/worldmap/WorldMapView.cpp
@@ -176,7 +176,7 @@ void WorldMapView::revealArea(int areaIndex) {
     }
 }
 
-void WorldMapView::paintEvent(QPaintEvent* event) {
+void WorldMapView::paintEvent(QPaintEvent*) {
     QPainter painter(this);
     painter.fillRect(rect(), palette().window());
     if (_image.isNull()) {
@@ -201,8 +201,6 @@ void WorldMapView::paintEvent(QPaintEvent* event) {
         painter.setBrush(Qt::NoBrush);
         painter.drawRect(marker.adjusted(-2, -2, 2, 2));
     }
-
-    Q_UNUSED(event);
 }
 
 void WorldMapView::drawLabels(QPainter& painter) const {
@@ -278,8 +276,8 @@ void WorldMapView::mouseMoveEvent(QMouseEvent* event) {
     }
 
     const QPointF world = toWorld(event->position());
-    const int worldX = static_cast<int>(std::floor(world.x()));
-    const int worldY = static_cast<int>(std::floor(world.y()));
+    const auto worldX = static_cast<int>(std::floor(world.x()));
+    const auto worldY = static_cast<int>(std::floor(world.y()));
     const worldmap::AreaMarker* area = _scene->areaAt(worldX, worldY);
     if (area != _hovered) {
         _hovered = area;
@@ -338,11 +336,11 @@ void WorldMapView::leaveEvent(QEvent* event) {
 
 bool WorldMapView::event(QEvent* event) {
     if (event->type() == QEvent::ToolTip && _scene != nullptr) {
-        auto* help = static_cast<QHelpEvent*>(event);
+        const auto* help = static_cast<const QHelpEvent*>(event);
         const QPointF world = toWorld(QPointF(help->pos()));
-        const worldmap::AreaMarker* area = _scene->areaAt(static_cast<int>(std::floor(world.x())),
-            static_cast<int>(std::floor(world.y())));
-        if (area != nullptr) {
+        if (const worldmap::AreaMarker* area = _scene->areaAt(static_cast<int>(std::floor(world.x())),
+                static_cast<int>(std::floor(world.y())));
+            area != nullptr) {
             QToolTip::showText(help->globalPos(), tooltipFor(*area), this);
         } else {
             QToolTip::hideText();
@@ -353,22 +351,26 @@ bool WorldMapView::event(QEvent* event) {
 }
 
 QString WorldMapView::tooltipFor(const worldmap::AreaMarker& area) const {
-    QString text = QStringLiteral("<b>%1</b>").arg(QString::fromStdString(area.label()));
+    // The tooltip is rich text and every string in it comes out of game data files, so escape them
+    // rather than trust that no name ever contains '<' or '&'.
+    const auto escaped = [](const std::string& value) { return QString::fromStdString(value).toHtmlEscaped(); };
+
+    QString text = QStringLiteral("<b>%1</b>").arg(escaped(area.label()));
     if (area.label() != area.name) {
-        text += QStringLiteral(" <i>(%1)</i>").arg(QString::fromStdString(area.name));
+        text += QStringLiteral(" <i>(%1)</i>").arg(escaped(area.name));
     }
     text += QStringLiteral("<br>Area %1 &middot; %2")
                 .arg(area.index)
                 .arg(QString::fromLatin1(cityAreaSizeName(area.size)));
     if (!area.terrain.empty()) {
-        text += QStringLiteral(" &middot; %1").arg(QString::fromStdString(area.terrain));
+        text += QStringLiteral(" &middot; %1").arg(escaped(area.terrain));
     }
     text += QStringLiteral("<br>%1").arg(area.knownAtStart ? QStringLiteral("Known at start")
                                                            : QStringLiteral("Discovered through play"));
     if (!area.mapFiles.empty()) {
         QStringList maps;
         for (const std::string& mapFile : area.mapFiles) {
-            maps << QString::fromStdString(mapFile);
+            maps << escaped(mapFile);
         }
         text += QStringLiteral("<br>%1").arg(maps.join(QStringLiteral(", ")));
     }

--- a/src/ui/worldmap/WorldMapView.h
+++ b/src/ui/worldmap/WorldMapView.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <QImage>
+#include <QPoint>
+#include <QPointF>
+#include <QWidget>
+
+#include <memory>
+
+namespace geck::worldmap {
+class WorldMapScene;
+struct AreaMarker;
+}
+
+namespace geck {
+
+/// The worldmap canvas: draws the scene's image, pans, zooms, and reports what the pointer is over.
+///
+/// The image itself is produced by WorldMapScene in the engine's own palette maths, so this widget
+/// only scales and blits it. The one thing it draws itself is the area labels — the engine renders
+/// those with its bitmap font, which does not survive being scaled, so they are Qt text in the
+/// engine's green instead.
+class WorldMapView : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit WorldMapView(QWidget* parent = nullptr);
+    ~WorldMapView() override;
+
+    /// Takes over the scene to display; pass nullptr to clear. Resets the view to fit.
+    void setScene(std::shared_ptr<worldmap::WorldMapScene> scene);
+    [[nodiscard]] const worldmap::WorldMapScene* scene() const { return _scene.get(); }
+
+    void setMarkersVisible(bool visible);
+    void setLabelsVisible(bool visible);
+    [[nodiscard]] bool labelsVisible() const { return _labelsVisible; }
+
+    /// Scales the whole worldmap to fit the widget, and re-centres.
+    void zoomToFit();
+    /// Back to one screen pixel per worldmap pixel, centred on the view's middle.
+    void zoomToActualSize();
+
+    /// The area the user last clicked, or nullptr.
+    [[nodiscard]] const worldmap::AreaMarker* selectedArea() const { return _selected; }
+    /// Scrolls an area into the middle of the view and selects it.
+    void revealArea(int areaIndex);
+
+Q_SIGNALS:
+    /// The user clicked an area (or empty terrain, in which case the pointer is null).
+    void areaSelected(const geck::worldmap::AreaMarker* area);
+    /// The user double-clicked an area — the editor opens its first map.
+    void areaActivated(const geck::worldmap::AreaMarker* area);
+    /// The pointer moved to a new worldmap pixel, over @p area (may be null). For a status bar.
+    void hovered(int worldX, int worldY, const geck::worldmap::AreaMarker* area);
+
+protected:
+    void paintEvent(QPaintEvent* event) override;
+    void resizeEvent(QResizeEvent* event) override;
+    void showEvent(QShowEvent* event) override;
+    void mousePressEvent(QMouseEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
+    void mouseReleaseEvent(QMouseEvent* event) override;
+    void mouseDoubleClickEvent(QMouseEvent* event) override;
+    void wheelEvent(QWheelEvent* event) override;
+    void leaveEvent(QEvent* event) override;
+    bool event(QEvent* event) override; // tooltips
+
+private:
+    /// Widget coordinates -> worldmap pixel, and back.
+    [[nodiscard]] QPointF toWorld(const QPointF& widgetPos) const;
+    [[nodiscard]] QPointF toWidget(const QPointF& worldPos) const;
+
+    void drawLabels(QPainter& painter) const;
+    void setZoom(double zoom, const QPointF& anchorWidgetPos);
+    void clampPan();
+    /// Runs the pending fit once the widget has a real size to fit to.
+    void fitIfPending();
+    [[nodiscard]] QString tooltipFor(const worldmap::AreaMarker& area) const;
+
+    std::shared_ptr<worldmap::WorldMapScene> _scene;
+    QImage _image; ///< a view onto the scene's pixels, not a copy
+
+    double _zoom = 1.0;
+    QPointF _topLeft; ///< the worldmap pixel drawn at the widget's top-left corner
+    /// A scene can arrive before the widget has been laid out, when width()/height() are still
+    /// meaningless; the fit then waits for the first real size.
+    bool _fitPending = false;
+
+    bool _panning = false;
+    QPoint _panAnchor;
+    QPointF _panOrigin;
+    bool _dragged = false;
+
+    const worldmap::AreaMarker* _selected = nullptr;
+    const worldmap::AreaMarker* _hovered = nullptr;
+    bool _labelsVisible = true;
+};
+
+} // namespace geck

--- a/src/ui/worldmap/WorldMapView.h
+++ b/src/ui/worldmap/WorldMapView.h
@@ -75,7 +75,8 @@ private:
     /// VECTOR_MARKER_ZOOM in the .cpp for why and when.
     void drawVectorMarkers(QPainter& painter) const;
     /// True while the circles are being drawn as geometry, so the scene must leave them out of the
-    /// bitmap. Keeps the scene and the painter from both drawing them.
+    /// bitmap. Keeps the scene and the painter from both drawing them. Decided by syncSceneMarkers()
+    /// rather than recomputed here, because the zoom threshold has hysteresis.
     [[nodiscard]] bool usingVectorMarkers() const;
     /// Pushes usingVectorMarkers() through to the scene after anything that changes the zoom.
     void syncSceneMarkers();
@@ -105,6 +106,9 @@ private:
     /// What the user asked for. Whether the circles then come from the scene's bitmap or are
     /// painted as geometry is a matter of zoom — see usingVectorMarkers().
     bool _markersVisible = true;
+    /// Which of the two the view is currently on. Kept rather than derived so the zoom threshold
+    /// can have hysteresis; maintained by syncSceneMarkers().
+    bool _vectorMarkers = false;
 };
 
 } // namespace geck

--- a/src/ui/worldmap/WorldMapView.h
+++ b/src/ui/worldmap/WorldMapView.h
@@ -71,6 +71,14 @@ private:
     [[nodiscard]] QPointF toWidget(const QPointF& worldPos) const;
 
     void drawLabels(QPainter& painter) const;
+    /// Draws the area circles as geometry rather than magnified sprite pixels. See
+    /// VECTOR_MARKER_ZOOM in the .cpp for why and when.
+    void drawVectorMarkers(QPainter& painter) const;
+    /// True while the circles are being drawn as geometry, so the scene must leave them out of the
+    /// bitmap. Keeps the scene and the painter from both drawing them.
+    [[nodiscard]] bool usingVectorMarkers() const;
+    /// Pushes usingVectorMarkers() through to the scene after anything that changes the zoom.
+    void syncSceneMarkers();
     void setZoom(double zoom, const QPointF& anchorWidgetPos);
     void clampPan();
     /// Runs the pending fit once the widget has a real size to fit to.
@@ -94,6 +102,9 @@ private:
     const worldmap::AreaMarker* _selected = nullptr;
     const worldmap::AreaMarker* _hovered = nullptr;
     bool _labelsVisible = true;
+    /// What the user asked for. Whether the circles then come from the scene's bitmap or are
+    /// painted as geometry is a matter of zoom — see usingVectorMarkers().
+    bool _markersVisible = true;
 };
 
 } // namespace geck

--- a/src/ui/worldmap/WorldMapWidget.cpp
+++ b/src/ui/worldmap/WorldMapWidget.cpp
@@ -111,7 +111,7 @@ void WorldMapWidget::setupUi() {
 
     _areaList = new QListWidget(side);
     _areaList->setMinimumWidth(AREA_LIST_WIDTH);
-    connect(_areaList, &QListWidget::currentItemChanged, this, [this](QListWidgetItem* item, QListWidgetItem*) {
+    connect(_areaList, &QListWidget::currentItemChanged, this, [this](const QListWidgetItem* item, QListWidgetItem*) {
         if (item != nullptr) {
             _view->revealArea(item->data(AREA_INDEX_ROLE).toInt());
         }

--- a/src/ui/worldmap/WorldMapWidget.cpp
+++ b/src/ui/worldmap/WorldMapWidget.cpp
@@ -11,6 +11,7 @@
 #include <QListWidget>
 #include <QSplitter>
 #include <QStackedWidget>
+#include <QStringList>
 #include <QToolButton>
 #include <QVBoxLayout>
 
@@ -72,26 +73,41 @@ void WorldMapWidget::setupUi() {
     connect(actual, &QToolButton::clicked, this, [this] { _view->zoomToActualSize(); });
     toolbar->addWidget(actual);
 
+    // Missing art is the scene's own diagnosis; without it on screen the user just sees black
+    // tiles, or markers that cannot be clicked, with nothing to explain why.
+    _warning = new QLabel(this);
+    _warning->setStyleSheet(ui::theme::styles::statusWarning());
+    _warning->setVisible(false);
+    toolbar->addWidget(_warning);
+
     toolbar->addStretch();
+
+    // Two labels, not one: the summary is about the map and the readout about the pointer, and a
+    // single label meant the area count vanished on the first mouse move.
+    _summary = new QLabel(this);
+    _summary->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    toolbar->addWidget(_summary);
 
     _status = new QLabel(this);
     _status->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    _status->setMinimumWidth(AREA_LIST_WIDTH);
+    _status->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
     toolbar->addWidget(_status);
     layout->addLayout(toolbar);
 
     auto* splitter = new QSplitter(Qt::Horizontal, this);
 
     // Left: the map (or, when there is no worldmap data, an explanation in its place).
-    auto* canvasStack = new QStackedWidget(splitter);
-    _view = new WorldMapView(canvasStack);
-    canvasStack->addWidget(_view);
+    _canvasStack = new QStackedWidget(splitter);
+    _view = new WorldMapView(_canvasStack);
+    _canvasStack->addWidget(_view);
 
-    _placeholder = new QLabel(canvasStack);
+    _placeholder = new QLabel(_canvasStack);
     _placeholder->setAlignment(Qt::AlignCenter);
     _placeholder->setWordWrap(true);
     _placeholder->setStyleSheet(ui::theme::styles::statusError());
-    canvasStack->addWidget(_placeholder);
-    splitter->addWidget(canvasStack);
+    _canvasStack->addWidget(_placeholder);
+    splitter->addWidget(_canvasStack);
 
     connect(_view, &WorldMapView::areaSelected, this, &WorldMapWidget::onAreaSelected);
     connect(_view, &WorldMapView::areaActivated, this, &WorldMapWidget::onAreaActivated);
@@ -136,41 +152,50 @@ void WorldMapWidget::setupUi() {
     layout->addWidget(splitter, 1);
 
     // The stack starts on the placeholder until a load succeeds.
-    canvasStack->setCurrentWidget(_placeholder);
+    _canvasStack->setCurrentWidget(_placeholder);
     _placeholder->setText(tr("No world map loaded."));
 }
 
 bool WorldMapWidget::reload() {
-    auto* canvasStack = qobject_cast<QStackedWidget*>(_view->parentWidget());
-
     _scene = worldmap::WorldMapScene::load(_resources);
     _view->setScene(_scene);
     _selectedMapFile.clear();
     _openMapButton->setEnabled(false);
+    _status->clear();
+    _warning->setVisible(false);
 
     if (!_scene) {
         _placeholder->setText(tr("The world map needs city.txt, worldmap.txt and color.pal from the "
                                  "game data. Add a Fallout 2 data folder or master.dat in "
                                  "Preferences, then try again."));
-        if (canvasStack != nullptr) {
-            canvasStack->setCurrentWidget(_placeholder);
-        }
+        _canvasStack->setCurrentWidget(_placeholder);
         _areaList->clear();
-        _status->clear();
+        _summary->clear();
         return false;
     }
 
-    if (canvasStack != nullptr) {
-        canvasStack->setCurrentWidget(_view);
-    }
+    _canvasStack->setCurrentWidget(_view);
     refreshAreaList();
-
-    if (!_scene->missingArt().empty()) {
-        spdlog::warn("World map: {} tile(s) drew black because their art is missing",
-            _scene->missingArt().size());
-    }
-    _status->setText(tr("%1 areas").arg(_scene->areas().size()));
+    showMissingArt();
+    _summary->setText(tr("%1 areas").arg(_scene->areas().size()));
     return true;
+}
+
+void WorldMapWidget::showMissingArt() {
+    const std::vector<std::string>& missing = _scene->missingArt();
+    if (missing.empty()) {
+        return;
+    }
+
+    spdlog::warn("World map: {} piece(s) of art are missing", missing.size());
+
+    QStringList details;
+    for (const std::string& entry : missing) {
+        details << QString::fromStdString(entry);
+    }
+    _warning->setText(tr("%n art file(s) missing", "", static_cast<int>(missing.size())));
+    _warning->setToolTip(details.join(QLatin1Char('\n')));
+    _warning->setVisible(true);
 }
 
 void WorldMapWidget::refreshAreaList() {

--- a/src/ui/worldmap/WorldMapWidget.cpp
+++ b/src/ui/worldmap/WorldMapWidget.cpp
@@ -1,0 +1,248 @@
+#include "ui/worldmap/WorldMapWidget.h"
+
+#include "editor/worldmap/WorldMapScene.h"
+#include "ui/theme/ThemeManager.h"
+#include "ui/worldmap/WorldMapView.h"
+
+#include <QCheckBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QSplitter>
+#include <QStackedWidget>
+#include <QToolButton>
+#include <QVBoxLayout>
+
+#include <spdlog/spdlog.h>
+
+namespace geck {
+
+namespace {
+
+    // Wide enough for the longest shipped area name plus its "known at start" marker.
+    constexpr int AREA_LIST_WIDTH = 220;
+
+    constexpr int AREA_INDEX_ROLE = Qt::UserRole;
+
+} // namespace
+
+WorldMapWidget::WorldMapWidget(resource::GameResources& resources, QWidget* parent)
+    : QWidget(parent)
+    , _resources(resources) {
+    setupUi();
+}
+
+WorldMapWidget::~WorldMapWidget() = default;
+
+bool WorldMapWidget::hasScene() const {
+    return _scene != nullptr;
+}
+
+void WorldMapWidget::setupUi() {
+    auto* layout = new QVBoxLayout(this);
+    layout->setContentsMargins(ui::theme::spacing::MARGIN_NORMAL, ui::theme::spacing::MARGIN_NORMAL,
+        ui::theme::spacing::MARGIN_NORMAL, ui::theme::spacing::MARGIN_NORMAL);
+    layout->setSpacing(ui::theme::spacing::NORMAL);
+
+    auto* toolbar = new QHBoxLayout();
+    toolbar->setSpacing(ui::theme::spacing::NORMAL);
+
+    auto* markers = new QCheckBox(tr("Markers"), this);
+    markers->setChecked(true);
+    markers->setToolTip(tr("Draw the area circles the game blends over the map"));
+    connect(markers, &QCheckBox::toggled, this, [this](bool on) { _view->setMarkersVisible(on); });
+    toolbar->addWidget(markers);
+
+    auto* labels = new QCheckBox(tr("Labels"), this);
+    labels->setChecked(true);
+    labels->setToolTip(tr("Draw the area names under their circles"));
+    connect(labels, &QCheckBox::toggled, this, [this](bool on) { _view->setLabelsVisible(on); });
+    toolbar->addWidget(labels);
+
+    auto* fit = new QToolButton(this);
+    fit->setText(tr("Fit"));
+    fit->setToolTip(tr("Scale the whole world map to the window"));
+    connect(fit, &QToolButton::clicked, this, [this] { _view->zoomToFit(); });
+    toolbar->addWidget(fit);
+
+    auto* actual = new QToolButton(this);
+    actual->setText(tr("1:1"));
+    actual->setToolTip(tr("Show the map at its native size, as the game draws it"));
+    connect(actual, &QToolButton::clicked, this, [this] { _view->zoomToActualSize(); });
+    toolbar->addWidget(actual);
+
+    toolbar->addStretch();
+
+    _status = new QLabel(this);
+    _status->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    toolbar->addWidget(_status);
+    layout->addLayout(toolbar);
+
+    auto* splitter = new QSplitter(Qt::Horizontal, this);
+
+    // Left: the map (or, when there is no worldmap data, an explanation in its place).
+    auto* canvasStack = new QStackedWidget(splitter);
+    _view = new WorldMapView(canvasStack);
+    canvasStack->addWidget(_view);
+
+    _placeholder = new QLabel(canvasStack);
+    _placeholder->setAlignment(Qt::AlignCenter);
+    _placeholder->setWordWrap(true);
+    _placeholder->setStyleSheet(ui::theme::styles::statusError());
+    canvasStack->addWidget(_placeholder);
+    splitter->addWidget(canvasStack);
+
+    connect(_view, &WorldMapView::areaSelected, this, &WorldMapWidget::onAreaSelected);
+    connect(_view, &WorldMapView::areaActivated, this, &WorldMapWidget::onAreaActivated);
+    connect(_view, &WorldMapView::hovered, this, &WorldMapWidget::onHovered);
+
+    // Right: the area list, filtered.
+    auto* side = new QWidget(splitter);
+    auto* sideLayout = new QVBoxLayout(side);
+    sideLayout->setContentsMargins(0, 0, 0, 0);
+    sideLayout->setSpacing(ui::theme::spacing::TIGHT);
+
+    _filter = new QLineEdit(side);
+    _filter->setPlaceholderText(tr("Filter areas..."));
+    _filter->setClearButtonEnabled(true);
+    connect(_filter, &QLineEdit::textChanged, this, &WorldMapWidget::onFilterChanged);
+    sideLayout->addWidget(_filter);
+
+    _areaList = new QListWidget(side);
+    _areaList->setMinimumWidth(AREA_LIST_WIDTH);
+    connect(_areaList, &QListWidget::currentItemChanged, this, [this](QListWidgetItem* item, QListWidgetItem*) {
+        if (item != nullptr) {
+            _view->revealArea(item->data(AREA_INDEX_ROLE).toInt());
+        }
+    });
+    sideLayout->addWidget(_areaList, 1);
+
+    _openMapButton = new QToolButton(side);
+    _openMapButton->setText(tr("Open Map"));
+    _openMapButton->setToolButtonStyle(Qt::ToolButtonTextOnly);
+    _openMapButton->setEnabled(false);
+    _openMapButton->setToolTip(tr("Open the selected area's first map in the editor"));
+    connect(_openMapButton, &QToolButton::clicked, this, [this] {
+        if (!_selectedMapFile.empty()) {
+            Q_EMIT openMapRequested(QString::fromStdString(_selectedMapFile));
+        }
+    });
+    sideLayout->addWidget(_openMapButton);
+
+    splitter->addWidget(side);
+    splitter->setStretchFactor(0, 1);
+    splitter->setStretchFactor(1, 0);
+    layout->addWidget(splitter, 1);
+
+    // The stack starts on the placeholder until a load succeeds.
+    canvasStack->setCurrentWidget(_placeholder);
+    _placeholder->setText(tr("No world map loaded."));
+}
+
+bool WorldMapWidget::reload() {
+    auto* canvasStack = qobject_cast<QStackedWidget*>(_view->parentWidget());
+
+    _scene = worldmap::WorldMapScene::load(_resources);
+    _view->setScene(_scene);
+    _selectedMapFile.clear();
+    _openMapButton->setEnabled(false);
+
+    if (!_scene) {
+        _placeholder->setText(tr("The world map needs city.txt, worldmap.txt and color.pal from the "
+                                 "game data. Add a Fallout 2 data folder or master.dat in "
+                                 "Preferences, then try again."));
+        if (canvasStack != nullptr) {
+            canvasStack->setCurrentWidget(_placeholder);
+        }
+        _areaList->clear();
+        _status->clear();
+        return false;
+    }
+
+    if (canvasStack != nullptr) {
+        canvasStack->setCurrentWidget(_view);
+    }
+    refreshAreaList();
+
+    if (!_scene->missingArt().empty()) {
+        spdlog::warn("World map: {} tile(s) drew black because their art is missing",
+            _scene->missingArt().size());
+    }
+    _status->setText(tr("%1 areas").arg(_scene->areas().size()));
+    return true;
+}
+
+void WorldMapWidget::refreshAreaList() {
+    // Filling the list must not move the map: QListWidget makes the first inserted row current, and
+    // that would fire currentItemChanged and scroll the view to an area the user never picked.
+    const QSignalBlocker blocker(_areaList);
+
+    _areaList->clear();
+    if (!_scene) {
+        return;
+    }
+
+    const QString filter = _filter->text().trimmed();
+    for (const worldmap::AreaMarker& area : _scene->areas()) {
+        const QString label = QString::fromStdString(area.label());
+        const QString internal = QString::fromStdString(area.name);
+        if (!filter.isEmpty()
+            && !label.contains(filter, Qt::CaseInsensitive)
+            && !internal.contains(filter, Qt::CaseInsensitive)) {
+            continue;
+        }
+
+        auto* item = new QListWidgetItem(label, _areaList);
+        item->setData(AREA_INDEX_ROLE, area.index);
+        item->setToolTip(internal);
+        if (!area.knownAtStart) {
+            // Areas the player has to find are dimmed, so the starting world reads at a glance.
+            item->setForeground(QColor(ui::theme::colors::TEXT_SECONDARY));
+        }
+    }
+}
+
+void WorldMapWidget::onFilterChanged(const QString&) {
+    refreshAreaList();
+}
+
+void WorldMapWidget::onAreaSelected(const worldmap::AreaMarker* area) {
+    _selectedMapFile = area != nullptr && !area->mapFiles.empty() ? area->mapFiles.front() : std::string();
+    _openMapButton->setEnabled(!_selectedMapFile.empty());
+
+    if (area == nullptr) {
+        return;
+    }
+
+    // Mirror the click into the list without bouncing back into the view.
+    const QSignalBlocker blocker(_areaList);
+    for (int row = 0; row < _areaList->count(); ++row) {
+        if (_areaList->item(row)->data(AREA_INDEX_ROLE).toInt() == area->index) {
+            _areaList->setCurrentRow(row);
+            break;
+        }
+    }
+}
+
+void WorldMapWidget::onAreaActivated(const worldmap::AreaMarker* area) {
+    if (area != nullptr && !area->mapFiles.empty()) {
+        Q_EMIT openMapRequested(QString::fromStdString(area->mapFiles.front()));
+    }
+}
+
+void WorldMapWidget::onHovered(int worldX, int worldY, const worldmap::AreaMarker* area) {
+    QString text = QStringLiteral("%1, %2").arg(worldX).arg(worldY);
+    if (_scene) {
+        const std::string terrain = _scene->terrainAt(worldX, worldY);
+        if (!terrain.empty()) {
+            text += QStringLiteral(" · %1").arg(QString::fromStdString(terrain));
+        }
+    }
+    if (area != nullptr) {
+        text += QStringLiteral(" · %1").arg(QString::fromStdString(area->label()));
+    }
+    _status->setText(text);
+}
+
+} // namespace geck

--- a/src/ui/worldmap/WorldMapWidget.h
+++ b/src/ui/worldmap/WorldMapWidget.h
@@ -8,6 +8,7 @@
 class QLabel;
 class QLineEdit;
 class QListWidget;
+class QStackedWidget;
 class QToolButton;
 
 namespace geck::resource {
@@ -49,6 +50,9 @@ Q_SIGNALS:
 private:
     void setupUi();
     void refreshAreaList();
+    /// Puts the scene's missingArt() on screen, so black tiles and unclickable markers have a
+    /// visible cause rather than only a log line.
+    void showMissingArt();
     void onAreaSelected(const worldmap::AreaMarker* area);
     void onAreaActivated(const worldmap::AreaMarker* area);
     void onHovered(int worldX, int worldY, const worldmap::AreaMarker* area);
@@ -56,8 +60,11 @@ private:
 
     resource::GameResources& _resources;
 
+    QStackedWidget* _canvasStack = nullptr; ///< the map, or the placeholder in its place
     WorldMapView* _view = nullptr;
     QLabel* _status = nullptr;      ///< live pointer readout: position, terrain, area
+    QLabel* _summary = nullptr;     ///< what was loaded; not overwritten by the readout
+    QLabel* _warning = nullptr;     ///< missing art, hidden when there is none
     QLabel* _placeholder = nullptr; ///< shown instead of the map when there is no worldmap data
     QLineEdit* _filter = nullptr;
     QListWidget* _areaList = nullptr;

--- a/src/ui/worldmap/WorldMapWidget.h
+++ b/src/ui/worldmap/WorldMapWidget.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <QWidget>
+
+#include <memory>
+#include <string>
+
+class QLabel;
+class QLineEdit;
+class QListWidget;
+class QToolButton;
+
+namespace geck::resource {
+class GameResources;
+}
+
+namespace geck::worldmap {
+class WorldMapScene;
+struct AreaMarker;
+}
+
+namespace geck {
+
+class WorldMapView;
+
+/// The World Map screen: the rendered worldmap next to a searchable list of its areas.
+///
+/// Sits in the main window's central stack alongside the welcome screen and the map editor, because
+/// it is a view of the game's data rather than of any one map — it needs mounted game data but no
+/// open map.
+class WorldMapWidget : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit WorldMapWidget(resource::GameResources& resources, QWidget* parent = nullptr);
+    ~WorldMapWidget() override;
+
+    /// (Re)reads city.txt/worldmap.txt and redraws. Safe to call whenever the data paths change;
+    /// returns false (and shows why, in place of the map) when there is no worldmap to draw.
+    bool reload();
+
+    /// True once a worldmap has been loaded successfully.
+    [[nodiscard]] bool hasScene() const;
+
+Q_SIGNALS:
+    /// The user asked to open a map belonging to an area (double-click, or the Open Map button).
+    void openMapRequested(const QString& mapFileName);
+
+private:
+    void setupUi();
+    void refreshAreaList();
+    void onAreaSelected(const worldmap::AreaMarker* area);
+    void onAreaActivated(const worldmap::AreaMarker* area);
+    void onHovered(int worldX, int worldY, const worldmap::AreaMarker* area);
+    void onFilterChanged(const QString& text);
+
+    resource::GameResources& _resources;
+
+    WorldMapView* _view = nullptr;
+    QLabel* _status = nullptr;      ///< live pointer readout: position, terrain, area
+    QLabel* _placeholder = nullptr; ///< shown instead of the map when there is no worldmap data
+    QLineEdit* _filter = nullptr;
+    QListWidget* _areaList = nullptr;
+    QToolButton* _openMapButton = nullptr;
+
+    std::shared_ptr<worldmap::WorldMapScene> _scene;
+    std::string _selectedMapFile; ///< the first map of the selected area, "" when none
+};
+
+} // namespace geck

--- a/src/util/PaletteBlend.cpp
+++ b/src/util/PaletteBlend.cpp
@@ -1,0 +1,120 @@
+#include "util/PaletteBlend.h"
+
+#include "format/pal/Pal.h"
+
+namespace geck::palette {
+
+namespace {
+
+    // The engine keeps colours as RGB555 while blending; these split one out into channels.
+    constexpr int redOf(int rgb) { return (rgb & 0x7C00) >> 10; }
+    constexpr int greenOf(int rgb) { return (rgb & 0x3E0) >> 5; }
+    constexpr int blueOf(int rgb) { return rgb & 0x1F; }
+
+    constexpr int packRgb555(int r, int g, int b) { return (r << 10) | (g << 5) | b; }
+
+    // The palette's 6-bit channels are the raw file bytes; anything above 0x3F is not a colour but
+    // a marker for an unmapped slot. colorPaletteLoad zeroes those, so Color2RGB reads black.
+    constexpr std::uint8_t MAX_CHANNEL = 0x3F;
+
+} // namespace
+
+BlendTables::BlendTables(const Pal& pal) {
+    _pal = pal.rgbConversionTable();
+
+    // colorPaletteLoad: mark the slots the palette actually maps and zero the rest, then Color2RGB
+    // (6-bit channels halved to 5) for every index.
+    const auto& colors = pal.palette();
+    for (std::size_t index = 0; index < COLORS; ++index) {
+        const Rgb& color = colors[index];
+        const bool mapped = color.r <= MAX_CHANNEL && color.g <= MAX_CHANNEL && color.b <= MAX_CHANNEL;
+        _mapped[index] = mapped ? 1 : 0;
+
+        const int r = mapped ? color.r : 0;
+        const int g = mapped ? color.g : 0;
+        const int b = mapped ? color.b : 0;
+        _rgb555[index] = packRgb555(r >> 1, g >> 1, b >> 1);
+        // The renderer shows the stored 6-bit channels shifted up by two (svga.cc).
+        _rgb888[index] = static_cast<std::uint32_t>((r << 2) << 16 | (g << 2) << 8 | (b << 2));
+    }
+
+    // _obj_blend_table_init: the grey level that selects a blend row, weighted towards green.
+    // r/g/b are 0-31 here, so the result never exceeds 7.
+    for (std::size_t index = 0; index < COLORS; ++index) {
+        const int rgb = _rgb555[index];
+        _commonGray[index] = static_cast<std::uint8_t>(((blueOf(rgb) + 3 * redOf(rgb) + 6 * greenOf(rgb)) / 10) >> 2);
+    }
+    _commonGray[0] = 0;
+
+    // _setIntensityTables / _setIntensityTableColor. Levels 0-127 darken towards black and 128-255
+    // lighten towards white, in 1/128 steps; level 128 is the colour unchanged. Unmapped colours
+    // get an all-zero row, matching the engine's memset.
+    for (std::size_t color = 0; color < COLORS; ++color) {
+        if (_mapped[color] == 0) {
+            continue; // _intensity is value-initialised to zero
+        }
+
+        const int rgb = _rgb555[color];
+        const int r = redOf(rgb);
+        const int g = greenOf(rgb);
+        const int b = blueOf(rgb);
+
+        int shift = 0;
+        for (std::size_t level = 0; level < 128; ++level) {
+            const int darker = packRgb555((r * shift) >> 16, (g * shift) >> 16, (b * shift) >> 16);
+            _intensity[color * COLORS + level] = _pal[static_cast<std::size_t>(darker)];
+
+            const int lighter = packRgb555(r + (((0x1F - r) * shift) >> 16),
+                g + (((0x1F - g) * shift) >> 16),
+                b + (((0x1F - b) * shift) >> 16));
+            _intensity[color * COLORS + 128 + level] = _pal[static_cast<std::size_t>(lighter)];
+
+            shift += 512;
+        }
+    }
+}
+
+BlendTable::BlendTable(const BlendTables& tables, std::uint32_t tintRgb)
+    : _tables(tables) {
+    // The engine's COLOR_* macros are _colorTable lookups, so the tint is snapped to the palette
+    // before _buildBlendTable reads its channels back out.
+    const std::uint8_t tint = tables.fromRgb555(rgb555(tintRgb));
+    const int tintColor = tables.toRgb555(tint);
+    const int r = redOf(tintColor);
+    const int g = greenOf(tintColor);
+    const int b = blueOf(tintColor);
+
+    // Row 0 is the identity: a grey level of 0 leaves the destination untouched.
+    for (std::size_t index = 0; index < 256; ++index) {
+        _rows[index] = static_cast<std::uint8_t>(index);
+    }
+
+    // Rows 1-7 mix the destination with the tint at a falling destination weight, so row 7 is the
+    // tint on its own. (_buildBlendTable then writes six flat shading rows past these; nothing
+    // reads them, because _commonGrayTable tops out at 7.)
+    int accumulatedR = r;
+    int accumulatedG = g;
+    int accumulatedB = b;
+    int destWeight = 6;
+    for (std::size_t row = 1; row < ROWS; ++row) {
+        for (std::size_t dest = 0; dest < 256; ++dest) {
+            const int destColor = tables.toRgb555(static_cast<std::uint8_t>(dest));
+            const int mixed = packRgb555((accumulatedR + redOf(destColor) * destWeight) / 7,
+                (accumulatedG + greenOf(destColor) * destWeight) / 7,
+                (accumulatedB + blueOf(destColor) * destWeight) / 7);
+            _rows[row * 256 + dest] = tables.fromRgb555(mixed);
+        }
+
+        --destWeight;
+        accumulatedR += r;
+        accumulatedG += g;
+        accumulatedB += b;
+    }
+}
+
+std::uint8_t BlendTable::blendPixel(std::uint8_t src, std::uint8_t dest) const {
+    const std::uint8_t blended = lookup(_tables.grayLevel(src), dest);
+    return _tables.intensity(blended, FULL_INTENSITY / 512);
+}
+
+} // namespace geck::palette

--- a/src/util/PaletteBlend.cpp
+++ b/src/util/PaletteBlend.cpp
@@ -74,7 +74,7 @@ BlendTables::BlendTables(const Pal& pal)
 }
 
 BlendTable::BlendTable(const BlendTables& tables, std::uint32_t tintRgb)
-    : _tables(tables) {
+    : _tables(&tables) {
     // The engine's COLOR_* macros are _colorTable lookups, so the tint is snapped to the palette
     // before _buildBlendTable reads its channels back out.
     const std::uint8_t tint = tables.fromRgb555(rgb555(tintRgb));
@@ -112,8 +112,8 @@ BlendTable::BlendTable(const BlendTables& tables, std::uint32_t tintRgb)
 }
 
 std::uint8_t BlendTable::blendPixel(std::uint8_t src, std::uint8_t dest) const {
-    const std::uint8_t blended = lookup(_tables.grayLevel(src), dest);
-    return _tables.intensity(blended, FULL_INTENSITY / 512);
+    const std::uint8_t blended = lookup(_tables->grayLevel(src), dest);
+    return _tables->intensity(blended, FULL_INTENSITY / 512);
 }
 
 } // namespace geck::palette

--- a/src/util/PaletteBlend.cpp
+++ b/src/util/PaletteBlend.cpp
@@ -19,9 +19,8 @@ namespace {
 
 } // namespace
 
-BlendTables::BlendTables(const Pal& pal) {
-    _pal = pal.rgbConversionTable();
-
+BlendTables::BlendTables(const Pal& pal)
+    : _pal(pal.rgbConversionTable()) {
     // colorPaletteLoad: mark the slots the palette actually maps and zero the rest, then Color2RGB
     // (6-bit channels halved to 5) for every index.
     const auto& colors = pal.palette();

--- a/src/util/PaletteBlend.h
+++ b/src/util/PaletteBlend.h
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace geck {
+class Pal;
+}
+
+/// @file
+/// @brief Fallout 2's palette-index colour maths, ported from fallout2-ce.
+///
+/// The engine never blends in RGB. Every pixel it draws is an index into `color.pal`, and every
+/// effect (translucency, tinting, dimming) is a lookup through tables derived from that palette.
+/// Reproducing an engine-drawn overlay pixel-for-pixel therefore means doing the same lookups on
+/// the same indices, then converting to RGB only at the very end.
+///
+/// @see fallout2-ce `color.cc` (`_buildBlendTable`, `_setIntensityTableColor`, `Color2RGB`)
+/// @see fallout2-ce `object.cc` (`_obj_blend_table_init`, `_dark_translucent_trans_buf_to_buf`)
+
+namespace geck::palette {
+
+/// A 24-bit 0xRRGGBB colour reduced to the 15-bit RGB555 index `_colorTable` is keyed by.
+/// Mirrors fallout2-ce color.h `rgb555`.
+constexpr int rgb555(std::uint32_t rgb) {
+    return static_cast<int>(((rgb >> 19) & 0x1F) << 10 | ((rgb >> 11) & 0x1F) << 5 | ((rgb >> 3) & 0x1F));
+}
+
+/// The tint the worldmap's city circles are blended with — fallout2-ce worldmap.cc uses
+/// `_getColorBlendTable(COLOR_GREEN)`, and `COLOR_GREEN` is `_colorTable[rgb555(0x00FF00)]`.
+constexpr std::uint32_t GREEN_RGB = 0x00FF00;
+
+/// The engine's derived colour tables for one loaded palette.
+///
+/// Built once per `color.pal` and then only read, so a renderer can blend as many overlays as it
+/// likes without recomputing anything. All indices are palette indices (0-255) unless stated.
+class BlendTables {
+public:
+    /// Derives every table from @p pal. The palette's own RGB-to-index conversion table (the
+    /// 32,768-entry block `color.pal` stores after its 768 RGB bytes) is used verbatim as the
+    /// engine's `_colorTable`.
+    explicit BlendTables(const Pal& pal);
+
+    /// The palette entry @p index as RGB555. Mirrors `Color2RGB`: the palette's 6-bit channels are
+    /// halved to 5 bits. Colours the palette does not map read as 0.
+    [[nodiscard]] int toRgb555(std::uint8_t index) const { return _rgb555[index]; }
+
+    /// The nearest palette index to an RGB555 value (`_colorTable`).
+    [[nodiscard]] std::uint8_t fromRgb555(int rgb) const {
+        return _pal[static_cast<std::size_t>(rgb) & (RGB555_VALUES - 1)];
+    }
+
+    /// The "common" grey level (0-7) of a palette index, weighted towards green. This is the row
+    /// selector into a blend table: 0 leaves the destination alone, 7 replaces it with the tint.
+    /// Mirrors `_commonGrayTable` (`_obj_blend_table_init`).
+    [[nodiscard]] std::uint8_t grayLevel(std::uint8_t index) const { return _commonGray[index]; }
+
+    /// `intensityColorTable[color][intensity]`: @p color darkened (intensity < 128) or lightened
+    /// (intensity > 128) in 1/128 steps, resolved back to a palette index. 128 is unchanged.
+    [[nodiscard]] std::uint8_t intensity(std::uint8_t color, std::uint8_t level) const {
+        return _intensity[index2d(color, level)];
+    }
+
+    /// The engine's RGB for a palette index, expanded from the stored 6-bit channels the way the
+    /// renderer displays them (`x << 2`, as in fallout2-ce svga.cc `directDrawSetPalette` and in
+    /// this project's Frame::rgba). Returns the three channels packed as 0xRRGGBB.
+    [[nodiscard]] std::uint32_t toRgb888(std::uint8_t index) const { return _rgb888[index]; }
+
+    /// Whether the palette maps this index at all. Unmapped entries are forced to black and are
+    /// excluded from the intensity table, exactly as `colorPaletteLoad` does.
+    [[nodiscard]] bool isMapped(std::uint8_t index) const { return _mapped[index] != 0; }
+
+private:
+    static constexpr std::size_t COLORS = 256;
+    static constexpr std::size_t RGB555_VALUES = 32768;
+
+    [[nodiscard]] static constexpr std::size_t index2d(std::uint8_t row, std::uint8_t column) {
+        return static_cast<std::size_t>(row) * COLORS + column;
+    }
+
+    std::array<std::uint8_t, RGB555_VALUES> _pal{};
+    std::array<int, COLORS> _rgb555{};
+    std::array<std::uint32_t, COLORS> _rgb888{};
+    std::array<std::uint8_t, COLORS> _mapped{};
+    std::array<std::uint8_t, COLORS> _commonGray{};
+    std::array<std::uint8_t, COLORS * COLORS> _intensity{};
+};
+
+/// One tint's blend table — the engine's `_getColorBlendTable(colour)` result.
+///
+/// Laid out as 8 rows of 256 entries. Row `g` (a @ref BlendTables::grayLevel) holds, for every
+/// destination index, the palette index that is `g/7` of the way from that destination towards the
+/// tint. Row 0 is the identity row. (The engine allocates six further rows of flat shading beyond
+/// these; nothing indexes them, because `_commonGrayTable` never exceeds 7.)
+class BlendTable {
+public:
+    /// Builds the table for @p tintRgb (a 0xRRGGBB colour, snapped to the nearest palette entry
+    /// first, as the engine's `COLOR_*` macros do). Mirrors `_buildBlendTable`.
+    BlendTable(const BlendTables& tables, std::uint32_t tintRgb);
+
+    /// The blend of destination index @p dest at grey level @p gray (0-7).
+    [[nodiscard]] std::uint8_t lookup(std::uint8_t gray, std::uint8_t dest) const {
+        return _rows[static_cast<std::size_t>(gray) * 256 + dest];
+    }
+
+    /// Blends one source pixel over one destination pixel the way
+    /// `_dark_translucent_trans_buf_to_buf` does at full intensity (0x10000): the source index
+    /// picks a grey level, that selects the blend row, and the result is passed through the
+    /// intensity table. Source index 0 is transparent and must be skipped by the caller.
+    [[nodiscard]] std::uint8_t blendPixel(std::uint8_t src, std::uint8_t dest) const;
+
+    /// The `intensity` argument `_dark_translucent_trans_buf_to_buf` is called with for the
+    /// worldmap circles (fallout2-ce worldmap.cc), i.e. "unchanged".
+    static constexpr int FULL_INTENSITY = 0x10000;
+
+private:
+    static constexpr std::size_t ROWS = 8;
+
+    const BlendTables& _tables;
+    std::array<std::uint8_t, ROWS * 256> _rows{};
+};
+
+} // namespace geck::palette

--- a/src/util/PaletteBlend.h
+++ b/src/util/PaletteBlend.h
@@ -96,7 +96,8 @@ private:
 class BlendTable {
 public:
     /// Builds the table for @p tintRgb (a 0xRRGGBB colour, snapped to the nearest palette entry
-    /// first, as the engine's `COLOR_*` macros do). Mirrors `_buildBlendTable`.
+    /// first, as the engine's `COLOR_*` macros do). Mirrors `_buildBlendTable`. @p tables must
+    /// outlive the table, which keeps referring to it for @ref blendPixel.
     BlendTable(const BlendTables& tables, std::uint32_t tintRgb);
 
     /// The blend of destination index @p dest at grey level @p gray (0-7).
@@ -117,7 +118,10 @@ public:
 private:
     static constexpr std::size_t ROWS = 8;
 
-    const BlendTables& _tables;
+    // A pointer rather than a reference: a blend table is a value a renderer may well want to keep
+    // several of (one per tint) and reassign as the palette changes, and a reference member would
+    // make it unassignable for no gain.
+    const BlendTables* _tables;
     std::array<std::uint8_t, ROWS * 256> _rows{};
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(general_tests
     general/test_map_name_resolver.cpp
     general/test_city_txt.cpp
     general/test_worldmap_txt.cpp
+    general/test_palette_blend.cpp
     general/test_quests_txt.cpp
     general/test_endgame_txt.cpp
     general/test_gvar_refs.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(general_tests
     general/test_city_txt.cpp
     general/test_worldmap_txt.cpp
     general/test_palette_blend.cpp
+    general/test_worldmap_scene.cpp
     general/test_quests_txt.cpp
     general/test_endgame_txt.cpp
     general/test_gvar_refs.cpp

--- a/tests/general/test_city_txt.cpp
+++ b/tests/general/test_city_txt.cpp
@@ -1,6 +1,9 @@
 #include <catch2/catch_test_macros.hpp>
 
+#include <cstdlib>
+
 #include "format/city/CityTxt.h"
+#include "format/worldmap/WorldmapTxt.h"
 #include "reader/city/CityTxtReader.h"
 
 using namespace geck;
@@ -15,7 +18,8 @@ area_name=Arroyo
 world_pos=184,133        ; Absolute position ; SAVED
 start_state=On           ; Starting state
 size=Medium              ; Size of circle
-townmap_art_idx=156
+townmap_art_idx=156      ; Fid num index for the townmap art
+townmap_label_art_idx=370
 entrance_0=On,350,275,Arroyo Bridge,-1,-1,3  ; Etc.
 entrance_1=On,280,175,Arroyo Village,-1,-1,0
 entrance_2=Off,-1,-1,Arroyo Caves,-1,-1,0
@@ -24,7 +28,9 @@ entrance_2=Off,-1,-1,Arroyo Caves,-1,-1,0
 area_name=The Den
 world_pos=308,213
 start_state=Off
+lock_state=On
 size=Large
+townmap_art_idx=160
 entrance_0=On,300,300,Den,-1,-1,2
 )";
 } // namespace
@@ -40,7 +46,11 @@ TEST_CASE("parseCityTxt reads worldmap areas, positions and entrances", "[city]"
     CHECK(arroyo->worldX == 184); // world_pos x, inline comment stripped
     CHECK(arroyo->worldY == 133);
     CHECK(arroyo->startOn == true);
+    CHECK(arroyo->locked == false); // no lock_state key at all
     CHECK(arroyo->size == "medium");
+    CHECK(cityAreaSize(arroyo->size) == CityAreaSize::Medium);
+    CHECK(arroyo->townMapArtIndex == 156);
+    CHECK(arroyo->townMapLabelArtIndex == 370);
     REQUIRE(arroyo->entrances.size() == 3);
     CHECK(arroyo->entrances[0].on == true);
     CHECK(arroyo->entrances[0].map == "Arroyo Bridge"); // lookup_name with a space survives the split
@@ -53,10 +63,48 @@ TEST_CASE("parseCityTxt reads worldmap areas, positions and entrances", "[city]"
     CHECK(den->name == "The Den");
     CHECK(den->worldX == 308);
     CHECK(den->size == "large");
+    CHECK(den->locked == true);
+    CHECK(den->townMapLabelArtIndex == -1); // key absent
     REQUIRE(den->entrances.size() == 1);
     CHECK(den->entrances[0].map == "Den");
 
     CHECK(city.find(99) == nullptr);
+}
+
+// The single most load-bearing fact in drawing the worldmap. city.txt's world_pos is measured from
+// the engine's 640x480 interface window, but the map view starts at (WM_VIEW_X, WM_VIEW_Y) inside
+// it, so a marker's real place on the worldmap is world_pos minus that. fallout2-ce applies the bias
+// in both directions (wmInterfaceRefresh draws at city->x - offset into a buffer whose view begins
+// at WM_VIEW_X; wmMatchWorldPosToArea hit-tests worldPos + WM_VIEW_X against city->x).
+//
+// The engine pins it down: a new game starts the party at the hard-coded world position (173, 122)
+// (wmGenDataSetStartWorldPos), and that has to be inside Arroyo. Only the biased rectangle contains
+// it — and puts it within two pixels of the circle's centre.
+TEST_CASE("worldmap markers sit WM_VIEW_X/Y before their world_pos", "[city][worldmap]") {
+    const CityTxt city = parseCityTxt(std::string{ kCityTxt });
+    const CityArea* arroyo = city.find(0);
+    REQUIRE(arroyo != nullptr);
+
+    constexpr int MEDIUM_CIRCLE = 25; // art/intrface/wrldspr1.frm
+    constexpr int START_X = 173;
+    constexpr int START_Y = 122;
+
+    const int left = arroyo->worldX - WM_VIEW_X;
+    const int top = arroyo->worldY - WM_VIEW_Y;
+    CHECK(left == 162);
+    CHECK(top == 112);
+
+    CHECK(START_X >= left);
+    CHECK(START_X <= left + MEDIUM_CIRCLE);
+    CHECK(START_Y >= top);
+    CHECK(START_Y <= top + MEDIUM_CIRCLE);
+
+    // Within a couple of pixels of dead centre, which is what makes the bias more than a coincidence.
+    CHECK(std::abs(left + MEDIUM_CIRCLE / 2 - START_X) <= 2);
+    CHECK(std::abs(top + MEDIUM_CIRCLE / 2 - START_Y) <= 2);
+
+    // Without the bias the party would start outside Arroyo's circle entirely.
+    CHECK(START_X < arroyo->worldX);
 }
 
 TEST_CASE("parseCityTxt tolerates empty input", "[city]") {

--- a/tests/general/test_palette_blend.cpp
+++ b/tests/general/test_palette_blend.cpp
@@ -1,0 +1,161 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <array>
+#include <cstdlib>
+#include <memory>
+
+#include "format/pal/Pal.h"
+#include "util/PaletteBlend.h"
+
+using namespace geck;
+using namespace geck::palette;
+
+namespace {
+
+// A stand-in for color.pal. Fallout stores 6-bit channels (0-63) and follows them with a table that
+// maps every RGB555 value back to the nearest palette index; here the palette is a plain 6x6x6 cube
+// so both directions are exact and the expected values can be worked out by hand.
+//
+// Index 0 is black (the transparent index), and the cube fills 1..216. Slots past that are left
+// above 0x3F, which is how a real palette marks an entry it does not map.
+constexpr int CUBE_SIDE = 6;
+constexpr int CUBE_STEP = 63 / (CUBE_SIDE - 1); // 12 -> channels 0,12,24,36,48,60
+
+std::unique_ptr<Pal> makeCubePal() {
+    auto pal = std::make_unique<Pal>("test.pal");
+
+    auto& colors = pal->palette();
+    colors.fill(Rgb{ 0xFF, 0xFF, 0xFF }); // unmapped everywhere by default
+    colors[0] = Rgb{ 0, 0, 0 };
+    for (int r = 0; r < CUBE_SIDE; ++r) {
+        for (int g = 0; g < CUBE_SIDE; ++g) {
+            for (int b = 0; b < CUBE_SIDE; ++b) {
+                const std::size_t index = 1 + static_cast<std::size_t>((r * CUBE_SIDE + g) * CUBE_SIDE + b);
+                colors[index] = Rgb{ static_cast<uint8_t>(r * CUBE_STEP),
+                    static_cast<uint8_t>(g * CUBE_STEP),
+                    static_cast<uint8_t>(b * CUBE_STEP) };
+            }
+        }
+    }
+
+    // The conversion table: for each RGB555 value pick the cube entry with the nearest channels.
+    auto& conversion = pal->rgbConversionTable();
+    const auto nearest = [](int channel5) { // 0-31 -> the cube step that is closest
+        const int channel6 = channel5 * 2;  // the palette's 6-bit scale
+        int best = 0;
+        int bestDistance = 1000;
+        for (int step = 0; step < CUBE_SIDE; ++step) {
+            const int distance = std::abs(step * CUBE_STEP - channel6);
+            if (distance < bestDistance) {
+                bestDistance = distance;
+                best = step;
+            }
+        }
+        return best;
+    };
+    for (int rgb = 0; rgb < static_cast<int>(Pal::NUM_CONVERSION_VALUES); ++rgb) {
+        const int r = nearest((rgb & 0x7C00) >> 10);
+        const int g = nearest((rgb & 0x3E0) >> 5);
+        const int b = nearest(rgb & 0x1F);
+        conversion[static_cast<std::size_t>(rgb)]
+            = static_cast<uint8_t>(1 + (r * CUBE_SIDE + g) * CUBE_SIDE + b);
+    }
+
+    return pal;
+}
+
+// The cube index for a colour given as steps along each axis.
+constexpr uint8_t cube(int r, int g, int b) {
+    return static_cast<uint8_t>(1 + (r * CUBE_SIDE + g) * CUBE_SIDE + b);
+}
+
+} // namespace
+
+TEST_CASE("BlendTables mirrors the engine's palette conversions", "[palette]") {
+    const auto pal = makeCubePal();
+    const BlendTables tables(*pal);
+
+    // Color2RGB halves the palette's 6-bit channels: step 2 is 24, and 24 >> 1 is 12.
+    CHECK(tables.toRgb555(cube(2, 0, 0)) == (12 << 10));
+    CHECK(tables.toRgb555(cube(0, 5, 0)) == (30 << 5)); // 60 >> 1
+    CHECK(tables.toRgb555(0) == 0);
+
+    // Entries the palette does not map read as black and are excluded.
+    CHECK(tables.isMapped(cube(1, 1, 1)));
+    CHECK_FALSE(tables.isMapped(255));
+    CHECK(tables.toRgb555(255) == 0);
+
+    // The display expansion the engine uses is a two-bit shift, not a rescale to 0-255.
+    CHECK(tables.toRgb888(cube(5, 0, 0)) == 0xF00000u); // 60 << 2 == 240
+    CHECK(tables.toRgb888(0) == 0x000000u);
+
+    // intensityColorTable: 128 is the colour unchanged, 0 is black, 255 is (near) white.
+    const uint8_t midGrey = cube(3, 3, 3);
+    CHECK(tables.intensity(midGrey, 128) == midGrey);
+    CHECK(tables.intensity(midGrey, 0) == cube(0, 0, 0));
+    CHECK(tables.intensity(midGrey, 255) == cube(5, 5, 5));
+}
+
+TEST_CASE("commonGrayTable weights green and stays within the blend table's rows", "[palette]") {
+    const auto pal = makeCubePal();
+    const BlendTables tables(*pal);
+
+    // _commonGrayTable is ((b + 3r + 6g) / 10) >> 2 over 5-bit channels, so it never exceeds 7 —
+    // which is exactly the number of blend rows the engine builds beyond the identity row.
+    for (int index = 0; index < 256; ++index) {
+        CHECK(tables.grayLevel(static_cast<uint8_t>(index)) <= 7);
+    }
+
+    CHECK(tables.grayLevel(0) == 0); // the transparent index is forced to zero
+    // Green weighs six times as much as blue, so full green outranks full blue.
+    CHECK(tables.grayLevel(cube(0, 5, 0)) > tables.grayLevel(cube(0, 0, 5)));
+    CHECK(tables.grayLevel(cube(0, 5, 0)) > tables.grayLevel(cube(5, 0, 0)));
+    CHECK(tables.grayLevel(cube(5, 5, 5)) == 7); // white saturates
+}
+
+TEST_CASE("BlendTable interpolates the destination towards the tint", "[palette]") {
+    const auto pal = makeCubePal();
+    const BlendTables tables(*pal);
+    const BlendTable green(tables, GREEN_RGB);
+
+    const uint8_t black = cube(0, 0, 0);
+    const uint8_t red = cube(5, 0, 0);
+
+    // Row 0 is the identity: a source pixel with no grey level leaves the destination alone.
+    for (int dest = 0; dest < 256; ++dest) {
+        CHECK(green.lookup(0, static_cast<uint8_t>(dest)) == dest);
+    }
+
+    // Row 7 is the tint on its own, whatever was underneath.
+    CHECK(green.lookup(7, black) == green.lookup(7, red));
+    CHECK(green.lookup(7, black) == cube(0, 5, 0)); // the palette's green
+
+    // The rows in between walk from the destination to the tint, so green rises monotonically.
+    int previousGreen = -1;
+    for (uint8_t row = 0; row <= 7; ++row) {
+        const int greenChannel = (tables.toRgb555(green.lookup(row, black)) & 0x3E0) >> 5;
+        CHECK(greenChannel >= previousGreen);
+        previousGreen = greenChannel;
+    }
+}
+
+TEST_CASE("blendPixel reproduces the worldmap circle's translucent tint", "[palette]") {
+    const auto pal = makeCubePal();
+    const BlendTables tables(*pal);
+    const BlendTable green(tables, GREEN_RGB);
+
+    const uint8_t terrain = cube(3, 2, 1); // some brown ground under the circle
+
+    // This is the whole of _dark_translucent_trans_buf_to_buf at intensity 0x10000: grey level picks
+    // the row, the row blends against the destination, the intensity table passes it through.
+    for (int src = 1; src < 256; ++src) {
+        const uint8_t source = static_cast<uint8_t>(src);
+        const uint8_t expected = tables.intensity(green.lookup(tables.grayLevel(source), terrain), 128);
+        CHECK(green.blendPixel(source, terrain) == expected);
+    }
+
+    // A dark source barely touches the terrain; a bright one replaces it with green. That contrast
+    // is what makes the circle read as a bright ring around a tinted interior.
+    CHECK(green.blendPixel(cube(0, 0, 1), terrain) == terrain);
+    CHECK(green.blendPixel(cube(5, 5, 5), terrain) == cube(0, 5, 0));
+}

--- a/tests/general/test_palette_blend.cpp
+++ b/tests/general/test_palette_blend.cpp
@@ -149,7 +149,7 @@ TEST_CASE("blendPixel reproduces the worldmap circle's translucent tint", "[pale
     // This is the whole of _dark_translucent_trans_buf_to_buf at intensity 0x10000: grey level picks
     // the row, the row blends against the destination, the intensity table passes it through.
     for (int src = 1; src < 256; ++src) {
-        const uint8_t source = static_cast<uint8_t>(src);
+        const auto source = static_cast<uint8_t>(src);
         const uint8_t expected = tables.intensity(green.lookup(tables.grayLevel(source), terrain), 128);
         CHECK(green.blendPixel(source, terrain) == expected);
     }

--- a/tests/general/test_palette_blend.cpp
+++ b/tests/general/test_palette_blend.cpp
@@ -139,6 +139,39 @@ TEST_CASE("BlendTable interpolates the destination towards the tint", "[palette]
     }
 }
 
+// The worldmap view redraws the area circles as geometry when magnified, on the grounds that a
+// blend row is nothing more exotic than a linear interpolation towards the tint: _buildBlendTable
+// row j computes (tint*j + dest*(7-j)) / 7 per RGB555 channel. Pin that down, because it is what
+// lets a radial gradient stand in for the sprite without inventing colours.
+TEST_CASE("a blend row is a linear interpolation towards the tint", "[palette]") {
+    const auto pal = makeCubePal();
+    const BlendTables tables(*pal);
+    const BlendTable green(tables, GREEN_RGB);
+
+    const int tint555 = tables.toRgb555(tables.fromRgb555(rgb555(GREEN_RGB)));
+    const int tintR = (tint555 & 0x7C00) >> 10;
+    const int tintG = (tint555 & 0x3E0) >> 5;
+    const int tintB = tint555 & 0x1F;
+
+    for (int dest = 0; dest < 256; ++dest) {
+        if (!tables.isMapped(static_cast<uint8_t>(dest))) {
+            continue;
+        }
+        const int dest555 = tables.toRgb555(static_cast<uint8_t>(dest));
+        const int destR = (dest555 & 0x7C00) >> 10;
+        const int destG = (dest555 & 0x3E0) >> 5;
+        const int destB = dest555 & 0x1F;
+
+        for (int row = 1; row <= 7; ++row) {
+            const int mixed = ((tintR * row + destR * (7 - row)) / 7) << 10
+                | ((tintG * row + destG * (7 - row)) / 7) << 5
+                | ((tintB * row + destB * (7 - row)) / 7);
+            CHECK(green.lookup(static_cast<uint8_t>(row), static_cast<uint8_t>(dest))
+                == tables.fromRgb555(mixed));
+        }
+    }
+}
+
 TEST_CASE("blendPixel reproduces the worldmap circle's translucent tint", "[palette]") {
     const auto pal = makeCubePal();
     const BlendTables tables(*pal);

--- a/tests/general/test_worldmap_scene.cpp
+++ b/tests/general/test_worldmap_scene.cpp
@@ -1,0 +1,137 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "editor/worldmap/WorldMapScene.h"
+#include "format/pal/Pal.h"
+#include "resource/GameResources.h"
+
+namespace fs = std::filesystem;
+using namespace geck;
+
+namespace {
+
+void writeFile(const fs::path& path, const std::string& contents) {
+    fs::create_directories(path.parent_path());
+    std::ofstream out(path, std::ios::binary);
+    out << contents;
+}
+
+// A structurally valid color.pal: 256 RGB triplets in the palette's 6-bit range, then the
+// 32,768-entry RGB555 -> index conversion table. The colours themselves do not matter here; what
+// matters is that PalReader accepts the file, so the scene gets as far as the art it cannot find.
+void writePal(const fs::path& path) {
+    std::vector<std::uint8_t> bytes;
+    bytes.reserve(768 + Pal::NUM_CONVERSION_VALUES);
+    for (int index = 0; index < 256; ++index) {
+        const auto channel = static_cast<std::uint8_t>(index % 64);
+        bytes.insert(bytes.end(), { channel, channel, channel });
+    }
+    bytes.resize(768 + Pal::NUM_CONVERSION_VALUES, 1);
+
+    fs::create_directories(path.parent_path());
+    std::ofstream out(path, std::ios::binary);
+    out.write(reinterpret_cast<const char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
+}
+
+constexpr const char* kCityTxt = R"(
+[Area 00]
+area_name=Arroyo
+world_pos=184,133
+start_state=On
+size=Medium
+townmap_art_idx=156
+entrance_0=On,350,275,Arroyo Bridge,-1,-1,3
+)";
+
+// One tile whose art_idx is far past the end of any intrface.lst — the shape a modded or partial
+// data set takes.
+constexpr const char* kWorldmapTxt = R"(
+[Data]
+terrain_types=Desert:1
+terrain_short_names=DES
+[Tile Data]
+num_horizontal_tiles=1
+[Tile 0]
+art_idx=999999
+0_0=Desert, No_Fill, None, None, None, Desert1
+)";
+
+// A data path holding whatever the test writes into it, mounted into its own GameResources.
+struct FixtureResources {
+    fs::path root;
+    resource::GameResources resources;
+
+    explicit FixtureResources(const std::string& name)
+        : root(fs::temp_directory_path() / name) { // NOSONAR: throwaway test dir, not security-sensitive
+        std::error_code ec;
+        fs::remove_all(root, ec);
+        fs::create_directories(root, ec);
+    }
+
+    ~FixtureResources() {
+        std::error_code ec;
+        fs::remove_all(root, ec);
+    }
+
+    FixtureResources(const FixtureResources&) = delete;
+    FixtureResources& operator=(const FixtureResources&) = delete;
+
+    void mount() { resources.files().addDataPath(root.string()); }
+};
+
+} // namespace
+
+// Both halves of an art lookup throw rather than returning null: ResourceRepository::load on a file
+// that is not mounted, FrmResolver::resolve on an LST that is missing or too short. The scene has
+// to absorb that, because in the editor load() runs inside a Qt slot, where an escaping exception
+// is a terminate() rather than an error message.
+TEST_CASE("WorldMapScene reports missing worldmap data instead of throwing", "[worldmap][scene]") {
+    FixtureResources fixture("geck_worldmap_scene_nodata_test");
+    writeFile(fixture.root / "data/city.txt", kCityTxt);
+    writeFile(fixture.root / "data/worldmap.txt", kWorldmapTxt);
+    fixture.mount();
+
+    // The text files are there, the art and the palette are not — a data folder added without
+    // master.dat next to it. color.pal is what the scene cannot do without.
+    std::unique_ptr<worldmap::WorldMapScene> scene;
+    REQUIRE_NOTHROW(scene = worldmap::WorldMapScene::load(fixture.resources));
+    CHECK(scene == nullptr);
+}
+
+TEST_CASE("WorldMapScene draws what it can and lists the art it could not load", "[worldmap][scene]") {
+    FixtureResources fixture("geck_worldmap_scene_noart_test");
+    writeFile(fixture.root / "data/city.txt", kCityTxt);
+    writeFile(fixture.root / "data/worldmap.txt", kWorldmapTxt);
+    writePal(fixture.root / "color.pal");
+    // Two entries, so every worldmap art index (the tile's 999999, the markers' 336-338) is past
+    // the end of the list and resolve() throws on each.
+    writeFile(fixture.root / "art/intrface/intrface.lst", "iface0.frm\niface1.frm\n");
+    fixture.mount();
+
+    std::unique_ptr<worldmap::WorldMapScene> scene;
+    REQUIRE_NOTHROW(scene = worldmap::WorldMapScene::load(fixture.resources));
+    REQUIRE(scene != nullptr);
+
+    // The canvas is still the size worldmap.txt describes, just black where the tile would be.
+    CHECK(scene->width() == WM_TILE_WIDTH);
+    CHECK(scene->height() == WM_TILE_HEIGHT);
+    CHECK(scene->pixels().size() == static_cast<std::size_t>(WM_TILE_WIDTH) * WM_TILE_HEIGHT * 4);
+
+    // The tile and all three marker sprites are reported, so the UI can say why the map is black
+    // and why clicking it does nothing.
+    CHECK(scene->missingArt().size() == 4);
+
+    REQUIRE(scene->areas().size() == 1);
+    const worldmap::AreaMarker& arroyo = scene->areas().front();
+    CHECK(arroyo.name == "Arroyo");
+    // No circle art means no hit box at all, rather than a zero-sized one that matches its corner.
+    CHECK(arroyo.width == 0);
+    CHECK_FALSE(arroyo.contains(arroyo.x, arroyo.y));
+    CHECK(scene->areaAt(arroyo.x, arroyo.y) == nullptr);
+    CHECK(scene->markerProfile(arroyo.size).empty());
+}

--- a/tests/general/test_worldmap_txt.cpp
+++ b/tests/general/test_worldmap_txt.cpp
@@ -71,16 +71,35 @@ terrain_types=Desert:1, Mountain:4, Ocean:2
 [Tile Data]
 num_horizontal_tiles=2
 [Tile 0]
+art_idx=339
+encounter_difficulty=0
+walk_mask_name=wrldmp00
 0_0=Desert, No_Fill, None, None, None, Desert1
 1_0=Mountain, No_Fill, None, None, None, Mtn
 0_1=Ocean, Fill_W, None, None, None, Fish
 [Tile 1]
+art_idx=340
+encounter_difficulty=3
 0_0=Mountain, No_Fill, None, None, None, Mtn
 )";
     const WorldmapTxt world = parseWorldmapTxt(std::string{ kTiles });
 
     CHECK(world.numHorizontalTiles == 2);
     REQUIRE(world.tiles.size() == 2);
+
+    // art_idx is what the background is made of: an intrface.lst index, resolved as a FID with the
+    // OBJ_TYPE_INTERFACE type byte (the shipped tiles are art/intrface/wrldmp00.frm upwards).
+    CHECK(world.tiles[0].artIndex == 339);
+    CHECK(world.tiles[0].walkMaskName == "wrldmp00");
+    CHECK(world.tiles[0].encounterDifficulty == 0);
+    CHECK(world.tiles[1].artIndex == 340);
+    CHECK(world.tiles[1].encounterDifficulty == 3);
+    CHECK(world.tiles[1].walkMaskName.empty()); // no mask = walkable throughout
+
+    // A 2x1 grid of 350x300 tiles.
+    CHECK(world.numVerticalTiles() == 1);
+    CHECK(world.widthPixels() == 700);
+    CHECK(world.heightPixels() == 300);
     // terrainAt: row = (x%350)/50, col = (y%300)/50, tile = (y/300)*numHoriz + x/350.
     CHECK(world.terrainAt(0, 0) == "Desert");     // tile 0, row 0, col 0
     CHECK(world.terrainAt(60, 0) == "Mountain");  // row 1 (60/50)


### PR DESCRIPTION
Adds a **View → World Map** screen showing the Fallout 2 world map as the game renders it: the `art/intrface/wrldmp*` tile grid with each area's translucent green circle blended over it.

## Drawn exactly, not approximately

The engine never blends in RGB — every pixel is an index into `color.pal`, and translucency is a lookup through tables derived from it (`_buildBlendTable`, `_commonGrayTable`, `intensityColorTable`). `src/util/PaletteBlend` ports those, so `WorldMapScene` composes tiles *and* markers in palette-index space and expands to RGBA only at the very end. The markers are pixel-identical to the engine rather than a lookalike.

`WorldMapScene` is Qt-free (gecko_core), so the same code backs the UI and `gecko-cli map world --render <png>`.

## Two engine facts, now asserted in tests

- The **yellow subtile grid is baked into the tile art** — the engine doesn't draw it.
- **`city.txt`'s `world_pos` is biased by the interface window.** The map view starts at `(WM_VIEW_X, WM_VIEW_Y) = (22, 21)` inside the 640×480 window, and `world_pos` is measured from the window origin — so a marker's real worldmap position is `world_pos - (22, 21)`. fallout2-ce applies the same bias when drawing (`wmInterfaceRefresh`) and when hit-testing (`wmMatchWorldPosToArea`). The clincher: a new game starts the party at the hard-coded `(173, 122)`, which lands inside Arroyo's circle (within 2px of its centre) only with the bias — without it the party would start 22px outside. `test_city_txt.cpp` locks this in so nobody has to re-derive it.

## The view

Pan, zoom (fit / 1:1 / wheel), hover readout of position + terrain + area, click to select, double-click to open an area's map, marker and label toggles, and a filterable area list with undiscovered areas dimmed. It needs mounted game data but no open map, so it sits in the central stack beside the welcome screen, and is dropped and rebuilt when the data paths change.

## Also in here

- `city.txt`: `townmap_art_idx`, `townmap_label_art_idx`, `lock_state`; `worldmap.txt`: `art_idx`, `walk_mask_name`, `encounter_difficulty` (`art_idx` is what the background is made of).
- `loadConfig` moved from `cli/` down to `resource/` so the editor and the headless tools share one copy.
- `PLAN.md` records what shipped, the coordinate guard note, and the follow-ups (town-map view, overlays, editing via a lossless `city.txt` round-trip).

## Verification

465/465 tests pass. Verified in the running app and via the CLI render; new tests cover the palette port (identity/tint rows, grey-level bounds, the full `blendPixel` path) and both readers' new keys.