### PR TITLE
Add find_script and find_text, fix the two maps that would not load, and say which script index base we mean

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,31 @@ regressions). There is no ctest label registration for filtering by category.
 - Hex positions can be 0-39,999 (valid range)
 - Tile positions can be 0-9,999 (valid range)
 
+#### Script Index Bases
+**IMPORTANT**: Three different numbers name the same script, and mixing them up returns the
+*neighbouring* script rather than an error:
+
+| Number | Base | Where it lives |
+| --- | --- | --- |
+| `programIndex` — what gecko speaks | **0-based** | the `scripts.lst` array index, and an object's `MapScript::script_id` |
+| map header `script_id` | 1-based | `Map::MapHeader::script_id` |
+| SSL `SCRIPT_*` (FRP `headers/scripts.h`) | 1-based | the `scripts.lst` *line* number; also sfall `set_script()` ids |
+
+gecko speaks the engine's internal 0-based index everywhere, because that is what map files actually
+store and what the engine indexes `scripts.lst` with (fallout2-ce `scripts.cc`,
+`scriptsGetFileName`). This is deliberate, and follows the engine-fidelity rule below. The 1-based
+forms are the engine's own *inputs*, and the engine itself decrements them, so gecko normalises on
+the way in at the same two places: `MapAnalyzer` resolves the header's `script_id - 1` (fallout2-ce
+`map.cc`, `script->index = gMapHeader.scriptIndex - 1`), and sfall's `set_script()` opcode
+decrements before validating (fallout2-ce `sfall_opcodes.cc`).
+
+##### Common Mistake
+- `SCRIPT_EPAC17 (1413)` from `headers/scripts.h` is `programIndex` **1412**. Passing the constant
+  straight through names `epac18` — a plausible wrong answer, never an error.
+- Prefer the `name` argument on `describe_script` / `find_script`; it has no index base to get wrong.
+- Every script-shaped result echoes `sslConstant` (== `programIndex + 1`) so the two can be
+  cross-checked at a glance. See `src/cli/ScriptIntrospect.h` for the full note.
+
 ## Drag and Drop Implementation
 
 ### Object Positioning

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,16 @@ regressions). There is no ctest label registration for filtering by category.
 - Hex positions can be 0-39,999 (valid range)
 - Tile positions can be 0-9,999 (valid range)
 
+#### Objects With No Known Type
+An object record whose PID names no known type is **legal, not corruption**. The engine's
+`objectDataRead` / `objectDataWrite` (fallout2-ce `proto.cc`) both fall out of their type switch
+through `default:`, so the record is the 22-field common block alone, with no type-specific tail.
+RPU's `epamain1.map` and `epamain2.map` each carry 17 such records with `pid == -1`.
+
+Reader and writer must agree here: rejecting them made both maps unreadable, and consuming the
+wrong number of bytes shifts every object after one by the width of a tail that was never on disk.
+Guarded by "MAP round-trip keeps an object whose PID has no known type".
+
 #### Script Index Bases
 **IMPORTANT**: Three different numbers name the same script, and mixing them up returns the
 *neighbouring* script rather than an error:

--- a/src/cli/MapLoad.cpp
+++ b/src/cli/MapLoad.cpp
@@ -43,7 +43,8 @@ namespace {
     }
 } // namespace
 
-std::unique_ptr<Map> loadMap(resource::GameResources& resources, const std::string& mapPath) {
+std::unique_ptr<Map> loadMap(resource::GameResources& resources, const std::string& mapPath,
+    std::string* error) {
     // Prefer the VFS so a map inside a DAT ("/maps/desert1.map") or a mounted data directory
     // resolves the same way the editor sees it.
     auto bytes = resources.files().readRawBytes(mapPath);
@@ -57,6 +58,9 @@ std::unique_ptr<Map> loadMap(resource::GameResources& resources, const std::stri
         bytes = readDiskBytes(mapPath);
     }
     if (!bytes) {
+        if (error != nullptr) {
+            *error = "not found in the mounted data or on disk";
+        }
         return nullptr;
     }
     try {
@@ -64,6 +68,9 @@ std::unique_ptr<Map> loadMap(resource::GameResources& resources, const std::stri
         return reader.openFile(mapPath, *bytes);
     } catch (const std::exception& e) {
         spdlog::debug("loadMap: parse failed for {}: {}", mapPath, e.what());
+        if (error != nullptr) {
+            *error = e.what();
+        }
         return nullptr;
     }
 }

--- a/src/cli/MapLoad.h
+++ b/src/cli/MapLoad.h
@@ -23,7 +23,10 @@ namespace cli {
 
     /// Read and parse a map from the mounted data. Returns nullptr (logging at debug) if the map can't
     /// be read or parsed, so callers can skip or report as they prefer. Shared by analyze and render.
-    std::unique_ptr<Map> loadMap(resource::GameResources& resources, const std::string& mapPath);
+    /// Pass `error` to recover the reason — the parse exception's message, or a note that the file was
+    /// not found — so a skipped map can be reported rather than silently dropped.
+    std::unique_ptr<Map> loadMap(resource::GameResources& resources, const std::string& mapPath,
+        std::string* error = nullptr);
 
 } // namespace cli
 } // namespace geck

--- a/src/cli/ScriptIntrospect.cpp
+++ b/src/cli/ScriptIntrospect.cpp
@@ -1,17 +1,28 @@
 #include "cli/ScriptIntrospect.h"
 
+#include "cli/MapAnalyzer.h" // listMapPaths
+#include "cli/MapLoad.h"     // loadMap
 #include "format/lst/Lst.h"
+#include "format/map/Map.h"
+#include "format/map/MapScript.h"
 #include "format/msg/Msg.h"
 #include "resource/GameResources.h"
+#include "resource/MapNameResolver.h"
 #include "resource/ResourcePaths.h"
+#include "resource/ScriptNames.h"
 
 #include <nlohmann/json.hpp>
 #include <spdlog/spdlog.h>
 
 #include <algorithm>
 #include <cctype>
+#include <filesystem>
+#include <memory>
+#include <optional>
 #include <ostream>
+#include <regex>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -76,41 +87,480 @@ namespace {
         }
         return dialog;
     }
