### PR TITLE
Mount and write an install's data folder, not the folder above it

### DIFF
--- a/src/resource/DataFileSystem.cpp
+++ b/src/resource/DataFileSystem.cpp
@@ -23,21 +23,20 @@ void DataFileSystem::clear() {
     _vfs = std::make_shared<vfspp::VirtualFileSystem>();
 }
 
-void DataFileSystem::addDataPath(const std::filesystem::path& path) {
-    const std::scoped_lock lock(_mutex);
-    addDataPathLocked(path);
-}
-
 namespace {
 
     // Resolves a user-supplied data path to the directory or archive to mount. nullopt when it cannot
     // be used: a macOS .app without a recognised Fallout 2 layout, or an unresolvable path.
+    //
+    // An install mounts its loose `data` folder, not its root (util::looseDataDirectory): every lookup
+    // here is data-relative ("proto/scenery/scenery.lst"), so mounting the root would hide those files
+    // under "/data/..." and let the packaged DATs answer in their place.
     std::optional<std::filesystem::path> resolveMountRoot(const std::filesystem::path& path) {
         if (path.extension() == ".dat") {
             return path;
         }
-        if (auto resolved = util::resolveGameDataRoot(path); resolved && !resolved->empty()) {
-            return *resolved;
+        if (auto resolved = util::resolveLooseDataDirectory(path)) {
+            return resolved;
         }
         // Never fall through to mounting a raw .app root - NativeFileSystem would traverse Wine dosdevices
         // symlinks.
@@ -54,7 +53,8 @@ namespace {
 
 } // namespace
 
-void DataFileSystem::addDataPathLocked(const std::filesystem::path& path) {
+void DataFileSystem::addDataPath(const std::filesystem::path& path) {
+    const std::scoped_lock lock(_mutex);
     const auto mountRoot = resolveMountRoot(path);
     if (!mountRoot) {
         return;

--- a/src/resource/DataFileSystem.h
+++ b/src/resource/DataFileSystem.h
@@ -28,9 +28,7 @@ struct MountedSourceInfo {
  * Background loaders read game data concurrently with the main thread, but
  * vfspp's VirtualFileSystem mutates internal state (opened-file tracking, the
  * mounted-filesystem list) on every OpenFile/AddFileSystem call without any
- * synchronization of its own. All access therefore goes through _mutex. Mounting
- * a directory also mounts its nested archives; that recursion runs through the
- * private addDataPathLocked() helper so the public lock is taken exactly once.
+ * synchronization of its own. All access therefore goes through _mutex.
  */
 class DataFileSystem final {
 public:
@@ -56,9 +54,6 @@ public:
     [[nodiscard]] std::vector<MountedSourceInfo> mounts() const;
 
 private:
-    // Mounts a path with _mutex already held; addDataPath() is the public locking entry point.
-    void addDataPathLocked(const std::filesystem::path& path);
-
     static std::filesystem::path normalizeVfsPath(const std::filesystem::path& path);
     static std::string globToRegexPattern(const std::string& pattern);
 

--- a/src/resource/WritableDataRoot.cpp
+++ b/src/resource/WritableDataRoot.cpp
@@ -1,6 +1,7 @@
 #include "resource/WritableDataRoot.h"
 
 #include "resource/DataFileSystem.h"
+#include "util/GameDataPathResolver.h"
 
 #include <spdlog/spdlog.h>
 
@@ -19,7 +20,7 @@ bool sameDataPathEntry(const std::filesystem::path& a, const std::filesystem::pa
     return a.lexically_normal() == b.lexically_normal();
 }
 
-std::optional<std::filesystem::path> findWritableDataPath(const std::vector<std::filesystem::path>& dataPaths) {
+std::optional<std::filesystem::path> findWritableDataPathEntry(const std::vector<std::filesystem::path>& dataPaths) {
     for (auto it = dataPaths.rbegin(); it != dataPaths.rend(); ++it) {
         std::error_code ec;
         if (std::filesystem::is_directory(*it, ec)) {
@@ -29,6 +30,24 @@ std::optional<std::filesystem::path> findWritableDataPath(const std::vector<std:
     return std::nullopt;
 }
 
+namespace {
+
+    // The directory an entry's edits belong in: an install's loose `data` folder, which is both what
+    // the VFS mounts for it and what the engine reads back. A folder that is no install stands alone.
+    std::filesystem::path writableDirectoryFor(const std::filesystem::path& entry) {
+        return util::resolveLooseDataDirectory(entry).value_or(entry);
+    }
+
+} // namespace
+
+std::optional<std::filesystem::path> findWritableDataPath(const std::vector<std::filesystem::path>& dataPaths) {
+    const auto entry = findWritableDataPathEntry(dataPaths);
+    if (!entry) {
+        return std::nullopt;
+    }
+    return writableDirectoryFor(*entry);
+}
+
 std::optional<std::filesystem::path> findWritableDataPath(const std::vector<std::filesystem::path>& dataPaths,
     const std::filesystem::path& preferred) {
     if (!preferred.empty()) {
@@ -36,7 +55,7 @@ std::optional<std::filesystem::path> findWritableDataPath(const std::vector<std:
             [&preferred](const std::filesystem::path& entry) { return sameDataPathEntry(entry, preferred); });
         std::error_code ec;
         if (listed && std::filesystem::is_directory(preferred, ec)) {
-            return preferred;
+            return writableDirectoryFor(preferred);
         }
         spdlog::warn("Configured save location '{}' is {} — falling back to the highest-priority folder",
             preferred.string(), listed ? "not an existing directory" : "no longer among the data paths");

--- a/src/resource/WritableDataRoot.h
+++ b/src/resource/WritableDataRoot.h
@@ -22,7 +22,15 @@ public:
 /// directory (DAT/archive paths are read-only and skipped), or nullopt if there is none. Editing writes
 /// into a folder the user can see and manage in their Data Paths — there is no hidden auto-mounted
 /// location. Being last means its copies shadow the archives mounted before it.
+///
+/// An install folder resolves to the `data` folder mounted for it (util::looseDataDirectory), so the
+/// copy lands on the read path — both the editor's and the engine's.
 std::optional<std::filesystem::path> findWritableDataPath(const std::vector<std::filesystem::path>& dataPaths);
+
+/// The same choice, left as the listed entry instead of resolved into its `data` tree — for callers
+/// that have to match it against the data-path list itself (the save-location badge in the Data Paths
+/// table marks the row the user chose, not the subfolder the bytes land in).
+std::optional<std::filesystem::path> findWritableDataPathEntry(const std::vector<std::filesystem::path>& dataPaths);
 
 /// Same, but honouring an explicit user choice first: when `preferred` is non-empty, is one of
 /// `dataPaths`, and is an existing directory, it is the writable root regardless of list order.

--- a/src/ui/widgets/DataPathsWidget.cpp
+++ b/src/ui/widgets/DataPathsWidget.cpp
@@ -205,7 +205,8 @@ void DataPathsWidget::setDataPaths(const std::vector<std::filesystem::path>& pat
     // A save-location marker whose folder is no longer among the rows can't stay marked.
     if (!_writableDataPath.empty()) {
         const auto current = getDataPaths();
-        if (std::find(current.begin(), current.end(), _writableDataPath) == current.end()) {
+        if (std::none_of(current.begin(), current.end(),
+                [this](const std::filesystem::path& entry) { return isMarkedSaveLocation(entry); })) {
             _writableDataPath.clear();
         }
     }
@@ -376,7 +377,7 @@ void DataPathsWidget::updateButtonStates() {
     // already carries the marker, so clicking clears it.
     const bool markable = isMarkableRow(row);
     _saveLocationButton->setEnabled(markable);
-    _saveLocationButton->setChecked(markable && !_writableDataPath.empty() && pathAtRow(row) == _writableDataPath);
+    _saveLocationButton->setChecked(markable && isMarkedSaveLocation(pathAtRow(row)));
 
     _scriptSourceButton->setEnabled(markable);
     _scriptSourceButton->setChecked(markable
@@ -403,6 +404,10 @@ bool DataPathsWidget::isMarkableRow(int row) const {
     return !path.empty() && std::filesystem::is_directory(path, ec);
 }
 
+bool DataPathsWidget::isMarkedSaveLocation(const std::filesystem::path& path) const {
+    return !_writableDataPath.empty() && resource::sameDataPathEntry(path, _writableDataPath);
+}
+
 void DataPathsWidget::onToggleSaveLocation() {
     const int row = selectedRow();
     if (!isMarkableRow(row)) {
@@ -410,7 +415,7 @@ void DataPathsWidget::onToggleSaveLocation() {
     }
 
     const std::filesystem::path path = pathAtRow(row);
-    if (_writableDataPath == path) {
+    if (isMarkedSaveLocation(path)) {
         _writableDataPath.clear();
         setStatusMessage("Save location cleared — the highest-priority folder will be used.", "info");
     } else {
@@ -471,11 +476,12 @@ void DataPathsWidget::refreshSaveLocationMarkers() {
 
     // Which ENTRY saves are attributed to right now — the badge marks a row, so this compares in
     // data-path terms (findWritableDataPathEntry), not the `data` subfolder the bytes end up in.
-    // Mirrors resource::findWritableDataPath's preference rule but resolves the fallback locally, so
-    // a stale marker does not warn-log on every repaint.
+    // Mirrors resource::findWritableDataPath's preference rule — the same equivalence test for
+    // membership, via isMarkedSaveLocation — but resolves the fallback locally, so a stale marker
+    // does not warn-log on every repaint.
     std::optional<std::filesystem::path> effective;
-    if (std::error_code ec; !_writableDataPath.empty()
-        && std::find(paths.begin(), paths.end(), _writableDataPath) != paths.end()
+    if (std::error_code ec; std::any_of(paths.begin(), paths.end(),
+                                [this](const std::filesystem::path& entry) { return isMarkedSaveLocation(entry); })
         && std::filesystem::is_directory(_writableDataPath, ec)) {
         effective = _writableDataPath;
     } else {
@@ -484,7 +490,7 @@ void DataPathsWidget::refreshSaveLocationMarkers() {
 
     // The marker only takes effect while it is usable; when it isn't, the badge (and its claim
     // about where saves land) must follow the actual fallback, not the configured wish.
-    const bool markerUsable = !_writableDataPath.empty() && effective.has_value() && *effective == _writableDataPath;
+    const bool markerUsable = effective.has_value() && isMarkedSaveLocation(*effective);
 
     for (int row = 0; row < _pathsTable->rowCount(); ++row) {
         QTableWidgetItem* item = _pathsTable->item(row, PathColumn);
@@ -492,8 +498,8 @@ void DataPathsWidget::refreshSaveLocationMarkers() {
             continue;
         }
         const std::filesystem::path rowPath = Settings::normalizeDataPath(item->text().toStdString());
-        const bool isExplicit = !_writableDataPath.empty() && rowPath == _writableDataPath;
-        const bool isEffective = effective.has_value() && rowPath == *effective;
+        const bool isExplicit = isMarkedSaveLocation(rowPath);
+        const bool isEffective = effective.has_value() && resource::sameDataPathEntry(rowPath, *effective);
 
         QFont font = _pathsTable->font();
         font.setBold(isExplicit);
@@ -534,7 +540,7 @@ void DataPathsWidget::removeSelectedPath() {
         return;
     }
 
-    const bool removedMarked = !_writableDataPath.empty() && pathAtRow(row) == _writableDataPath;
+    const bool removedMarked = isMarkedSaveLocation(pathAtRow(row));
     if (removedMarked) {
         _writableDataPath.clear();
     }
@@ -700,7 +706,7 @@ void DataPathsWidget::onCellDoubleClicked(int row, int /*column*/) {
         // Re-picking a marked folder keeps it the save location under its new path.
         const std::filesystem::path oldPath = Settings::normalizeDataPath(currentPath.toStdString());
         const std::filesystem::path newNormalized = Settings::normalizeDataPath(newPath.toStdString());
-        if (!_writableDataPath.empty() && _writableDataPath == oldPath) {
+        if (isMarkedSaveLocation(oldPath)) {
             _writableDataPath = newNormalized;
         }
         // Likewise carry a script-source marker across to the new path.

--- a/src/ui/widgets/DataPathsWidget.cpp
+++ b/src/ui/widgets/DataPathsWidget.cpp
@@ -469,15 +469,17 @@ void DataPathsWidget::onToggleScriptSource() {
 void DataPathsWidget::refreshSaveLocationMarkers() {
     const auto paths = getDataPaths();
 
-    // Where saves would land right now. Mirrors resource::findWritableDataPath but resolves the
-    // fallback locally, so a stale marker does not warn-log on every repaint.
+    // Which ENTRY saves are attributed to right now — the badge marks a row, so this compares in
+    // data-path terms (findWritableDataPathEntry), not the `data` subfolder the bytes end up in.
+    // Mirrors resource::findWritableDataPath's preference rule but resolves the fallback locally, so
+    // a stale marker does not warn-log on every repaint.
     std::optional<std::filesystem::path> effective;
     if (std::error_code ec; !_writableDataPath.empty()
         && std::find(paths.begin(), paths.end(), _writableDataPath) != paths.end()
         && std::filesystem::is_directory(_writableDataPath, ec)) {
         effective = _writableDataPath;
     } else {
-        effective = resource::findWritableDataPath(paths);
+        effective = resource::findWritableDataPathEntry(paths);
     }
 
     // The marker only takes effect while it is usable; when it isn't, the badge (and its claim
@@ -552,8 +554,9 @@ void DataPathsWidget::removeSelectedPath() {
 }
 
 int DataPathsWidget::addFolderExpanded(const std::filesystem::path& folder, bool atTop) {
-    // expandDataPaths returns the folder before its DATs, and inserting each atTop reverses that. To
-    // get the same layout when appending, append in reverse; the DATs keep priority over the folder.
+    // expandDataPaths returns a folder's DATs before the folder itself, so the folder's loose files
+    // win. The table shows the stored order reversed (highest priority first), so inserting each row
+    // at the top preserves that order and appending has to reverse it to reach the same result.
     auto expanded = util::expandDataPaths({ folder });
     if (!atTop) {
         std::reverse(expanded.begin(), expanded.end());

--- a/src/ui/widgets/DataPathsWidget.h
+++ b/src/ui/widgets/DataPathsWidget.h
@@ -83,6 +83,11 @@ private:
     // A row can be marked (as the save location or a script source) only if it's a real folder
     // (not a .dat, not missing, not the protected built-in resources path).
     bool isMarkableRow(int row) const;
+    // Whether `path` is the folder currently marked as the save location. Equivalence, not string
+    // equality: the marker is stored as the user picked it, so a symlink or a redundant "/." would
+    // otherwise read as a different folder here than it does in Settings and WritableDataRoot, and
+    // the badge would call a marker unusable that those two still honour.
+    bool isMarkedSaveLocation(const std::filesystem::path& path) const;
     // Re-derive each row's save-location badge (bold + save icon for the explicit marker, italic for
     // the positional default) from the current rows + marker. Called whenever either changes.
     void refreshSaveLocationMarkers();

--- a/src/util/GameDataPathResolver.cpp
+++ b/src/util/GameDataPathResolver.cpp
@@ -18,6 +18,15 @@ namespace {
         return std::filesystem::is_regular_file(path, ec);
     }
 
+    // The archives the engine opens by name from the folder it runs in (gameDbInit). Their presence
+    // is what separates an INSTALL from the loose data it ships: a data tree and a mod overlay both
+    // hold a `data` folder of their own (ai.txt, city.txt, ...), so that folder alone proves nothing.
+    bool hasEngineArchives(const std::filesystem::path& directory) {
+        return isRegularFile(directory / "master.dat")
+            || isRegularFile(directory / "critter.dat")
+            || isRegularFile(directory / "patch000.dat");
+    }
+
 } // namespace
 
 bool hasFallout2DataLayout(const std::filesystem::path& path) {
@@ -25,10 +34,23 @@ bool hasFallout2DataLayout(const std::filesystem::path& path) {
         return false;
     }
 
-    return isDirectory(path / "data")
-        || isRegularFile(path / "master.dat")
-        || isRegularFile(path / "critter.dat")
-        || isRegularFile(path / "patch000.dat");
+    return isDirectory(path / "data") || hasEngineArchives(path);
+}
+
+std::filesystem::path looseDataDirectory(const std::filesystem::path& gameRoot) {
+    const std::filesystem::path data = gameRoot / "data";
+    if (!hasEngineArchives(gameRoot) || !isDirectory(data)) {
+        return gameRoot; // a data tree or mod folder IS the loose data; a DAT-only install has none
+    }
+    return data;
+}
+
+std::optional<std::filesystem::path> resolveLooseDataDirectory(const std::filesystem::path& path) {
+    const auto gameRoot = resolveGameDataRoot(path);
+    if (!gameRoot || gameRoot->empty()) {
+        return std::nullopt;
+    }
+    return looseDataDirectory(*gameRoot);
 }
 
 // Append a directory's bundled master.dat/critter.dat (present and not already listed) to `out`.
@@ -94,15 +116,17 @@ std::optional<std::filesystem::path> resolveGameDataRoot(const std::filesystem::
     }
 #endif
 
-    if (hasFallout2DataLayout(path)) {
-        return path;
+    // Before the layout test, not after: a data tree keeps a `data` folder of its own (ai.txt,
+    // city.txt, ...), so an install's own "data" would otherwise satisfy hasFallout2DataLayout and
+    // come back as the root — leaving looseDataDirectory() to append onto it and reach data/data.
+    // The parent must be an install, not merely a folder with a `data` child (which every parent of
+    // a path named "data" trivially is).
+    if (path.filename() == "data" && hasEngineArchives(path.parent_path())) {
+        return path.parent_path();
     }
 
-    if (path.filename() == "data") {
-        const std::filesystem::path parent = path.parent_path();
-        if (hasFallout2DataLayout(parent)) {
-            return parent;
-        }
+    if (hasFallout2DataLayout(path)) {
+        return path;
     }
 
     return std::nullopt;

--- a/src/util/GameDataPathResolver.h
+++ b/src/util/GameDataPathResolver.h
@@ -10,11 +10,35 @@ namespace geck::util {
 /// (data/ subdirectory, master.dat, critter.dat, or patch000.dat).
 bool hasFallout2DataLayout(const std::filesystem::path& path);
 
+/// The loose game files of an install: `<gameRoot>/data`, or the root itself when it has no such
+/// folder (a DAT-only install).
+///
+/// The engine reads every file relative to this directory — it is fallout2.cfg's master_patches, the
+/// last database gameDbInit() opens and so the one that wins over master.dat/critter.dat. Editor
+/// paths are relative to it too ("proto/scenery/scenery.lst"), which is why it, and not the install
+/// root, is what gets mounted and written to: mounting the root buries the loose files at
+/// "/data/proto/..." where nothing looks, leaving the packaged DAT copy to answer — a Restoration
+/// Project map then resolves its PIDs against vanilla's shorter proto lists and fails to load.
+///
+/// Only an install descends: a folder is one when it holds the archives the engine opens by name
+/// (master.dat / critter.dat / patch000.dat). A data tree and a loose mod overlay both contain a
+/// `data` folder of their own, so descending on that alone would bury them in their own data/data.
+std::filesystem::path looseDataDirectory(const std::filesystem::path& gameRoot);
+
+/// The directory a user-supplied data-path entry actually stands for: its install resolved
+/// (resolveGameDataRoot), then descended into that install's loose data (looseDataDirectory).
+/// nullopt when the entry names no recognisable game layout at all.
+///
+/// Mounting and writing must agree on this — a save that lands anywhere but the mounted directory is
+/// invisible to the editor that wrote it — so both go through this one function.
+std::optional<std::filesystem::path> resolveLooseDataDirectory(const std::filesystem::path& path);
+
 /// Expand each directory that ships master.dat / critter.dat into the directory followed by those DATs,
-/// so every mounted archive is an explicit data-path entry rather than a silent nested mount. Order is
-/// preserved — the directory precedes its DATs, matching the legacy mount order so priority is
-/// unchanged. `.dat` entries and DAT-less directories pass through untouched; an already-listed path is
-/// never duplicated. Used to migrate older folder-only settings and when adding a folder in the UI.
+/// so every mounted archive is an explicit data-path entry rather than a silent nested mount. The DATs
+/// come first and the directory last: mounts resolve last-wins, so the folder's loose files override
+/// the archives it ships, as they do in the engine. `.dat` entries and DAT-less directories pass
+/// through untouched; an already-listed path is never duplicated. Used to migrate older folder-only
+/// settings and when adding a folder in the UI.
 std::vector<std::filesystem::path> expandDataPaths(const std::vector<std::filesystem::path>& dataPaths);
 
 /// Attempt to resolve a user-supplied path to a Fallout 2 game data root.
@@ -23,9 +47,14 @@ std::vector<std::filesystem::path> expandDataPaths(const std::vector<std::filesy
 ///   1. Empty path -> nullopt
 ///   2. .dat extension -> returned as-is
 ///   3. macOS .app bundle or Contents/Resources -> probe GOG wrapper path
-///   4. Has Fallout 2 data layout -> return path
-///   5. Filename is "data" and parent has layout -> return parent
+///   4. Filename is "data" and the parent is an install -> return parent
+///   5. Has Fallout 2 data layout -> return path
 ///   6. Otherwise -> nullopt
+///
+/// Rule 4 precedes rule 5 deliberately: an install's `data` contains a `data` folder of its own, so
+/// it would otherwise pass rule 5 and be reported as the root. It also tests the parent for the
+/// engine's archives — every parent of a path named "data" has a `data` child by definition, so the
+/// layout test alone would pull a standalone data tree up to its unrelated parent.
 std::optional<std::filesystem::path> resolveGameDataRoot(const std::filesystem::path& path);
 
 /// Compare two paths for equivalence.  Uses std::filesystem::equivalent first,

--- a/tests/general/test_game_data_path_resolver.cpp
+++ b/tests/general/test_game_data_path_resolver.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <thread>
 
+#include "resource/DataFileSystem.h"
 #include "util/GameDataPathResolver.h"
 
 namespace {
@@ -78,6 +79,77 @@ TEST_CASE("hasFallout2DataLayout detects patch000.dat", "[paths]") {
     TempDir tmp;
     touchFile(tmp.root / "patch000.dat");
     REQUIRE(geck::util::hasFallout2DataLayout(tmp.root));
+}
+
+// =============================================================================
+// looseDataDirectory
+// =============================================================================
+
+TEST_CASE("looseDataDirectory is the install root's data folder", "[paths]") {
+    TempDir tmp;
+    createFallout2DataLayout(tmp.root);
+
+    REQUIRE(geck::util::looseDataDirectory(tmp.root) == tmp.root / "data");
+}
+
+TEST_CASE("looseDataDirectory falls back to the root of a DAT-only install", "[paths]") {
+    TempDir tmp;
+    touchFile(tmp.root / "master.dat");
+
+    REQUIRE(geck::util::looseDataDirectory(tmp.root) == tmp.root);
+}
+
+// Appending `data` is only safe because a resolved game root is never a data folder itself, and a
+// data folder is only recognisable by its company: it holds a `data` folder of its own (ai.txt,
+// city.txt, ...) and so satisfies hasFallout2DataLayout exactly like an install root does.
+TEST_CASE("a data folder resolves to its install root even though it looks like one", "[paths]") {
+    TempDir tmp;
+    createFallout2DataLayout(tmp.root);
+    mkdirs(tmp.root / "data/data");
+    mkdirs(tmp.root / "data/proto");
+
+    const auto root = geck::util::resolveGameDataRoot(tmp.root / "data");
+    REQUIRE(root.has_value());
+    REQUIRE(*root == tmp.root);
+    REQUIRE(geck::util::looseDataDirectory(*root) == tmp.root / "data"); // and back, not data/data
+}
+
+// The counterpart to the append: a folder that ships loose data WITHOUT the engine's archives is the
+// data itself (a standalone data tree, or a mod overlay adding files under data/). Descending on its
+// `data` folder would bury art/, proto/ and the rest.
+TEST_CASE("looseDataDirectory leaves a data tree that is not an install alone", "[paths]") {
+    TempDir tmp;
+    mkdirs(tmp.root / "art/scenery");
+    mkdirs(tmp.root / "data"); // its own data/ (ai.txt, city.txt, ...), not an install's
+
+    REQUIRE(geck::util::looseDataDirectory(tmp.root) == tmp.root);
+}
+
+TEST_CASE("DataFileSystem mounts a data tree as given", "[paths][vfs]") {
+    TempDir tmp;
+    touchFile(tmp.root / "data/maps.txt"); // the data tree's own data/maps.txt
+    touchFile(tmp.root / "proto/scenery/scenery.lst");
+
+    geck::resource::DataFileSystem dfs;
+    dfs.addDataPath(tmp.root);
+
+    CHECK(dfs.exists("data/maps.txt"));
+    CHECK(dfs.exists("proto/scenery/scenery.lst"));
+}
+
+// Regression: choosing the install folder as a data path mounted the folder itself, so its loose
+// `data` files landed at "/data/proto/..." - a path nothing looks up - and master.dat answered
+// instead. A Restoration Project map then hit PIDs past the end of vanilla's proto lists and failed
+// to load at all ("PID index out of range").
+TEST_CASE("DataFileSystem mounts an install folder's loose data files", "[paths][vfs]") {
+    TempDir tmp;
+    touchFile(tmp.root / "master.dat");
+    touchFile(tmp.root / "data/proto/scenery/scenery.lst");
+
+    geck::resource::DataFileSystem dfs;
+    dfs.addDataPath(tmp.root);
+
+    REQUIRE(dfs.exists("proto/scenery/scenery.lst"));
 }
 
 // =============================================================================

--- a/tests/general/test_writable_data_root.cpp
+++ b/tests/general/test_writable_data_root.cpp
@@ -73,6 +73,22 @@ TEST_CASE("findWritableDataPath returns the last directory, skipping archives", 
     fs::remove_all(base);
 }
 
+TEST_CASE("findWritableDataPath writes into an install folder's data tree", "[writableroot]") {
+    const fs::path base = fs::path{ GECK_TEST_TMP_DIR } / "fwdp_install";
+    fs::remove_all(base);
+    writeFile(base / "master.dat", "x"); // an archive next to data/ is what makes it an install
+    fs::create_directories(base / "data" / "proto");
+
+    // The listed entry is what the save-location badge marks ...
+    CHECK(resource::findWritableDataPathEntry({ base }) == base);
+    // ... while the bytes land in the tree actually mounted for it, which is also where the engine
+    // (master_patches) reads them back from.
+    CHECK(resource::findWritableDataPath({ base }) == base / "data");
+    CHECK(resource::findWritableDataPath({ base }, base) == base / "data");
+
+    fs::remove_all(base);
+}
+
 TEST_CASE("findWritableDataPath honours an explicit save-location marker", "[writableroot]") {
     const fs::path base = fs::path{ GECK_TEST_TMP_DIR } / "fwdp_marker";
     fs::remove_all(base);


### PR DESCRIPTION
## The bug

Adding a Fallout 2 installation folder as a data path mounted the installation **root**. Every lookup the editor makes is relative to the game's loose data (`proto/scenery/scenery.lst`), so the files under `<install>/data` landed at `/data/proto/...` — a path nothing looks up — and the `master.dat` mounted beside them answered instead.

A Restoration Project installation then resolved its maps' PIDs against vanilla's shorter proto lists, and the map failed to load at all.

The same applied on the way out: map saves and name/variable edits were written to the installation root, where neither the editor nor the engine reads them back.

## The fix

`<install>/data` is what the engine reads: it is `fallout2.cfg`'s `master_patches`, the last database `gameDbInit()` opens and so the one that wins over `master.dat`/`critter.dat`. `util::looseDataDirectory()` names it, and both the mount (`DataFileSystem`) and the save location (`findWritableDataPath`) resolve through the shared `util::resolveLooseDataDirectory()` — they have to agree, or an edited copy lands somewhere the editor that wrote it cannot read back.

Whether to descend is decided by the **archives**, not by the presence of a `data` folder: a data tree and a mod overlay each carry a `data` folder of their own (`ai.txt`, `city.txt`, …), so a folder counts as an installation when it holds `master.dat`, `critter.dat` or `patch000.dat`. A standalone data tree or mod overlay is therefore still mounted exactly as given.

For the same reason `resolveGameDataRoot()` now asks "is this an installation's `data` folder?" *before* its layout test — an installation's own `data/` satisfies that test, so it used to come back as the root, and appending to it would have reached `data/data`.

The Data Paths save-location badge marks the row the user picked, not the subfolder the bytes land in, so it compares in data-path terms through the new `findWritableDataPathEntry()`.

## Also in here

- `addDataPathLocked()` existed so the (since removed) nested-archive recursion took the public lock once, and had a single caller left — folded back into `addDataPath()`, with the class comment corrected.
- `addFolderExpanded()`'s comment had `expandDataPaths()`'s order backwards: the DATs come first and the folder last, so the folder's loose files win. The code was right, the comment was not.

## Tests

Six new cases: `looseDataDirectory` over an installation, a DAT-only installation and a non-installation data tree; the `data`-folder-resolves-to-its-root round trip; `DataFileSystem` mounting both shapes (the second is the regression that made RP maps unloadable); and the writable root resolving into `<install>/data` while the listed entry stays the row.

`general_tests` (468 cases) and `qt_tests` (117 cases) pass locally.