+
+    // --- script resolution -------------------------------------------------------
+
+    const Lst* loadScriptsLst(resource::GameResources& resources) {
+        try {
+            return resources.repository().load<Lst>(ResourcePaths::Lst::SCRIPTS);
+        } catch (const std::exception& e) {
+            spdlog::debug("scripts.lst load failed: {}", e.what());
+            return nullptr;
+        }
+    }
+
+    // The identity block every script-shaped result leads with. `sslConstant` is the 1-based number
+    // the FRP headers/scripts.h SCRIPT_* constants carry, echoed next to the 0-based programIndex so
+    // the two bases can be told apart on sight instead of by silently naming the wrong script.
+    ordered_json scriptIdentity(resource::GameResources& resources, const Lst& scripts, int programIndex) {
+        const std::string& filename = scripts.list()[static_cast<std::size_t>(programIndex)];
+        ordered_json identity;
+        identity["programIndex"] = programIndex;
+        identity["sslConstant"] = programIndex + 1;
+        identity["filename"] = filename;
+        identity["name"] = stem(filename);
+        const std::string description = resource::scriptDescription(resources, programIndex);
+        identity["description"] = description.empty() ? ordered_json(nullptr) : ordered_json(description);
+        return identity;
+    }
+
+    // The outcome of turning a caller's `name`/`programIndex` into one scripts.lst entry: exactly one
+    // index, or a candidate list when a name fragment was ambiguous, or a hard error.
+    struct Resolution {
+        int programIndex = -1;       ///< >= 0 when a single script was selected
+        std::vector<int> candidates; ///< non-empty when `name` matched several entries
+        std::string error;           ///< non-empty when nothing matched at all
+        bool fromFragment = false;   ///< resolved from a substring, not an exact basename
+    };
+
+    // Resolve by name (exact basename first, then substring — so a half-remembered name still helps)
+    // or, failing that, by 0-based program index.
+    Resolution resolveScript(const Lst& scripts, const std::string& name, int programIndex) {
+        const auto& list = scripts.list();
+        if (!name.empty()) {
+            const std::string needle = toLower(stem(name));
+            std::vector<int> exact;
+            std::vector<int> partial;
+            for (std::size_t i = 0; i < list.size(); ++i) {
+                const std::string entry = toLower(stem(list[i]));
+                if (entry.empty()) {
+                    continue;
+                }
+                if (entry == needle) {
+                    exact.push_back(static_cast<int>(i));
+                } else if (!needle.empty() && entry.find(needle) != std::string::npos) {
+                    partial.push_back(static_cast<int>(i));
+                }
+            }
+            if (exact.size() == 1) {
+                return { exact.front(), {}, {}, false };
+            }
+            if (!exact.empty()) {
+                return { -1, exact, {}, false }; // scripts.lst genuinely lists the same basename twice
+            }
+            if (partial.size() == 1) {
+                // Exactly one entry contains the fragment, so there is nothing to choose between —
+                // resolve it, and flag that it came from a fragment so the caller can see what it got.
+                return { partial.front(), {}, {}, true };
+            }
+            if (!partial.empty()) {
+                return { -1, partial, {}, false };
+            }
+            return { -1, {}, "no script named '" + name + "' in scripts.lst", false };
+        }
+        if (programIndex < 0 || programIndex >= static_cast<int>(list.size())) {
+            return { -1, {},
+                "program index " + std::to_string(programIndex) + " out of range (have "
+                    + std::to_string(list.size())
+                    + " scripts). Note the SCRIPT_* constants in headers/scripts.h are 1-based: subtract 1, "
+                      "or pass 'name' instead",
+                false };
+        }
+        return { programIndex, {}, {}, false };
+    }
+
+    // A candidate-list result: the caller gave a fragment that names several scripts, so report them
+    // rather than picking one.
+    ordered_json ambiguousResult(resource::GameResources& resources, const Lst& scripts,
+        const std::string& query, const std::vector<int>& candidates) {
+        ordered_json root;
+        root["query"] = query;
+        root["ambiguous"] = true;
+        auto matches = ordered_json::array();
+        for (const int index : candidates) {
+            matches.push_back(scriptIdentity(resources, scripts, index));
+        }
+        root["matches"] = std::move(matches);
+        root["hint"] = "several scripts.lst entries match that name; re-run with an exact 'name' or a 'programIndex'";
+        return root;
+    }
+
+    void emit(std::ostream& out, const ordered_json& root) {
+        // Fallout 2 text is CP-1252, not UTF-8; `replace` substitutes U+FFFD for stray bytes so dump()
+        // emits valid JSON instead of throwing on e.g. 0x85 ("…").
+        out << root.dump(-1, ' ', false, ordered_json::error_handler_t::replace) << "\n";
+    }
+
+    // --- find_script -------------------------------------------------------------
+
+    // Every placement of `programIndex` in one map: the map's own header script, plus per-section
+    // map_scripts counts. Returns nullopt when the map does not reference the script at all.
+    std::optional<ordered_json> placementsIn(const Map& map, int programIndex) {
+        const auto& mapFile = map.getMapFile();
+        // The header's script_id is 1-based (the engine runs scripts.lst[script_id - 1], fallout2-ce
+        // map.cc), unlike MapScript::script_id below, which is already the 0-based program index.
+        const bool asMapScript = mapFile.header.script_id > 0
+            && mapFile.header.script_id - 1 == programIndex;
+
+        auto sections = ordered_json::array();
+        int total = 0;
+        for (int section = 0; section < Map::SCRIPT_SECTIONS; ++section) {
+            int count = 0;
+            for (const MapScript& script : mapFile.map_scripts[section]) {
+                if (static_cast<int>(script.script_id) == programIndex) {
+                    ++count;
+                }
+            }
+            if (count > 0) {
+                // The map_scripts section index is the script type (MapScript.h).
+                const auto type = static_cast<MapScript::ScriptType>(section);
+                sections.push_back({ { "section", std::string(MapScript::toString(type)) }, { "count", count } });
+                total += count;
+            }
+        }
+        if (!asMapScript && total == 0) {
+            return std::nullopt;
+        }
+        ordered_json entry;
+        entry["asMapScript"] = asMapScript;
+        entry["sections"] = std::move(sections);
+        entry["instances"] = total;
+        return entry;
+    }
+
+    // maps.txt/map.msg lookup, or nullopt when maps.txt isn't mounted (friendly names are a bonus,
+    // never a reason to fail the scan).
+    std::optional<resource::MapNameResolver> makeNameResolver(resource::GameResources& resources) {
+        try {
+            return resource::MapNameResolver(resources);
+        } catch (const std::exception& e) {
+            spdlog::debug("find-script: no map name resolver: {}", e.what());
+            return std::nullopt;
+        }
+    }
+
+    // --- find_text ---------------------------------------------------------------
+
+    // Substring (default) or ECMAScript-regex matching, case-insensitive unless asked otherwise.
+    class TextMatcher {
+    public:
+        static std::optional<TextMatcher> make(const FindTextOptions& options, std::string& error) {
+            TextMatcher matcher;
+            matcher._useRegex = options.regex;
+            matcher._caseSensitive = options.caseSensitive;
+            if (options.regex) {
+                auto flags = std::regex::ECMAScript;
+                if (!options.caseSensitive) {
+                    flags |= std::regex::icase;
+                }
+                try {
+                    matcher._regex = std::regex(options.pattern, flags);
+                } catch (const std::regex_error& e) {
+                    error = std::string("invalid regex: ") + e.what();
+                    return std::nullopt;
+                }
+            } else {
+                matcher._needle = options.caseSensitive ? options.pattern : toLower(options.pattern);
+            }
+            return matcher;
+        }
+
+        [[nodiscard]] bool matches(const std::string& haystack) const {
+            if (_useRegex) {
+                return std::regex_search(haystack, _regex);
+            }
+            if (_caseSensitive) {
+                return haystack.find(_needle) != std::string::npos;
+            }
+            return toLower(haystack).find(_needle) != std::string::npos;
+        }
+
+    private:
+        bool _useRegex = false;
+        bool _caseSensitive = false;
+        std::string _needle;
+        std::regex _regex;
+    };
+
+    // Which corpora a scope name selects.
+    struct TextScope {
+        bool dialog = false;
+        bool game = false;
+        bool source = false;
+    };
+
+    TextScope parseScope(const std::string& scope) {
+        if (scope == "dialog") {
+            return { true, false, false };
+        }
+        if (scope == "game") {
+            return { false, true, false };
+        }
+        if (scope == "source") {
+            return { false, false, true };
+        }
+        return { true, true, true }; // "all", and anything unrecognised
+    }
+
+    // VFS paths come back with a leading slash ("/text/english/dialog/x.msg") whose presence depends
+    // on the mount, so compare against the path with it stripped.
+    bool hasPrefix(const std::string& path, const std::string& prefix) {
+        const std::string_view rest = std::string_view(path).substr(path.starts_with('/') ? 1 : 0);
+        return rest.size() >= prefix.size() && toLower(std::string(rest.substr(0, prefix.size()))) == prefix;
+    }
+
+    std::string extensionOf(const std::filesystem::path& path) {
+        return toLower(path.extension().string());
+    }
+
+    std::string trimmed(const std::string& line) {
+        const auto first = line.find_first_not_of(" \t\r\n");
+        if (first == std::string::npos) {
+            return {};
+        }
+        const auto last = line.find_last_not_of(" \t\r\n");
+        return line.substr(first, last - first + 1);
+    }
+
+    // Accumulates hits up to the caller's limit, so a broad pattern truncates instead of flooding.
+    struct MatchSink {
+        ordered_json matches = ordered_json::array();
+        int limit = 0;
+        int total = 0;
+        int filesSearched = 0;
+
+        [[nodiscard]] bool full() const { return total >= limit; }
+        void add(ordered_json match) {
+            ++total;
+            if (static_cast<int>(matches.size()) < limit) {
+                matches.push_back(std::move(match));
+            }
+        }
+    };
+
+    void searchMsg(resource::GameResources& resources, const std::string& path, const char* kind,
+        const TextMatcher& matcher, MatchSink& sink) {
+        const Msg* msg = nullptr;
+        try {
+            msg = resources.repository().load<Msg>(path);
+        } catch (const std::exception& e) {
+            spdlog::debug("find-text: cannot read {}: {}", path, e.what());
+            return;
+        }
+        if (msg == nullptr) {
+            return;
+        }
+        ++sink.filesSearched;
+        for (const auto& [id, message] : msg->getMessages()) {
+            if (sink.full()) {
+                return;
+            }
+            if (matcher.matches(message.text)) {
+                sink.add({ { "kind", kind }, { "script", stem(path) }, { "path", path },
+                    { "id", id }, { "text", message.text } });
+            }
+        }
+    }
+
+    void searchSource(resource::GameResources& resources, const std::string& path,
+        const TextMatcher& matcher, MatchSink& sink) {
+        const auto bytes = resources.files().readRawBytes(path);
+        if (!bytes.has_value()) {
+            return;
+        }
+        ++sink.filesSearched;
+        const std::string text(bytes->begin(), bytes->end());
+        std::size_t lineStart = 0;
+        int lineNumber = 1;
+        while (lineStart <= text.size() && !sink.full()) {
+            const std::size_t lineEnd = text.find('\n', lineStart);
+            const std::string line = text.substr(lineStart,
+                (lineEnd == std::string::npos ? text.size() : lineEnd) - lineStart);
+            if (matcher.matches(line)) {
+                sink.add({ { "kind", "source" }, { "script", stem(path) }, { "path", path },
+                    { "line", lineNumber }, { "text", trimmed(line) } });
+            }
+            if (lineEnd == std::string::npos) {
+                break;
+            }
+            lineStart = lineEnd + 1;
+            ++lineNumber;
+        }
+    }
 } // namespace
 
 int describeScript(resource::GameResources& resources, const DescribeScriptOptions& options, std::ostream& out) {
-    const Lst* scripts = nullptr;
-    try {
-        scripts = resources.repository().load<Lst>(ResourcePaths::Lst::SCRIPTS);
-    } catch (const std::exception& e) {
-        spdlog::debug("describe-script: scripts.lst load failed: {}", e.what());
-    }
+    const Lst* scripts = loadScriptsLst(resources);
     if (scripts == nullptr) {
         out << "describe-script: scripts.lst not found (is the Fallout 2 data mounted?)\n";
         return 1;
     }
-    const auto& list = scripts->list();
-    if (options.programIndex < 0 || options.programIndex >= static_cast<int>(list.size())) {
-        out << "describe-script: program index " << options.programIndex << " out of range (have "
-            << list.size() << " scripts)\n";
+    const Resolution resolved = resolveScript(*scripts, options.name, options.programIndex);
+    if (!resolved.error.empty()) {
+        out << "describe-script: " << resolved.error << "\n";
+        return 1;
+    }
+    if (resolved.programIndex < 0) {
+        emit(out, ambiguousResult(resources, *scripts, options.name, resolved.candidates));
         return 1;
     }
 
     // programIndex is the 0-based scripts.lst index (== a critter/object's MapScript.script_id), which
     // the engine's scriptsGetFileName and the editor's SelectionPanel both index directly. The Lst
     // reader already strips the trailing comment, so the entry is just the script filename.
-    const std::string& filename = list[static_cast<std::size_t>(options.programIndex)];
-    const std::string basename = stem(filename);
-
-    ordered_json root;
-    root["programIndex"] = options.programIndex;
-    root["filename"] = filename;
-    root["name"] = basename;
+    ordered_json root = scriptIdentity(resources, *scripts, resolved.programIndex);
+    if (resolved.fromFragment) {
+        root["matchedFragment"] = options.name;
+    }
+    const std::string basename = root["name"].get<std::string>();
     attachSource(resources, basename, root);
     root["dialog"] = loadDialog(resources, basename, options.locale);
-    // Fallout 2 text is CP-1252, not UTF-8; `replace` substitutes U+FFFD for stray bytes so dump()
-    // emits valid JSON instead of throwing on e.g. 0x85 ("…").
-    out << root.dump(-1, ' ', false, ordered_json::error_handler_t::replace) << "\n";
+    emit(out, root);
+    return 0;
+}
+
+int findScript(resource::GameResources& resources, const FindScriptOptions& options, std::ostream& out) {
+    const Lst* scripts = loadScriptsLst(resources);
+    if (scripts == nullptr) {
+        out << "find-script: scripts.lst not found (is the Fallout 2 data mounted?)\n";
+        return 1;
+    }
+    const Resolution resolved = resolveScript(*scripts, options.name, options.programIndex);
+    if (!resolved.error.empty()) {
+        out << "find-script: " << resolved.error << "\n";
+        return 1;
+    }
+    if (resolved.programIndex < 0) {
+        // A fragment that names several scripts is a useful answer in itself, not a failure: the
+        // candidate list is how you go from a half-remembered name to an exact one.
+        emit(out, ambiguousResult(resources, *scripts, options.name, resolved.candidates));
+        return 0;
+    }
+
+    ordered_json root;
+    root["script"] = scriptIdentity(resources, *scripts, resolved.programIndex);
+    if (resolved.fromFragment) {
+        root["matchedFragment"] = options.name;
+    }
+    if (options.resolveOnly) {
+        root["placements"] = nullptr;
+        root["note"] = "resolveOnly: the map scan was skipped";
+        emit(out, root);
+        return 0;
+    }
+
+    const std::vector<std::string> mapPaths = options.maps.empty()
+        ? listMapPaths(resources.files())
+        : options.maps;
+    const auto names = makeNameResolver(resources);
+    auto placements = ordered_json::array();
+    auto unreadable = ordered_json::array();
+    int mapsScanned = 0;
+    int instances = 0;
+    for (const auto& mapPath : mapPaths) {
+        std::string loadError;
+        const std::unique_ptr<Map> map = loadMap(resources, mapPath, &loadError);
+        if (map == nullptr) {
+            // A partial scan beats no answer, but a silently skipped map could be the one holding the
+            // script, so absence of placements is only trustworthy alongside this list.
+            unreadable.push_back({ { "map", mapPath }, { "reason", loadError } });
+            continue;
+        }
+        ++mapsScanned;
+        auto entry = placementsIn(*map, resolved.programIndex);
+        if (!entry.has_value()) {
+            continue;
+        }
+        std::string display;
+        if (names.has_value()) {
+            const int index = names->indexOf(std::filesystem::path(mapPath).filename().string());
+            if (index >= 0) {
+                display = names->displayName(index, 0);
+            }
+        }
+        ordered_json placement;
+        placement["map"] = mapPath;
+        placement["displayName"] = display.empty() ? ordered_json(nullptr) : ordered_json(display);
+        placement.update(*entry);
+        instances += (*entry)["instances"].get<int>();
+        placements.push_back(std::move(placement));
+    }
+    root["placements"] = std::move(placements);
+    root["mapCount"] = static_cast<int>(root["placements"].size());
+    root["instanceCount"] = instances;
+    root["mapsScanned"] = mapsScanned;
+    root["mapsUnreadable"] = std::move(unreadable);
+    emit(out, root);
+    return 0;
+}
+
+int findText(resource::GameResources& resources, const FindTextOptions& options, std::ostream& out) {
+    if (options.pattern.empty()) {
+        out << "find-text: 'pattern' must not be empty\n";
+        return 1;
+    }
+    std::string error;
+    const auto matcher = TextMatcher::make(options, error);
+    if (!matcher.has_value()) {
+        out << "find-text: " << error << "\n";
+        return 1;
+    }
+
+    const TextScope scope = parseScope(options.scope);
+    const std::string dialogPrefix = "text/" + toLower(options.locale) + "/dialog/";
+    const std::string gamePrefix = "text/" + toLower(options.locale) + "/game/";
+
+    std::vector<std::string> msgDialog;
+    std::vector<std::string> msgGame;
+    std::vector<std::string> sslPaths;
+    for (const auto& path : resources.files().list("*")) {
+        const std::string generic = path.generic_string();
+        const std::string ext = extensionOf(path);
+        if (ext == ".msg") {
+            if (scope.dialog && hasPrefix(generic, dialogPrefix)) {
+                msgDialog.push_back(generic);
+            } else if (scope.game && hasPrefix(generic, gamePrefix)) {
+                msgGame.push_back(generic);
+            }
+        } else if (ext == ".ssl" && scope.source) {
+            sslPaths.push_back(generic);
+        }
+    }
+    std::ranges::sort(msgDialog);
+    std::ranges::sort(msgGame);
+    std::ranges::sort(sslPaths);
+
+    MatchSink sink;
+    sink.limit = options.limit > 0 ? options.limit : 200;
+    for (const auto& path : msgDialog) {
+        if (sink.full()) {
+            break;
+        }
+        searchMsg(resources, path, "dialog", *matcher, sink);
+    }
+    for (const auto& path : msgGame) {
+        if (sink.full()) {
+            break;
+        }
+        searchMsg(resources, path, "game", *matcher, sink);
+    }
+    for (const auto& path : sslPaths) {
+        if (sink.full()) {
+            break;
+        }
+        searchSource(resources, path, *matcher, sink);
+    }
+
+    ordered_json root;
+    root["pattern"] = options.pattern;
+    root["scope"] = options.scope;
+    root["regex"] = options.regex;
+    root["caseSensitive"] = options.caseSensitive;
+    root["filesSearched"] = sink.filesSearched;
+    root["matchCount"] = static_cast<int>(sink.matches.size());
+    root["truncated"] = sink.full();
+    root["matches"] = std::move(sink.matches);
+    emit(out, root);
     return 0;
 }
 

--- a/src/cli/ScriptIntrospect.cpp
+++ b/src/cli/ScriptIntrospect.cpp
@@ -338,6 +338,9 @@ namespace {
         }
     };
 
+    // `kind` is "dialog" (a per-script .msg, so the basename IS the script) or "game" (item/perk/quest
+    // text owned by no script). Only the former gets a `script`, so a caller cannot feed "perk" into
+    // describe_script and get an unrelated hit; `file` is always the basename.
     void searchMsg(resource::GameResources& resources, const std::string& path, const char* kind,
         const TextMatcher& matcher, MatchSink& sink) {
         const Msg* msg = nullptr;
@@ -356,8 +359,10 @@ namespace {
                 return;
             }
             if (matcher.matches(message.text)) {
-                sink.add({ { "kind", kind }, { "script", stem(path) }, { "path", path },
-                    { "id", id }, { "text", message.text } });
+                const bool scriptOwned = std::string_view(kind) == "dialog";
+                sink.add({ { "kind", kind },
+                    { "script", scriptOwned ? ordered_json(stem(path)) : ordered_json(nullptr) },
+                    { "file", stem(path) }, { "path", path }, { "id", id }, { "text", message.text } });
             }
         }
     }
@@ -377,8 +382,8 @@ namespace {
             const std::string line = text.substr(lineStart,
                 (lineEnd == std::string::npos ? text.size() : lineEnd) - lineStart);
             if (matcher.matches(line)) {
-                sink.add({ { "kind", "source" }, { "script", stem(path) }, { "path", path },
-                    { "line", lineNumber }, { "text", trimmed(line) } });
+                sink.add({ { "kind", "source" }, { "script", stem(path) }, { "file", stem(path) },
+                    { "path", path }, { "line", lineNumber }, { "text", trimmed(line) } });
             }
             if (lineEnd == std::string::npos) {
                 break;
@@ -401,8 +406,10 @@ int describeScript(resource::GameResources& resources, const DescribeScriptOptio
         return 1;
     }
     if (resolved.programIndex < 0) {
+        // The candidate list is a usable answer, not a failure: returning nonzero would make the MCP
+        // wrapper flag isError and contradict the tool's own contract. findScript agrees.
         emit(out, ambiguousResult(resources, *scripts, options.name, resolved.candidates));
-        return 1;
+        return 0;
     }
 
     // programIndex is the 0-based scripts.lst index (== a critter/object's MapScript.script_id), which

--- a/src/cli/ScriptIntrospect.h
+++ b/src/cli/ScriptIntrospect.h
@@ -2,6 +2,7 @@
 
 #include <iosfwd>
 #include <string>
+#include <vector>
 
 namespace geck {
 namespace resource {
@@ -10,18 +11,91 @@ namespace resource {
 
 namespace cli {
 
+    /// # Script index bases
+    ///
+    /// Three different numbers name the same Fallout 2 script, and only one of them is what this
+    /// module takes. Getting this wrong does not fail loudly — it returns the *neighbouring*
+    /// script — so it is spelled out here once:
+    ///
+    /// | Number                                 | Base    | Where it lives                                                     |
+    /// |----------------------------------------|---------|--------------------------------------------------------------------|
+    /// | `programIndex` — what gecko speaks     | 0-based | the `scripts.lst` array index, and an object's `MapScript::script_id` |
+    /// | map header `script_id`                 | 1-based | `MapFile::MapHeader::script_id`                                    |
+    /// | SSL `SCRIPT_*` (FRP `headers/scripts.h`) | 1-based | the `scripts.lst` *line* number; also sfall `set_script()` ids      |
+    ///
+    /// gecko speaks the engine's internal 0-based index everywhere, because that is the number
+    /// actually stored in map files and the one the engine indexes `scripts.lst` with
+    /// (fallout2-ce `scripts.cc`, `scriptsGetFileName`). This is deliberate, and required by the
+    /// engine-fidelity rule: stored ids are preserved exactly as the engine stores them rather than
+    /// re-based for convenience. The 1-based forms are the engine's own inputs, and the engine
+    /// itself decrements them — so gecko normalises on the way in, in the same two places:
+    ///
+    ///  - map header: `MapAnalyzer` resolves `script_id - 1` (fallout2-ce `map.cc`,
+    ///    `script->index = gMapHeader.scriptIndex - 1`);
+    ///  - sfall `set_script()`: the opcode decrements before validating (fallout2-ce
+    ///    `sfall_opcodes.cc`).
+    ///
+    /// The trap in practice: `SCRIPT_EPAC17 (1413)` in `headers/scripts.h` is `programIndex`
+    /// **1412**. Passing the constant through unadjusted names `epac18` — a plausible wrong answer,
+    /// never an error. So every entry point here also accepts a `name`, which is unambiguous, and
+    /// every result echoes `sslConstant` (== `programIndex + 1`) so the two can be cross-checked at
+    /// a glance.
+
     struct DescribeScriptOptions {
-        int programIndex = -1;          ///< 0-based scripts.lst index (== a critter/object's MapScript.script_id); -1 = unset
+        /// 0-based scripts.lst index (== a critter/object's `MapScript::script_id`); -1 = unset.
+        /// Ignored when `name` is set.
+        int programIndex = -1;
+        /// scripts.lst basename, case-insensitive and with any extension ignored ("epac17",
+        /// "EPAC17.int"). Preferred over `programIndex`: no index base to get wrong.
+        std::string name;
         std::string locale = "english"; ///< dialog .msg locale subdirectory
     };
 
-    /// Describe a Fallout 2 script by its scripts.lst program index (0-based, as analyze reports it
-    /// for a critter/object): resolve the filename, read the `.ssl` source if a source tree is mounted
-    /// (e.g. the FRP scripts_src), and load the dialog `.msg`. Resolution keys off the filename
-    /// basename (case-insensitive) — the name the engine itself uses — not SCRIPT_REALNAME. Emits a
-    /// JSON object to `out`; returns 0 on success, nonzero with a message on a hard error (no
-    /// scripts.lst, index out of range).
+    /// Describe a Fallout 2 script, selected by `name` or by 0-based `programIndex` (see the index-base
+    /// note above): resolve the filename, read the `.ssl` source if a source tree is mounted (e.g. the
+    /// FRP scripts_src), and load the dialog `.msg`. Resolution keys off the filename basename
+    /// (case-insensitive) — the name the engine itself uses — not SCRIPT_REALNAME. Emits a JSON object
+    /// to `out`; returns 0 on success, nonzero with a message on a hard error (no scripts.lst, unknown
+    /// name, index out of range).
     int describeScript(resource::GameResources& resources, const DescribeScriptOptions& options, std::ostream& out);
+
+    struct FindScriptOptions {
+        /// 0-based scripts.lst index; -1 = unset. Ignored when `name` is set.
+        int programIndex = -1;
+        /// scripts.lst basename, or a fragment of one. An exact (case-insensitive) basename match
+        /// selects that script; otherwise every entry containing the fragment is returned as a
+        /// candidate list and no map scan runs.
+        std::string name;
+        /// Scope the placement scan to these map VFS paths (e.g. "maps/epa1.map"); empty = every
+        /// mounted map.
+        std::vector<std::string> maps;
+        /// Skip the map scan and only resolve the script's identity. Cheap; use when all you need is
+        /// the index<->name mapping.
+        bool resolveOnly = false;
+    };
+
+    /// Find a script by name (or index) and report where the shipped maps actually place it: the map's
+    /// own header script, plus every `map_scripts` entry, per section. The inverse of describe_script —
+    /// "which map is this NPC on?" rather than "what does this script say?". Emits a JSON object to
+    /// `out`; returns 0 on success (including a no-placements or candidate-list result), nonzero on a
+    /// hard error (no scripts.lst, unknown name, index out of range).
+    int findScript(resource::GameResources& resources, const FindScriptOptions& options, std::ostream& out);
+
+    struct FindTextOptions {
+        std::string pattern; ///< required; substring by default, ECMAScript regex when `regex`
+        bool regex = false;
+        bool caseSensitive = false;
+        /// "dialog" (per-script dialog .msg), "game" (game/*.msg — item, perk, quest text), "source"
+        /// (.ssl, needs a source tree mounted), or "all".
+        std::string scope = "all";
+        std::string locale = "english";
+        int limit = 200; ///< max matches emitted; the result flags `truncated` when it bites
+    };
+
+    /// Search the mounted game text for `pattern` and report every hit with the script it belongs to,
+    /// so "which script mentions X?" is one call instead of a grep over a checkout. Emits a JSON object
+    /// to `out`; returns 0 on success (including no matches), nonzero on a hard error (bad regex).
+    int findText(resource::GameResources& resources, const FindTextOptions& options, std::ostream& out);
 
 } // namespace cli
 } // namespace geck

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -252,14 +252,52 @@ namespace {
         return runAnalyze(resources, args, /*paletteOnly*/ true);
     }
 
+    // A script selector: 'name' (unambiguous) or the 0-based 'programIndex'. One of the two is
+    // required — defaulting to index 0 would silently describe obj_dude instead of erroring.
+    void readScriptSelector(const json& args, std::string& name, int& programIndex) {
+        name = optString(args, "name");
+        programIndex = static_cast<int>(optInt(args, "programIndex", -1, -1, INT32_MAX));
+        if (name.empty() && programIndex < 0) {
+            throw ToolError{ "pass 'name' (e.g. \"epac17\") or a 0-based 'programIndex'. Note the "
+                             "SCRIPT_* constants in headers/scripts.h are 1-based: subtract 1" };
+        }
+    }
+
     json toolDescribeScript(resource::GameResources& resources, const json& args) {
         cli::DescribeScriptOptions opts;
-        opts.programIndex = static_cast<int>(requireInt(args, "programIndex", 0, INT32_MAX));
+        readScriptSelector(args, opts.name, opts.programIndex);
         if (const std::string locale = optString(args, "locale"); !locale.empty()) {
             opts.locale = locale;
         }
         std::ostringstream oss;
         const int rc = cli::describeScript(resources, opts, oss);
+        return toolText(oss.str(), rc != 0);
+    }
+
+    json toolFindScript(resource::GameResources& resources, const json& args) {
+        cli::FindScriptOptions opts;
+        readScriptSelector(args, opts.name, opts.programIndex);
+        opts.maps = optMaps(args);
+        opts.resolveOnly = optBool(args, "resolveOnly", false);
+        std::ostringstream oss;
+        const int rc = cli::findScript(resources, opts, oss);
+        return toolText(oss.str(), rc != 0);
+    }
+
+    json toolFindText(resource::GameResources& resources, const json& args) {
+        cli::FindTextOptions opts;
+        opts.pattern = requireString(args, "pattern");
+        opts.regex = optBool(args, "regex", false);
+        opts.caseSensitive = optBool(args, "caseSensitive", false);
+        opts.limit = static_cast<int>(optInt(args, "limit", 200, 1, 5000));
+        if (const std::string scope = optString(args, "scope"); !scope.empty()) {
+            opts.scope = scope;
+        }
+        if (const std::string locale = optString(args, "locale"); !locale.empty()) {
+            opts.locale = locale;
+        }
+        std::ostringstream oss;
+        const int rc = cli::findText(resources, opts, oss);
         return toolText(oss.str(), rc != 0);
     }
 
@@ -640,14 +678,45 @@ namespace {
             json({ { "type", "object" }, { "properties", { { "pid", { { "type", "integer" } } } } }, { "required", json::array({ "pid" }) } }),
             [](resource::GameResources& r, const json& a) { return toolProtoInfo(r, a); }, "" });
         t.push_back({ "describe_script",
-            "Describe a Fallout 2 script by its scripts.lst program index (the 0-based script_id "
-            "analyze reports for a critter/object). Returns the filename, the .ssl source if a "
-            "script-source tree is mounted (e.g. the FRP scripts_src — hasSource flags whether it was "
-            "found), and the dialog .msg lines ([{id,text}]). Lets you read what an NPC does and says. "
-            "Optional 'locale' picks the dialog language subdir (default english). Args: programIndex, "
-            "optional locale.",
-            json({ { "type", "object" }, { "properties", { { "programIndex", { { "type", "integer" } } }, { "locale", { { "type", "string" } } } } }, { "required", json::array({ "programIndex" }) } }),
+            "Read one script: its .ssl source (when a source tree such as the FRP scripts_src is "
+            "mounted — hasSource flags whether it was found) and its dialog .msg lines ([{id,text}]), "
+            "so you can see what an NPC does and says. Select it by 'name' — the scripts.lst basename, "
+            "e.g. epac17, which is unambiguous, and a fragment comes back as a candidate list — or by "
+            "the 0-based 'programIndex' that analyze/describe_map report as a critter's script_id. "
+            "INDEX BASE, worth getting right: programIndex is the engine's own 0-based scripts.lst "
+            "index, while the SCRIPT_* constants in the FRP headers/scripts.h are 1-based line numbers, "
+            "so SCRIPT_EPAC17 (1413) is programIndex 1412 — passing such a constant unadjusted names "
+            "the NEXT script rather than failing. Every result echoes 'sslConstant' (= programIndex + "
+            "1) so the two can be cross-checked. Optional 'locale' picks the dialog language subdir "
+            "(default english). Args: name or programIndex, optional locale.",
+            json({ { "type", "object" }, { "properties", { { "name", { { "type", "string" } } }, { "programIndex", { { "type", "integer" } } }, { "locale", { { "type", "string" } } } } } }),
             [](resource::GameResources& r, const json& a) { return toolDescribeScript(r, a); }, "" });
+        t.push_back({ "find_script",
+            "Find WHERE a script lives: resolve it by 'name' (or 0-based 'programIndex', same index "
+            "base as describe_script) and report every shipped map that places it — the map's own "
+            "header script ('asMapScript') plus per-section map_scripts counts ([{section,count}]) and "
+            "an 'instances' total. The inverse of describe_script: which map is this NPC on, rather "
+            "than what does this script say. A 'name' fragment matching several scripts.lst entries "
+            "returns {ambiguous:true, matches:[...]} instead of guessing — which is also how you get "
+            "from a half-remembered name to an exact one. Scans every mounted map by default (a few "
+            "seconds); pass 'maps' to scope it, or resolveOnly=true to skip the scan and just get the "
+            "programIndex<->name mapping. Args: name or programIndex, optional maps (array), "
+            "resolveOnly.",
+            json({ { "type", "object" }, { "properties", { { "name", { { "type", "string" } } }, { "programIndex", { { "type", "integer" } } }, { "maps", { { "type", "array" }, { "items", { { "type", "string" } } } } }, { "resolveOnly", { { "type", "boolean" } } } } } }),
+            [](resource::GameResources& r, const json& a) { return toolFindScript(r, a); }, "" });
+        t.push_back({ "find_text",
+            "Search the mounted game text for a pattern and get every hit back with the script it "
+            "belongs to — answers which script mentions X in one call, instead of grepping a checkout. "
+            "'scope' picks the corpus: dialog (the per-script dialog .msg), game (game/*.msg — item, "
+            "perk and quest text), source (.ssl, needs a script-source tree mounted) or all (default). "
+            "Matches are [{kind,script,path,id|line,text}]: dialog/game hits carry the message 'id', "
+            "source hits the 'line' number, and 'script' is the basename to hand straight to "
+            "describe_script or find_script. Substring and case-insensitive by default; set regex=true "
+            "for ECMAScript syntax, caseSensitive=true to respect case. 'limit' caps the matches "
+            "(default 200) and 'truncated' says whether it bit. Args: pattern (required), optional "
+            "scope, regex, caseSensitive, limit, locale.",
+            json({ { "type", "object" }, { "properties", { { "pattern", { { "type", "string" } } }, { "scope", { { "type", "string" } } }, { "regex", { { "type", "boolean" } } }, { "caseSensitive", { { "type", "boolean" } } }, { "limit", { { "type", "integer" } } }, { "locale", { { "type", "string" } } } } }, { "required", json::array({ "pattern" }) } }),
+            [](resource::GameResources& r, const json& a) { return toolFindText(r, a); }, "" });
         t.push_back({ "reachability",
             "Per-elevation reachability for one map. Floods walkable hexes from the entry points "
             "(player start + exit grids — you can arrive at an exit coming from the adjacent map): "

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -681,7 +681,8 @@ namespace {
             "Read one script: its .ssl source (when a source tree such as the FRP scripts_src is "
             "mounted — hasSource flags whether it was found) and its dialog .msg lines ([{id,text}]), "
             "so you can see what an NPC does and says. Select it by 'name' — the scripts.lst basename, "
-            "e.g. epac17, which is unambiguous, and a fragment comes back as a candidate list — or by "
+            "e.g. epac17, which is unambiguous, and a fragment comes back as a successful "
+            "{ambiguous:true, matches:[...]} result rather than a guess — or by "
             "the 0-based 'programIndex' that analyze/describe_map report as a critter's script_id. "
             "INDEX BASE, worth getting right: programIndex is the engine's own 0-based scripts.lst "
             "index, while the SCRIPT_* constants in the FRP headers/scripts.h are 1-based line numbers, "
@@ -689,7 +690,7 @@ namespace {
             "the NEXT script rather than failing. Every result echoes 'sslConstant' (= programIndex + "
             "1) so the two can be cross-checked. Optional 'locale' picks the dialog language subdir "
             "(default english). Args: name or programIndex, optional locale.",
-            json({ { "type", "object" }, { "properties", { { "name", { { "type", "string" } } }, { "programIndex", { { "type", "integer" } } }, { "locale", { { "type", "string" } } } } } }),
+            json({ { "type", "object" }, { "properties", { { "name", { { "type", "string" } } }, { "programIndex", { { "type", "integer" } } }, { "locale", { { "type", "string" } } } } }, { "anyOf", json::array({ json{ { "required", json::array({ "name" }) } }, json{ { "required", json::array({ "programIndex" }) } } }) } }),
             [](resource::GameResources& r, const json& a) { return toolDescribeScript(r, a); }, "" });
         t.push_back({ "find_script",
             "Find WHERE a script lives: resolve it by 'name' (or 0-based 'programIndex', same index "
@@ -702,16 +703,17 @@ namespace {
             "seconds); pass 'maps' to scope it, or resolveOnly=true to skip the scan and just get the "
             "programIndex<->name mapping. Args: name or programIndex, optional maps (array), "
             "resolveOnly.",
-            json({ { "type", "object" }, { "properties", { { "name", { { "type", "string" } } }, { "programIndex", { { "type", "integer" } } }, { "maps", { { "type", "array" }, { "items", { { "type", "string" } } } } }, { "resolveOnly", { { "type", "boolean" } } } } } }),
+            json({ { "type", "object" }, { "properties", { { "name", { { "type", "string" } } }, { "programIndex", { { "type", "integer" } } }, { "maps", { { "type", "array" }, { "items", { { "type", "string" } } } } }, { "resolveOnly", { { "type", "boolean" } } } } }, { "anyOf", json::array({ json{ { "required", json::array({ "name" }) } }, json{ { "required", json::array({ "programIndex" }) } } }) } }),
             [](resource::GameResources& r, const json& a) { return toolFindScript(r, a); }, "" });
         t.push_back({ "find_text",
             "Search the mounted game text for a pattern and get every hit back with the script it "
             "belongs to — answers which script mentions X in one call, instead of grepping a checkout. "
             "'scope' picks the corpus: dialog (the per-script dialog .msg), game (game/*.msg — item, "
             "perk and quest text), source (.ssl, needs a script-source tree mounted) or all (default). "
-            "Matches are [{kind,script,path,id|line,text}]: dialog/game hits carry the message 'id', "
-            "source hits the 'line' number, and 'script' is the basename to hand straight to "
-            "describe_script or find_script. Substring and case-insensitive by default; set regex=true "
+            "Matches are [{kind,script,file,path,id|line,text}]: dialog/game hits carry the message "
+            "'id', source hits the 'line' number. 'script' is the basename to hand straight to "
+            "describe_script or find_script, and is NULL for game/*.msg hits, which are item/perk/quest "
+            "text owned by no script — use 'file' there. Substring and case-insensitive by default; set regex=true "
             "for ECMAScript syntax, caseSensitive=true to respect case. 'limit' caps the matches "
             "(default 200) and 'truncated' says whether it bit. Args: pattern (required), optional "
             "scope, regex, caseSensitive, limit, locale.",

--- a/src/reader/map/MapReader.cpp
+++ b/src/reader/map/MapReader.cpp
@@ -41,6 +41,18 @@ std::unique_ptr<MapObject> MapReader::readMapObject() {
 
     auto pro = _proLoadCallback(object->pro_pid);
 
+    // ITEM and SCENERY read a type-specific tail whose LENGTH depends on the proto's subtype, so a
+    // missing proto is not a cosmetic gap: guessing the tail would desynchronise the stream and
+    // corrupt every object after it. Fail explicitly and name the PID (per the engine-data rule —
+    // no substitute values), so the answer is "this proto is not mounted", not a silent bad parse.
+    if (pro == nullptr
+        && (static_cast<Pro::OBJECT_TYPE>(objectTypeId) == Pro::OBJECT_TYPE::ITEM
+            || static_cast<Pro::OBJECT_TYPE>(objectTypeId) == Pro::OBJECT_TYPE::SCENERY)) {
+        throw ParseException("proto " + std::to_string(object->pro_pid) + " (type " + std::to_string(objectTypeId)
+                + ", index " + std::to_string(object->protoId()) + ") could not be loaded, so its object tail length is unknown",
+            _path, _stream.position());
+    }
+
     switch (static_cast<Pro::OBJECT_TYPE>(objectTypeId)) {
         case Pro::OBJECT_TYPE::ITEM: {
             uint32_t subtype_id = pro->objectSubtypeId();
@@ -61,7 +73,9 @@ std::unique_ptr<MapObject> MapReader::readMapObject() {
                 case Pro::ITEM_TYPE::DRUG:
                     break;
                 default:
-                    throw std::runtime_error{ "Unknown item type " + std::to_string(objectTypeId) };
+                    throw ParseException("Unknown item type " + std::to_string(subtype_id) + " for proto "
+                            + std::to_string(object->pro_pid),
+                        _path, _stream.position());
             }
         } break;
         case Pro::OBJECT_TYPE::CRITTER: {
@@ -105,7 +119,9 @@ std::unique_ptr<MapObject> MapReader::readMapObject() {
                 case Pro::SCENERY_TYPE::GENERIC:
                     break;
                 default:
-                    throw std::runtime_error{ "Unknown scenery type: " + std::to_string(subtype_id) };
+                    throw ParseException("Unknown scenery type " + std::to_string(subtype_id) + " for proto "
+                            + std::to_string(object->pro_pid),
+                        _path, _stream.position());
             }
         } break;
         case Pro::OBJECT_TYPE::WALL:
@@ -120,7 +136,9 @@ std::unique_ptr<MapObject> MapReader::readMapObject() {
             }
             break;
         default:
-            throw ParseException("Unknown object type: " + std::to_string(objectTypeId), _path, _stream.position());
+            throw ParseException("Unknown object type " + std::to_string(objectTypeId) + " for proto "
+                    + std::to_string(object->pro_pid),
+                _path, _stream.position());
     }
 
     return object;

--- a/src/reader/map/MapReader.cpp
+++ b/src/reader/map/MapReader.cpp
@@ -136,9 +136,15 @@ std::unique_ptr<MapObject> MapReader::readMapObject() {
             }
             break;
         default:
-            throw ParseException("Unknown object type " + std::to_string(objectTypeId) + " for proto "
-                    + std::to_string(object->pro_pid),
-                _path, _stream.position());
+            // The engine tolerates an object whose PID names no known type: objectDataRead
+            // (fallout2-ce proto.cc) falls out of its type switch through `default: break`, so such a
+            // record is the common block alone, with no type-specific tail — and objectDataWrite does
+            // the same on the way out. RPU's epamain1/epamain2 each carry 17 records with pid -1, and
+            // rejecting them made both maps unreadable. Keep the object, so a load/save round-trip
+            // reproduces it byte for byte.
+            spdlog::debug("Object with unrecognised type {} (pid {}) carries no type-specific data, as in the engine",
+                objectTypeId, static_cast<int32_t>(object->pro_pid));
+            break;
     }
 
     return object;

--- a/src/writer/map/MapWriter.cpp
+++ b/src/writer/map/MapWriter.cpp
@@ -315,8 +315,10 @@ void MapWriter::writeObject(const MapObject& object) {
             }
             break;
         default:
-            throw ValidationException("Unknown object type", getPath(),
-                "object type " + std::to_string(objectTypeId));
+            // Mirrors MapReader, and the engine's own objectDataWrite (fallout2-ce proto.cc): an
+            // unrecognised object type writes no type-specific tail. Emitting nothing here is what
+            // lets a map holding such records (RPU's EPA mains) round-trip unchanged.
+            break;
     }
 
     // Write inventory objects if any

--- a/tests/general/test_map_roundtrip.cpp
+++ b/tests/general/test_map_roundtrip.cpp
@@ -327,3 +327,47 @@ TEST_CASE("MAP non-exit MISC object writes no trailing exit data", "[map][roundt
     CHECK(exitObj.exit_elevation == 903);
     CHECK(exitObj.exit_orientation == 904);
 }
+
+// An object whose PID names no known type is legal, not corruption: the engine's objectDataRead and
+// objectDataWrite (fallout2-ce proto.cc) both fall out of their type switch through `default:`, so
+// such a record is the 22-field common block alone, with no type-specific tail. RPU's epamain1.map
+// and epamain2.map each carry 17 of them with pid -1, and rejecting them made both maps unreadable.
+// Reader and writer have to agree here, or every object after one shifts by the width of a tail that
+// was never on disk.
+TEST_CASE("MAP round-trip keeps an object whose PID has no known type", "[map][roundtrip]") {
+    StubProvider provider; // deliberately empty: pid -1 resolves to no proto, as in the shipped maps
+
+    auto original = Map::createEmptyMapFile();
+    auto& objects = original.map_objects[0];
+
+    auto untyped = std::make_shared<MapObject>();
+    fillBase(*untyped, 42);
+    untyped->pro_pid = 0xFFFFFFFFu; // the engine's "no proto" sentinel
+    untyped->elevation = 0;
+    objects.push_back(untyped);
+
+    // A wall behind it: if the untyped record consumed the wrong number of bytes, this one is read
+    // from the wrong offset and its base fields come back as garbage.
+    auto wall = std::make_shared<MapObject>();
+    fillBase(*wall, 43);
+    wall->pro_pid = pidOf(Pro::OBJECT_TYPE::WALL, 100);
+    wall->elevation = 0;
+    objects.push_back(wall);
+
+    TempFile mapFile{ "geck_map_roundtrip_untyped", ".map" };
+    const auto& path = mapFile.path();
+    {
+        MapWriter writer{ [&](int32_t pid) { return provider.load(static_cast<uint32_t>(pid)); } };
+        writer.openFile(path);
+        REQUIRE(writer.write(original));
+    } // destructor flushes and closes before we read it back
+
+    MapReader reader{ [&](uint32_t pid) { return provider.load(pid); } };
+    auto reloaded = reader.openFile(path);
+    REQUIRE(reloaded != nullptr);
+
+    const auto& got = reloaded->getMapFile().map_objects.at(0);
+    REQUIRE(got.size() == 2);
+    checkBase(*got[0], *untyped);
+    checkBase(*got[1], *wall);
+}

--- a/tests/general/test_mcp_server.cpp
+++ b/tests/general/test_mcp_server.cpp
@@ -36,7 +36,7 @@ TEST_CASE("McpServer speaks JSON-RPC and exposes the tools", "[mcp]") {
             names.push_back(tool["name"].get<std::string>());
             CHECK(tool.contains("inputSchema"));
         }
-        for (const char* expected : { "list_maps", "analyze", "palette", "proto_info", "describe_script", "reachability", "describe_map", "map_graph", "world_map", "world_encounters", "quests", "gvars", "endings", "find_gvar", "generate", "render_map", "extract_pattern", "script_api", "frm_info", "resolve_fid", "list_frms", "render_frm", "resource_find", "resource_list", "resource_missing" }) {
+        for (const char* expected : { "list_maps", "analyze", "palette", "proto_info", "describe_script", "find_script", "find_text", "reachability", "describe_map", "map_graph", "world_map", "world_encounters", "quests", "gvars", "endings", "find_gvar", "generate", "render_map", "extract_pattern", "script_api", "frm_info", "resolve_fid", "list_frms", "render_frm", "resource_find", "resource_list", "resource_missing" }) {
             CHECK(std::find(names.begin(), names.end(), expected) != names.end());
         }
     }
@@ -66,6 +66,26 @@ TEST_CASE("McpServer speaks JSON-RPC and exposes the tools", "[mcp]") {
             }
         }
         CHECK(seen == 2);
+    }
+
+    // The 0-based programIndex is the engine's own index base (see cli/ScriptIntrospect.h), so the
+    // 1-based SCRIPT_* constants from headers/scripts.h name the NEXT script if passed unadjusted.
+    // Defaulting a missing selector to 0 would describe obj_dude just as silently, so both
+    // script-selecting tools insist on one and say which base they mean.
+    SECTION("the script tools demand a selector and name the index base") {
+        for (const char* tool : { "describe_script", "find_script" }) {
+            const json resp = server.handleMessage({ { "jsonrpc", "2.0" }, { "id", 6 }, { "method", "tools/call" },
+                { "params", { { "name", tool }, { "arguments", json::object() } } } });
+            CHECK(resp["result"]["isError"] == true);
+            const auto text = resp["result"]["content"][0]["text"].get<std::string>();
+            CHECK(text.find("1-based") != std::string::npos);
+        }
+    }
+
+    SECTION("find_text requires a pattern") {
+        const json resp = server.handleMessage({ { "jsonrpc", "2.0" }, { "id", 7 }, { "method", "tools/call" },
+            { "params", { { "name", "find_text" }, { "arguments", json::object() } } } });
+        CHECK(resp["result"]["isError"] == true);
     }
 
     SECTION("a notification (no id) gets no response") {


### PR DESCRIPTION
Two new read-only MCP tools, a map-reader fix the first tool immediately exposed, and a documentation fix for a trap that returns a *wrong answer* rather than an error.

## `find_script`

Resolves a script by `name` (or 0-based `programIndex`) and reports which shipped maps place it, per section — the inverse of `describe_script`: *which map is this NPC on?* rather than *what does this script say?*

```
find_script({name: "kcslim"})
  -> script:     {programIndex: 84, sslConstant: 85, filename: "kcslim.int", name: "kcslim", description: "Slim"}
     placements: [{map: "/maps/klamall.map", displayName: "Mall", asMapScript: false,
                   sections: [{section: "Critter", count: 1}], instances: 1}]
```

An exact basename wins; a *unique* fragment resolves and flags `matchedFragment`; a genuinely ambiguous fragment returns `{ambiguous: true, matches: [...]}` instead of guessing (`"epac"` → 24 candidates). `resolveOnly: true` skips the scan when only the index↔name mapping is wanted.

It also reports **`mapsUnreadable`**, because a map that fails to load could be the one holding the script — an empty `placements` is only trustworthy when that list is empty too. That earned its keep on the first run, which is where the next section comes from.

## `find_text`

Searches the dialog `.msg`, the `game/*.msg` (item, perk, quest text) and the `.ssl` sources in one call, returning the owning script basename so the result feeds straight back into `describe_script` / `find_script`.

```
find_text({pattern: "mostly farmers", scope: "dialog"})
  -> {kind: "dialog", script: "kcslim", id: 370, text: "Your tribe are mostly farmers aren't they? ..."}
```

Substring and case-insensitive by default; `regex: true` for ECMAScript, `scope` selects the corpus, `limit` caps output and `truncated` says whether it bit.

## The two maps that would not load

`find_script` reported `epac17` (the EPA Doctor) as placed nowhere — while listing `epamain1.map` and `epamain2.map` as unreadable, which is exactly where it would live. So the answer was misleading rather than empty, and the underlying bug was worth chasing.

Each of those maps carries **17 consecutive object records whose PID is `-1`**, and the reader threw `Unknown object type` on the first one, losing the entire map.

Those records are legal. The engine's `objectDataRead` falls out of its type switch through `default: break`, so an object whose PID names no known type is just the 22-field common block with no type-specific tail — and `objectDataWrite` does the same on the way out (fallout2-ce `proto.cc`). Reading them the engine's way consumes both maps to **exactly EOF**, with the per-elevation counts summing to the declared object total: two independent confirmations that this is the real layout, not a lucky resynchronisation.

Reader and writer now both fall through, as the engine does. They have to agree — consuming the wrong number of bytes shifts every object after one by the width of a tail that was never on disk, which is what turned 17 harmless records into an unreadable map. A round-trip test writes an untyped object followed by a wall and checks both come back intact; it fails if either side reverts.

All **176** shipped maps now parse. `describe_map`, `analyze` and `reachability` all read the EPA mains, and `find_script` correctly reports `epa2` as their map script.

Separately, an ITEM or SCENERY object took its tail length from the proto without checking the load succeeded, so a missing proto was a null dereference. It now fails explicitly and names the PID, since guessing the tail would desynchronise the stream. Parse errors carry the offending PID and byte offset, and `loadMap` can report *why* a map failed — which is what makes `mapsUnreadable` useful.

## The script index base

Three numbers name the same script, and mixing them up names the **neighbouring** one silently:

| Number | Base | Where it lives |
| --- | --- | --- |
| `programIndex` — what gecko speaks | **0-based** | the `scripts.lst` array index, and an object's `MapScript::script_id` |
| map header `script_id` | 1-based | `Map::MapHeader::script_id` |
| SSL `SCRIPT_*` (`headers/scripts.h`) | 1-based | the `scripts.lst` *line* number; also sfall `set_script()` ids |

I went looking for an off-by-one and found the opposite: gecko is engine-correct. `programIndex` is what map files store and what `scriptsGetFileName` indexes with, and the engine decrements the 1-based forms itself — `map.cc` (`script->index = gMapHeader.scriptIndex - 1`) and the sfall `set_script` opcode. `MapAnalyzer` already normalised the header the same way.

So nothing was re-based. Instead the trap is closed: both tools accept a `name`, every result echoes **`sslConstant`** (`== programIndex + 1`) for cross-checking against `headers/scripts.h`, and a missing selector is now an error naming the base rather than defaulting to `0` and describing `obj_dude`. Written up in `src/cli/ScriptIntrospect.h` and `CLAUDE.md`.

## Testing

`ctest`: 476/476 pass. The new round-trip test was confirmed to fail without the reader/writer fix. Both tools verified over stdio JSON-RPC against a `master.dat` + `critter.dat` + RPU mount (157 quests, 176/176 maps parsed, 2604 text files searched).