### PR TITLE
Give the panels keyboard shortcuts that reveal rather than toggle

### DIFF
--- a/docs/keybindings-implementation.md
+++ b/docs/keybindings-implementation.md
@@ -1,0 +1,402 @@
+# Keyboard shortcuts — implementation plan
+
+*Implementation plan for `docs/keybindings-plan.md`: the new default bindings, and the
+Preferences page that makes them remappable. Three shippable slices; each one is useful on its
+own and each is a separate PR.*
+
+---
+
+## 0. Corrections to the source doc (verified against the code)
+
+Four things in `keybindings-plan.md`'s "Already-bound keys" table are wrong or incomplete. They
+change what the slices below can safely claim.
+
+| Claim in the doc | What the code actually does |
+|---|---|
+| `F11` / `F16` are bound (spatial-script dialog / kill-type) | **Not bound anywhere.** `F11` appears only in `SFMLWidget::convertQtKeyToSf()` (`src/ui/widgets/SFMLWidget.cpp:316`), which is a Qt→SFML key-code translation table, not a binding. Both keys are free. |
+| — (missing) | **`P` is bound**: eyedropper, samples whatever is under the cursor into the matching palette (`src/ui/input/InputHandler.cpp:346`). Canvas-scoped already. |
+| — (missing) | **`Space` is bound**: in "Draw edge" mode it flips which side the exit-grid bars sit on (`src/ui/input/InputHandler.cpp:352`). Tool-modal. |
+| `Enter` is free | **`Enter` is already bound in `MarkExits` mode** — it finalizes the in-progress Draw-edge polyline (`src/ui/input/InputHandler.cpp:330`). The proposed `Enter` → Selection panel *must* stand down while that tool is active. |
+
+One more, on the doc's design caveat ("typing `b` in a search field places scroll blockers"):
+the risk is real but narrower than stated. `QLineEdit` (and `QSpinBox`, which embeds one)
+accepts `QEvent::ShortcutOverride` for any key below `Qt::Key_Escape`, so a plain letter typed
+into a panel's filter box is **not** stolen by a window-scoped `QAction`. The keys *are* stolen
+when focus sits on a non-text widget — a palette grid, a `QTreeView`, a non-editable
+`QComboBox`, a dock title bar. That is still a good enough reason to scope single-letter keys to
+the canvas, and it means the existing `B` / `R` have the same latent bug today.
+
+---
+
+## 1. Final default table
+
+Scope column: **App** = window-scoped `QAction` shortcut; **Canvas** = `QShortcut` on the
+`SFMLWidget` with `Qt::WidgetWithChildrenShortcut`; **Tool** = stays inside `InputHandler`'s
+tool state machine, not user-remappable (see §5).
+
+| Key | Action id | Label | Scope | Slice |
+|---|---|---|---|---|
+| `Return` | `panel.selection.reveal` | Inspect selection (reveal Selection panel) | Canvas | 1 |
+| `Alt+1` | `panel.mapInfo` | Map Information panel | App | 1 |
+| `Alt+2` | `panel.selection` | Selection panel | App | 1 |
+| `Alt+3` | `panel.scripts` | Scripts panel | App | 1 |
+| `Alt+4` | `panel.tilePalette` | Tile Palette panel | App | 1 |
+| `Alt+5` | `panel.objectPalette` | Object Palette panel | App | 1 |
+| `Alt+6` | `panel.fileBrowser` | File Browser panel | App | 1 |
+| `` Alt+` `` | `panel.log` | Log panel | App | 1 |
+| `Ctrl+1` | `view.elevation1` | Elevation 1 | App | 2 |
+| `Ctrl+2` | `view.elevation2` | Elevation 2 | App | 2 |
+| `Ctrl+3` | `view.elevation3` | Elevation 3 | App | 2 |
+| `S` | `tool.select` | Select mode | Canvas | 2 |
+| `G` | `view.hexGrid` | Toggle hex grid | Canvas | 2 |
+| `Home` | `view.centerOnPlayer` | Center on player start | Canvas | 2 |
+| `F` | `view.fitMap` | Fit map in view | Canvas | 2 |
+| `Ctrl+Shift+E` | `script.editSource` | Edit script source of selection | App | 2 |
+| `B` | `tool.scrollBlockerRect` | Scroll-blocker rectangle | Canvas *(moved from App)* | 2 |
+| `R` | `tool.rotate` | Rotate selected object | Canvas *(moved from App)* | 2 |
+| `P` | `tool.pick` | Eyedropper | Canvas *(moved from InputHandler)* | 3 |
+
+Decisions folded in:
+
+- **`` Alt+` `` goes to the Log dock**, not the Script Console. The console is behind
+  `GECK_SCRIPTING_ENABLED` (`MainWindow.cpp:1222`) and would leave the key dead in a
+  scripting-off build; the Log dock is unconditional. The console keeps its View-menu entry.
+- **`Return` vs numpad Enter.** A `QShortcut` on `Qt::Key_Return` does not catch
+  `Qt::Key_Enter`. Register the reveal action with two `QShortcut` sinks; only the `Return` one
+  is rebindable.
+- **`B` and `R` move to canvas scope** in slice 2. This is a user-visible behaviour change —
+  they stop firing when a palette grid or tree has focus — and it retires the
+  `_rotateAction->setEnabled(...)` workaround at `MainWindow.cpp:999` that exists only because
+  `R` is currently window-scoped.
+
+---
+
+## 2. Slice 1 — panel reveal + `Return` (no new infrastructure)
+
+Everything lands in `MainWindow`. No `Settings` change, no new files.
+
+### 2.1 Reveal-and-focus semantics
+
+Today `addPanelToggleAction()` (`MainWindow.cpp:311`) makes a checkable menu action whose
+`toggled` handler shows or hides the dock. "Toggle" is the wrong verb for a keyboard shortcut on
+a **tabbed** dock: `Alt+1` on a Map Info dock that is visible-but-tabbed-behind Scripts would
+hide it rather than surface it.
+
+Add alongside it:
+
+```cpp
+// MainWindow.cpp
+void MainWindow::revealPanel(QDockWidget* dock) {
+    if (!dock) return;
+    const bool onTop = dock->isVisible() && !dock->visibleRegion().isEmpty();
+    const bool focused = dock->isAncestorOf(QApplication::focusWidget());
+    if (onTop && focused) {          // already the active, focused tab -> hide
+        dock->hide();
+        return;
+    }
+    dock->show();                    // hidden, or visible but tabbed behind / unfocused
+    dock->raise();
+    if (QWidget* w = dock->widget()) w->setFocus(Qt::ShortcutFocusReason);
+}
+```
+
+`dock->hide()` / `show()` both fire `QDockWidget::visibilityChanged`, which the existing handler
+at `MainWindow.cpp:344` already uses to re-sync the menu action's check state and persist the
+layout — so the menu checkmarks stay correct for free.
+
+### 2.2 Wiring the `Alt+…` family
+
+`addPanelToggleAction()` gains a `const QKeySequence& shortcut` parameter and calls
+`revealPanel()` instead of the inline `showDock` lambda. `setupPanelsMenu()`
+(`MainWindow.cpp:2308`) grows a `shortcut` field in its `PanelToggleSpec` array.
+
+Ordering gotcha: `setupPanelsMenu()` runs from `setupMenuBar()`, but `_logDock` is not created
+until `setupDockWidgets()` (`MainWindow.cpp:1242`). Attach `` Alt+` `` where the log action is
+already configured — `MainWindow.cpp:1252`, right after
+`logAction->setText(tr("&Log"))` — using `_logDock->toggleViewAction()`, and route it through
+`revealPanel()` rather than the raw toggle action so it gets the same reveal semantics.
+
+### 2.3 `Return` → reveal Selection panel
+
+```cpp
+// after the SFMLWidget exists (EditorWidget construction / setCurrentEditorWidget)
+_inspectSelectionShortcut = new QShortcut(QKeySequence(Qt::Key_Return), sfmlWidget);
+_inspectSelectionShortcut->setContext(Qt::WidgetWithChildrenShortcut);
+connect(_inspectSelectionShortcut, &QShortcut::activated, this, [this] {
+    if (!_currentEditorWidget || !_currentEditorWidget->hasSelection()) return;  // no-op, per plan
+    revealPanel(_selectionDock);
+});
+```
+
+Plus a second `QShortcut` on `Qt::Key_Enter` sharing the same lambda.
+
+**Must be disabled in `MarkExits` mode**, or it eats the Draw-edge finalize. `syncToolModeActions()`
+(`MainWindow.cpp:959`) already runs on every mode change and already does exactly this dance for
+`_rotateAction`; add:
+
+```cpp
+if (_inspectSelectionShortcut) {
+    _inspectSelectionShortcut->setEnabled(mode != EditorMode::MarkExits);
+}
+```
+
+`QShortcut` with `WidgetWithChildrenShortcut` only fires while the canvas has focus, so a
+`Return` pressed in a panel's filter box is untouched.
+
+**Files:** `src/ui/core/MainWindow.{h,cpp}`.
+**Test:** extend `tests/qt/test_ui_regressions.cpp:751` ("MainWindow panel toggles stay wired in
+the no-map layout") with reveal-semantics cases — hidden → shows+raises; tabbed-behind → raises
+without hiding; visible+focused → hides.
+
+---
+
+## 3. Slice 2 — editor navigation keys
+
+Still no registry; these are direct bindings that slice 3 later re-points at the table.
+
+| Binding | Where the behaviour already lives |
+|---|---|
+| `Ctrl+1/2/3` | `_elevation1Action`…`_elevation3Action` already exist (`MainWindow.cpp:673-688`). One-line `setShortcut()` each. They are `setDisabled(true)` until `updateElevationMenu()` enables the elevations the map actually has — a shortcut on a disabled action is correctly a no-op. |
+| `Home` | `EditorWidget::centerViewOnPlayerPosition()` already exists (`EditorWidget.cpp:2876`). Canvas `QShortcut` → call it. |
+| `S` | `_selectToolAction` already exists (`MainWindow.cpp:861`). Do **not** `setShortcut()` on it (that would be window scope); add a canvas `QShortcut` that calls `_selectToolAction->trigger()`. |
+| `G` | Same shape via `_showHexGridAction->toggle()`. |
+| `Ctrl+Shift+E` | Reuses the Scripts-panel / Map-Info "Edit Script Source" path from the SSL toolchain work; resolves the selected object's script and hands off to `ScriptSourceService`. Enabled only when the selection has a script. |
+
+### 3.1 `F` — fit map in view (the only new behaviour)
+
+`ViewportController` has `centerViewOnMap()` and `setZoomLevel()` but no fit-to-extent. Add:
+
+```cpp
+// src/viewport/ViewportController.{h,cpp}
+void fitMapInView();   // zoom so the whole 100x100 tile grid fits, then re-center
+```
+
+The tile grid spans roughly **7920 × 3576** world px (from `Constants.h`: `MAP_WIDTH/HEIGHT` 100,
+`TILE_X_OFFSET` 48, `TILE_Y_OFFSET_LARGE` 32, `TILE_Y_OFFSET_SMALL` 24, `TILE_Y_OFFSET_TINY` 12,
+plus `TILE_WIDTH` 80 / `TILE_HEIGHT` 36). At a 1600×900 viewport the required zoom is
+`min(1600/8000, 900/3612) ≈ 0.20` — comfortably inside the existing `MIN_ZOOM = 0.1` clamp, so
+no clamp change is needed. Derive the extents from the same `TileUtils` math
+`centerViewOnMap()` uses rather than hardcoding, so the two cannot drift.
+
+Unit-testable headless (no GL): `tests/general/test_viewport_controller.cpp` already exercises
+this class.
+
+### 3.2 Migrating `B` and `R` to canvas scope
+
+Drop the `QKeySequence("B")` at `MainWindow.cpp:482` and the `QKeySequence("R")` at
+`MainWindow.cpp:828`; replace with canvas `QShortcut`s triggering the same actions. Then delete
+the `_rotateAction->setEnabled(...)` guard at `MainWindow.cpp:999` and update the comment at
+`InputHandler.cpp:339-342`, which documents the workaround — `R` will now reach the viewport
+without the toolbar action being disabled first.
+
+**Files:** `src/ui/core/MainWindow.{h,cpp}`, `src/viewport/ViewportController.{h,cpp}`,
+`src/ui/input/InputHandler.cpp` (comment only).
+**Tests:** `tests/general/test_viewport_controller.cpp` (fit math, clamp behaviour);
+`tests/qt/test_ui_regressions.cpp` (elevation shortcuts are no-ops on a map without that
+elevation).
+
+---
+
+## 4. Slice 3 — central table + Preferences page
+
+This is `PLAN.md` "Editor limitations §7" and the prerequisite for §8 (customizable toolbar).
+
+### 4.1 New files
+
+```
+src/ui/input/ActionSpec.h              # the default table (id, label, category, keys, scope)
+src/ui/input/KeyBindingRegistry.h/.cpp # overrides, conflicts, persistence, live rebind
+src/ui/widgets/KeybindingsWidget.h/.cpp# the Preferences tab
+tests/qt/test_keybindings.cpp
+```
+
+All four get added to `src/CMakeLists.txt` (explicit source lists — no globbing) and
+`tests/CMakeLists.txt`'s `qt_tests` target.
+
+### 4.2 The table
+
+```cpp
+// src/ui/input/ActionSpec.h
+namespace geck {
+
+enum class ActionScope { Application, Canvas };
+
+struct ActionSpec {
+    const char* id;          // stable + persisted — never renamed once shipped
+    const char* label;       // "Selection Panel"
+    const char* category;    // "Panels" | "File" | "Edit" | "View" | "Navigation" | "Tools"
+    const char* defaultKeys; // QKeySequence portable text, "" = unbound by default
+    ActionScope scope;
+};
+
+std::span<const ActionSpec> actionSpecs();
+
+} // namespace geck
+```
+
+String ids rather than an enum because they are what lands in `settings.json`; a reordered enum
+would silently repoint every user's overrides.
+
+### 4.3 Registry
+
+```cpp
+class KeyBindingRegistry : public QObject {
+    Q_OBJECT
+public:
+    explicit KeyBindingRegistry(std::shared_ptr<Settings> settings, QObject* parent = nullptr);
+
+    QKeySequence shortcut(QStringView id) const;         // override if set, else default
+    QKeySequence defaultShortcut(QStringView id) const;
+    bool isCustomized(QStringView id) const;
+
+    // Empty result = no conflict. Canvas actions are checked against Application actions too:
+    // a window-scoped QAction shortcut fires even while the canvas has focus, so the two
+    // scopes are not independent namespaces.
+    QString conflictingActionId(QStringView id, const QKeySequence& seq) const;
+
+    void setShortcut(QStringView id, const QKeySequence& seq);  // empty sequence = unbound
+    void resetToDefault(QStringView id);
+    void resetAllToDefaults();
+    void save();
+
+    // Sinks: whatever is registered here is re-keyed automatically on rebind.
+    void bind(QStringView id, QAction* action);
+    void bind(QStringView id, QShortcut* shortcut);
+
+signals:
+    void bindingChanged(const QString& id, const QKeySequence& seq);
+};
+```
+
+`bind()` holds `QPointer` sinks and connects `bindingChanged` to `setShortcut()` /
+`setKey()`, so a rebind takes effect immediately with no restart and no re-walk of the menu bar.
+Owned by `MainWindow` (constructed next to `_settings`), injected into `SettingsDialog`.
+
+Migration is mechanical: every `QKeySequence("…")` literal in `setupMenuBar()`,
+`setupToolBar()`, `setupPanelsMenu()` and the slice-1/2 `QShortcut`s becomes
+`registry.bind(actions::X, action)` — the registry supplies the key. Slices 1 and 2 are written
+so this is a find-and-replace, not a redesign.
+
+### 4.4 Persistence
+
+Add to `Settings`:
+
+```cpp
+QMap<QString, QString> getKeyBindings() const;               // actionId -> portable text
+void setKeyBindings(const QMap<QString, QString>& bindings);
+```
+
+Stored as a top-level `"keyBindings"` object. **Write only entries that differ from the
+default** — that way changing a default in a later release still reaches users who never
+customized that action. An explicitly-unbound action persists as an empty string, which is
+distinct from absent.
+
+No `SETTINGS_VERSION` bump: an absent `"keyBindings"` key means "no overrides", which
+`Settings::fromJson()` already tolerates. Avoid touching the version — the 1.0→1.1 data-path
+migration at `Settings.cpp:178` keys off `_version != SETTINGS_VERSION` and would re-run
+`expandDataPaths()` on every existing install if the constant moved.
+
+### 4.5 Preferences page
+
+`src/ui/widgets/KeybindingsWidget` follows the shape of `DataPathsWidget` / `ScriptToolsWidget`
+(emit `changed()` + `statusChanged()`, edit an in-memory copy, commit on Apply/OK), and
+`SettingsDialog` gains `setupKeybindingsTab()` in `setupTabs()` (`SettingsDialog.cpp:74`). The
+registry pointer joins the constructor: `SettingsDialog(settings, registry, parent)`, null →
+tab omitted, so a bare-constructed dialog in a test still builds.
+
+Layout:
+
+- Filter `QLineEdit` at the top (matches label, category, and current keys).
+- `QTreeWidget` grouped by category — columns **Action / Shortcut / Default**, customized rows
+  shown bold with a per-row reset affordance.
+- Double-click the Shortcut cell → inline `QKeySequenceEdit` with
+  `setMaximumSequenceLength(1)` (single chord; multi-chord sequences are not wanted here).
+- Live conflict detection on `keySequenceChanged`: on a hit, mark the row with
+  `ui::theme::colors::ERROR` and set the status line to
+  *"Alt+2 is already assigned to Selection Panel"*, with a **Reassign** button that unbinds the
+  other action. Escape reverts the edit.
+- **Reset** (selected) and **Reset All** buttons.
+
+Use `ui::theme::spacing::*` and `ui::theme::styles::status*()` per `CLAUDE.md` — no hardcoded
+colours or paddings.
+
+### 4.6 Status-bar hints
+
+`hintForContext()` (`src/ui/core/EditorHints.h`) hardcodes key names and is explicitly
+documented as "kept in lockstep with InputHandler's handlers and the toolbar shortcuts". Once
+keys are remappable that comment becomes a lie. Give it a key-lookup callable
+(`std::function<QString(QStringView actionId)>`) so it stays pure and headless-testable while
+following rebinds. Small, and it keeps `tests/qt/test_editor_hints.cpp` meaningful.
+
+---
+
+## 5. What stays hardcoded, and why
+
+`InputHandler`'s remaining keys are **tool state-machine keys**, not commands: `Esc` (cancel /
+abandon the Draw-edge line), `Enter` (finalize that line), `Space` (flip the edge side), `R`
+while stamping (cycle pattern variant), `Delete`/`Backspace`. They are meaningful only inside a
+specific mode, they are dispatched in SFML key codes rather than `QKeySequence`, and rebinding
+them independently of their mode would produce incoherent states.
+
+Recommendation: leave them out of the registry and surface them in the Preferences page as a
+**read-only "Tool keys" section**, so they are discoverable without being editable. `P`
+(eyedropper) is the exception — it is a global canvas command wearing a tool key's clothes, so
+migrate it to a canvas `QShortcut` in slice 3 and make it rebindable.
+
+If tool keys are wanted as rebindable later, the migration path is a `CanvasShortcutDispatcher`
+consulted from `SFMLWidget::keyPressEvent()` *before* the Qt→SFML translation, returning
+handled/not-handled so unclaimed keys fall through to `InputHandler` unchanged.
+
+---
+
+## 6. Tests
+
+Added to `qt_tests` as `tests/qt/test_keybindings.cpp`:
+
+1. **Table integrity** — ids unique; every `defaultKeys` parses to a non-empty `QKeySequence`
+   (or is deliberately `""`); no two Application-scope defaults collide; no Canvas default
+   collides with an Application default.
+2. **Persistence round-trip** — set an override, `save()`, reload a fresh `Settings`, read it
+   back; confirm only the changed entry is written and a reset removes it from the JSON.
+3. **Conflict detection** — `conflictingActionId()` finds the collision, returns empty for the
+   action's own id, and treats an empty sequence as never conflicting.
+4. **Live rebind** — a `bind()`-registered `QAction` and `QShortcut` both pick up a new key
+   without re-registration.
+5. **Reveal semantics** (slice 1) — hidden → show+raise; tabbed-behind → raise; visible+focused
+   → hide.
+6. **`Return` stands down in `MarkExits`** — the guard that keeps the Draw-edge finalize working.
+7. **Fit-map math** (slice 2, in `tests/general/test_viewport_controller.cpp`) — the whole grid
+   is inside the view afterwards, and the zoom stays within the clamp.
+
+Existing suites that must stay green: `tests/qt/test_input_handler.cpp` (unchanged in slices 1–2;
+slice 3 touches it only if `P` moves), `tests/qt/test_editor_hints.cpp` (signature change in
+§4.6), `tests/qt/test_ui_regressions.cpp:751`.
+
+---
+
+## 7. Sequencing and effort
+
+| Slice | Scope | Files | Rough size |
+|---|---|---|---|
+| 1 | `Return` + `Alt+1…6` + `` Alt+` `` reveal-and-focus | `MainWindow.{h,cpp}` | ~150 lines + tests |
+| 2 | Elevation, `S`, `G`, `Home`, `F`, `Ctrl+Shift+E`; `B`/`R` → canvas | `MainWindow.{h,cpp}`, `ViewportController.{h,cpp}` | ~250 lines + tests |
+| 3 | Registry + Settings + Preferences page; migrate all literals | 4 new files, `MainWindow`, `SettingsDialog`, `Settings`, `EditorHints` | ~900 lines + tests |
+
+Slices 1 and 2 are independently shippable and answer the motivating gap. Slice 3 is the one
+that pays down `PLAN.md` §7 and unblocks §8 (customizable toolbar shares the same table).
+
+Per `CLAUDE.md`: run `./format.sh` before committing, open a PR per slice, wait for CI, and
+address Copilot / SonarCloud comments before considering a slice done.
+
+---
+
+## 8. Open decisions
+
+1. **`Ctrl+Shift+E` behaviour when the selection has no script** — no-op, or offer to attach one?
+   Recommend no-op with a status-bar message, matching the `Return` no-op convention.
+2. **Should slice 3 ship a "Keyboard shortcuts" reference (printable list)?** Cheap once the
+   table exists — a read-only view of the same tree — and it is the discoverability half of the
+   motivating gap. Recommend yes, in the Help menu.
+3. **macOS `Alt` = Option.** `Alt+digit` does not collide with menu mnemonics on macOS (there
+   are none) and `QLineEdit` will not see it as text, so the family is safe; worth a manual
+   check on the first macOS build since Option-digit types glyphs in some contexts.

--- a/docs/keybindings-plan.md
+++ b/docs/keybindings-plan.md
@@ -1,0 +1,98 @@
+# Keyboard shortcuts plan
+
+*Proposal for the default keybindings the editor should ship, and the one gap that motivated it:
+there is currently **no keyboard shortcut to show/focus any panel** — only the `View › Panels` menu
+mnemonics. This doc is the source list for the default bindings; every one is intended to be
+user-remappable through the configurable-keybindings work package (see the last section).*
+
+## Already-bound keys (do not collide)
+
+| Key | Action |
+|---|---|
+| `Ctrl+N` / `Ctrl+O` / `Ctrl+B` | New map / Open map / Browse Maps |
+| `Ctrl+S` / `Ctrl+Shift+S` / `Ctrl+W` | Save / Save As / Close map |
+| `Ctrl+,` / `Ctrl+Q` | Preferences / Quit |
+| `Ctrl+A` / `Ctrl+D` | Select All / Deselect All |
+| `Ctrl+Z` / `Ctrl+Y` | Undo / Redo |
+| `Ctrl+E` | Show Exit Grids (view toggle) |
+| `B` | Scroll-blocker rectangle mode |
+| `R` | Cycle stamp variant |
+| `F5` | Save & Play in Fallout 2 |
+| `F11` / `F16` | Spatial-script dialog / kill-type (legacy) |
+| `Esc` | Cancel current mode |
+| `Delete` / `Backspace` | Delete selected objects |
+
+Everything proposed below avoids these.
+
+---
+
+## 1. The motivating case: selected object → Selection panel
+
+Bind this two ways, because they serve different moments:
+
+- **`Enter` / `Return` — "inspect the selection."** After clicking a critter/object on the canvas,
+  `Enter` shows *and* focuses the Selection panel (raising it if hidden or tabbed behind another
+  dock). No number to remember — it reads as "open what I just selected," and is a no-op when
+  nothing is selected. This is the binding that fits the scenario most naturally.
+- **`Alt+2` — direct toggle of the Selection panel** regardless of selection (part of the numbered
+  family below).
+
+## 2. Panel family — `Alt+1…6`, `` Alt+` ``
+
+One consistent, discoverable group; each toggles **and** focuses its dock.
+
+| Key | Panel |
+|---|---|
+| `Alt+1` | Map Information |
+| `Alt+2` | Selection |
+| `Alt+3` | Scripts |
+| `Alt+4` | Tile Palette |
+| `Alt+5` | Object Palette |
+| `Alt+6` | File Browser |
+| `` Alt+` `` | Log / Script Console |
+
+`Alt+digit` is chosen deliberately so `Ctrl+digit` stays free for elevation, and so it rarely
+collides with text entry.
+
+## 3. Other high-value gaps
+
+Not panels, but the shortcuts a map editor is expected to have and Gecko currently lacks.
+
+| Key | Action | Why |
+|---|---|---|
+| `Ctrl+1` / `Ctrl+2` / `Ctrl+3` | Switch to elevation 1 / 2 / 3 | No elevation shortcut exists today — the biggest everyday gap |
+| `S` | Return to Select mode | Complements the existing `B` / `R` canvas keys; faster than `Esc` |
+| `G` | Toggle grid | Universal editor convention |
+| `Home` | Center view on player start | Fast "where's the entrance" jump |
+| `F` | Fit whole map in view | Quick zoom-to-extent |
+| `Ctrl+Shift+E` | Edit Script Source of the selected object's script | Jump from a scripted critter straight to its `.ssl` (ties into the SSL toolchain work) |
+
+---
+
+## Design caveats to build in
+
+- **Scope single-letter keys to the canvas.** `S` / `G` (like the existing `B` / `R`) must fire
+  only when the map view has focus, not while typing in a panel's filter box or a spin field —
+  otherwise typing "b" in a search field places scroll blockers. These should be editor-widget
+  shortcuts, not application-global `QAction`s.
+- **Toggle + focus semantics for panels.** A panel shortcut should raise a hidden/tabbed dock and
+  give it focus; pressing it again may hide it. "Show and focus" matters more than "toggle" for the
+  `Enter`-on-selection case.
+
+## Relationship to the configurable-keybindings work package
+
+This list is the intended set of **defaults** for the central command/action table proposed in
+`PLAN.md` (Editor limitations §7): a stable `action id → default QKeySequence + label/category`
+table, a Preferences page to rebind with live conflict detection, and persistence via `Settings`,
+driving both the menu/toolbar `QAction`s and the `InputHandler` dispatch. Rather than scattering
+more `QKeySequence` literals through `MainWindow::setupMenuBar()` and `InputHandler`, these bindings
+should land as rows in that table so they are discoverable and remappable from day one.
+
+### Suggested sequencing
+
+1. **Cheapest first slice (standalone):** `Enter` → reveal+focus the Selection panel, and the
+   `Alt+1…6` / `` Alt+` `` panel family. Directly answers the motivating gap; no new infrastructure.
+2. **Editor-navigation slice:** elevation `Ctrl+1/2/3`, `S` select, `G` grid, `Home` center, `F` fit
+   — all canvas-scoped.
+3. **Full slice:** fold everything above into the central keybinding table + Preferences rebind UI,
+   so the defaults become user-remappable.

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -176,6 +176,11 @@ void MainWindow::setEditorWidget(std::unique_ptr<EditorWidget> editorWidget) {
             std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - initStart).count());
     }
 
+    // The canvas exists only once init() has built it, and it is rebuilt per map, so the
+    // canvas-scoped shortcuts are re-installed here (parented to the widget, so the old ones go
+    // with it). Before connectToEditorWidget(), whose syncToolModeActions() seeds their enabled state.
+    installCanvasShortcuts();
+
     connectToEditorWidget();
     connect(_currentEditorWidget, &EditorWidget::undoStackChanged, this, &MainWindow::updateUndoRedoActions);
     // Any edit (or undo/redo) marks the map dirty for the close/title prompts.
@@ -314,37 +319,88 @@ void MainWindow::connectMenuSignals() {
     updateUndoRedoActions();
 }
 
-QAction* MainWindow::addPanelToggleAction(const QString& label, QDockWidget* dock, QAction*& actionRef) {
-    auto showDock = [this](QDockWidget* targetDock, bool visible) {
-        if (!targetDock) {
+void MainWindow::revealPanel(QDockWidget* dock, QAction* action) {
+    if (!dock) {
+        return;
+    }
+
+    // Panels are tabbed, so "visible" is not the same as "on screen": a dock sitting behind
+    // another tab is visible to Qt but hidden to the user, and a plain toggle would take it away
+    // just as they asked for it. Raise those instead, and hide only the tab already on top.
+    const bool onTop = !dock->isHidden() && !dock->visibleRegion().isEmpty();
+
+    if (onTop) {
+        dock->hide();
+    } else {
+        dock->show();
+        if (!dock->isFloating() && dockWidgetArea(dock) != Qt::NoDockWidgetArea) {
+            dock->raise();
+        }
+        // Put the caret in the panel so it can be used straight away. A panel whose widget takes
+        // no focus simply keeps it where it was.
+        if (QWidget* panel = dock->widget()) {
+            panel->setFocus(Qt::ShortcutFocusReason);
+        }
+    }
+
+    // show()/hide() fire visibilityChanged, which re-syncs the menu check state; a raise fires
+    // nothing, so re-assert it here for the tabbed-behind case.
+    if (action) {
+        const QSignalBlocker blocker(*action);
+        action->setChecked(!dock->isHidden());
+    }
+}
+
+void MainWindow::installCanvasShortcuts() {
+    SFMLWidget* canvas = _currentEditorWidget ? _currentEditorWidget->getSFMLWidget() : nullptr;
+    if (!canvas) {
+        return;
+    }
+
+    // "Inspect the selection": reveal the Selection panel for whatever was just clicked. Scoped to
+    // the canvas so a Return pressed in a panel's filter box or a spin box is left alone, and a
+    // no-op with an empty selection (there is nothing to inspect).
+    const auto inspectSelection = [this]() {
+        if (!_currentEditorWidget) {
             return;
         }
-
-        if (visible) {
-            targetDock->show();
-            if (!targetDock->isFloating() && dockWidgetArea(targetDock) != Qt::NoDockWidgetArea) {
-                targetDock->raise();
-            }
+        const selection::SelectionManager* selectionManager = _currentEditorWidget->getSelectionManager();
+        if (!selectionManager || !selectionManager->hasSelection()) {
             return;
         }
-
-        targetDock->hide();
+        revealPanel(_selectionDock, _selectionPanelAction);
     };
 
+    const auto addCanvasShortcut = [this, canvas](QKeySequence keys, auto handler) {
+        auto* shortcut = new QShortcut(std::move(keys), canvas);
+        shortcut->setContext(Qt::WidgetWithChildrenShortcut);
+        connect(shortcut, &QShortcut::activated, this, std::move(handler));
+        return shortcut;
+    };
+
+    // Return and numpad Enter are distinct key codes; one QShortcut catches only its own.
+    _inspectSelectionShortcut = addCanvasShortcut(QKeySequence(Qt::Key_Return), inspectSelection);
+    _inspectSelectionEnterShortcut = addCanvasShortcut(QKeySequence(Qt::Key_Enter), inspectSelection);
+}
+
+QAction* MainWindow::addPanelToggleAction(const QString& label, QDockWidget* dock, QAction*& actionRef,
+    const QKeySequence& shortcut) {
     actionRef = _panelsMenu->addAction(label);
     actionRef->setCheckable(true);
     actionRef->setChecked(true);
     QAction* action = actionRef;
+    if (!shortcut.isEmpty()) {
+        action->setShortcut(shortcut);
+    }
 
-    connect(action, &QAction::toggled, this, [this, dock, showDock](bool visible) {
-        if (_suppressDockStateSave) {
-            return;
-        }
-
-        spdlog::debug("{} action toggled: {}", dock->windowTitle().toStdString(), visible);
-        // showDock() flips the dock, which fires QDockWidget::visibilityChanged below; that handler
-        // persists the new layout, so there's nothing to save here.
-        showDock(dock, visible);
+    // triggered(), not toggled(): the check state Qt flips before this runs is only a request —
+    // revealPanel() decides from the dock's own state and re-asserts the box. Using triggered()
+    // also means the programmatic setChecked() calls elsewhere cannot reach here.
+    connect(action, &QAction::triggered, this, [this, dock, action]() {
+        spdlog::debug("{} panel action triggered", dock->windowTitle().toStdString());
+        // revealPanel() flips the dock, which fires QDockWidget::visibilityChanged below; that
+        // handler persists the new layout, so there's nothing to save here.
+        revealPanel(dock, action);
     });
 
     connect(dock, &QDockWidget::visibilityChanged, this, [this, dock, action](bool visible) {
@@ -1002,6 +1058,14 @@ void MainWindow::syncToolModeActions(EditorMode mode) {
         }
     }
 
+    // Enter finalizes the in-progress "Draw edge" polyline (InputHandler), so the inspect-selection
+    // shortcut must stand down in that mode rather than eat the key.
+    for (QShortcut* shortcut : { _inspectSelectionShortcut.data(), _inspectSelectionEnterShortcut.data() }) {
+        if (shortcut) {
+            shortcut->setEnabled(mode != EditorMode::MarkExits);
+        }
+    }
+
     // Free up "R" for the viewport while stamping or while a registered tool runs (object
     // placement); otherwise the toolbar shortcut would swallow the key before it reaches the editor.
     if (_rotateAction) {
@@ -1255,9 +1319,22 @@ void MainWindow::setupDockWidgets() {
         consoleAction->setText(tr("Script &Console"));
         _viewMenu->addAction(consoleAction);
 #endif
-        QAction* logAction = _logDock->toggleViewAction();
-        logAction->setText(tr("&Log"));
-        _viewMenu->addAction(logAction);
+        // Not _logDock->toggleViewAction(): that one plain-toggles, and the Log dock shares the
+        // bottom area with the Script Console, so Alt+` needs to raise it when it is tabbed
+        // behind. The check state is kept in step with the dock below instead.
+        _logPanelAction = _viewMenu->addAction(tr("&Log"));
+        _logPanelAction->setCheckable(true);
+        _logPanelAction->setChecked(!_logDock->isHidden());
+        _logPanelAction->setShortcut(QKeySequence(Qt::ALT | Qt::Key_QuoteLeft));
+        connect(_logPanelAction, &QAction::triggered, this, [this]() { revealPanel(_logDock, _logPanelAction); });
+        // The Log dock sits outside the managed-layout persistence, so this only mirrors state.
+        connect(_logDock, &QDockWidget::visibilityChanged, this, [this](bool visible) {
+            if (!_logPanelAction) {
+                return;
+            }
+            const QSignalBlocker blocker(*_logPanelAction);
+            _logPanelAction->setChecked(visible);
+        });
     }
 
     // MainWindow signals → current editor widget (connected once; both sender
@@ -2325,19 +2402,23 @@ void MainWindow::setupPanelsMenu() {
         const char* label;
         QDockWidget* dock;
         QAction** actionRef;
+        int shortcutKey; // Alt+<digit>; the family is deliberate, see docs/keybindings-plan.md
     };
 
+    // Alt+digit rather than Ctrl+digit: it keeps Ctrl+1..3 free for the elevations, and Alt+digit
+    // is not text, so a panel's filter box never swallows it.
     const std::array<PanelToggleSpec, 6> panelToggleSpecs = { {
-        { "Map &Information", _mapInfoDock, &_mapInfoPanelAction },
-        { "Scri&pts", _scriptsDock, &_scriptsPanelAction },
-        { "&Selection", _selectionDock, &_selectionPanelAction },
-        { "&Tile Palette", _tilePaletteDock, &_tilePalettePanelAction },
-        { "&Object Palette", _objectPaletteDock, &_objectPalettePanelAction },
-        { "&Virtual File System Browser", _fileBrowserDock, &_fileBrowserPanelAction },
+        { "Map &Information", _mapInfoDock, &_mapInfoPanelAction, Qt::Key_1 },
+        { "Scri&pts", _scriptsDock, &_scriptsPanelAction, Qt::Key_3 },
+        { "&Selection", _selectionDock, &_selectionPanelAction, Qt::Key_2 },
+        { "&Tile Palette", _tilePaletteDock, &_tilePalettePanelAction, Qt::Key_4 },
+        { "&Object Palette", _objectPaletteDock, &_objectPalettePanelAction, Qt::Key_5 },
+        { "&Virtual File System Browser", _fileBrowserDock, &_fileBrowserPanelAction, Qt::Key_6 },
     } };
 
     for (const PanelToggleSpec& spec : panelToggleSpecs) {
-        addPanelToggleAction(spec.label, spec.dock, *spec.actionRef);
+        addPanelToggleAction(spec.label, spec.dock, *spec.actionRef,
+            QKeySequence(Qt::ALT | static_cast<Qt::Key>(spec.shortcutKey)));
     }
 }
 

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -9,6 +9,8 @@
 #include <QIcon>
 #include <QTimer>
 #include <QKeyEvent>
+#include <QKeySequence>
+#include <QShortcut>
 #include <QPointer>
 #include <QStackedWidget>
 #include <QStatusBar>
@@ -231,7 +233,15 @@ private:
     void showPanelsForMap();
     void hidePanelsForNoMap();
     void setDockVisibility(QDockWidget* dock, QAction* action, bool visible);
-    QAction* addPanelToggleAction(const QString& label, QDockWidget* dock, QAction*& actionRef);
+    QAction* addPanelToggleAction(const QString& label, QDockWidget* dock, QAction*& actionRef,
+        const QKeySequence& shortcut = {});
+    // Show/raise/hide a panel dock for its menu item or keyboard shortcut. Docks are tabbed, so a
+    // dock Qt calls visible may be sitting behind another tab: raise it rather than hide it, and
+    // only hide when it is already the tab on top. `action` (optional) is re-checked to match.
+    void revealPanel(QDockWidget* dock, QAction* action);
+    // (Re)install the shortcuts scoped to the map canvas. Called whenever an EditorWidget is
+    // installed, since the SFML widget they hang off is rebuilt with it.
+    void installCanvasShortcuts();
     std::array<QDockWidget*, 6> managedDocks() const;
     std::array<DockActionPair, 6> managedDockActionPairs() const;
     void applyDefaultDockPlacements();
@@ -375,6 +385,13 @@ private:
     QAction* _tilePalettePanelAction;
     QAction* _objectPalettePanelAction;
     QAction* _fileBrowserPanelAction;
+    QAction* _logPanelAction = nullptr;
+
+    // "Inspect the selection": reveals the Selection panel from the canvas. Lives on the SFML
+    // widget (WidgetWithChildrenShortcut), so Return typed in a panel's filter box is untouched.
+    // Return and numpad Enter are separate key codes, hence the pair.
+    QPointer<QShortcut> _inspectSelectionShortcut;
+    QPointer<QShortcut> _inspectSelectionEnterShortcut;
 
     // Toolbar actions
     QAction* _selectionModeAction;

--- a/tests/qt/test_ui_regressions.cpp
+++ b/tests/qt/test_ui_regressions.cpp
@@ -10,6 +10,7 @@
 #include <QGroupBox>
 #include <QLabel>
 #include <QStackedWidget>
+#include <QShortcut>
 #include <QSignalSpy>
 #include <QStandardPaths>
 #include <QTemporaryDir>
@@ -38,6 +39,7 @@
 #include "ui/dialogs/ScriptSelectorDialog.h"
 #include "ui/widgets/DataPathsWidget.h"
 #include "ui/widgets/ObjectPreviewWidget.h"
+#include "ui/widgets/SFMLWidget.h"
 #include "ui/widgets/ProInfoPanelWidget.h"
 #include "ui/widgets/ProPreviewPanelWidget.h"
 #include "ui/widgets/WelcomeWidget.h"
@@ -790,6 +792,84 @@ TEST_CASE("MainWindow panel toggles stay wired in the no-map layout", "[qt][main
     REQUIRE_FALSE(selectionAction->isChecked());
 }
 
+// The panel shortcut family: Alt+1..6 on the six managed panels, Alt+` on the Log dock
+// (docs/keybindings-plan.md). Alt+digit rather than Ctrl+digit so Ctrl+1..3 stays free for the
+// elevations and a panel's filter box never swallows the key.
+TEST_CASE("Panel menu actions carry their Alt shortcuts", "[qt][mainwindow][keys]") {
+    removeTestSettings();
+
+    auto resources = std::make_shared<geck::resource::GameResources>();
+    geck::MainWindow window(resources, std::make_shared<geck::Settings>());
+    window.show();
+    QTest::qWait(250);
+
+    struct ExpectedShortcut {
+        const char* actionText;
+        QKeySequence keys;
+    };
+
+    const std::array<ExpectedShortcut, 7> expected = { {
+        { "Map Information", QKeySequence(Qt::ALT | Qt::Key_1) },
+        { "Selection", QKeySequence(Qt::ALT | Qt::Key_2) },
+        { "Scripts", QKeySequence(Qt::ALT | Qt::Key_3) },
+        { "Tile Palette", QKeySequence(Qt::ALT | Qt::Key_4) },
+        { "Object Palette", QKeySequence(Qt::ALT | Qt::Key_5) },
+        { "Virtual File System Browser", QKeySequence(Qt::ALT | Qt::Key_6) },
+        { "Log", QKeySequence(Qt::ALT | Qt::Key_QuoteLeft) },
+    } };
+
+    for (const ExpectedShortcut& entry : expected) {
+        QAction* action = findAction(window, entry.actionText);
+        REQUIRE(action != nullptr);
+        CHECK(action->shortcut() == entry.keys);
+    }
+}
+
+// The reason the panel keys reveal rather than plain-toggle: panels are tabbed, so a dock Qt calls
+// visible may be sitting behind another tab. Toggling would take it away exactly when the user asked
+// to see it.
+TEST_CASE("A panel action raises a tabbed-behind dock instead of hiding it", "[qt][mainwindow][keys]") {
+    removeTestSettings();
+
+    auto resources = std::make_shared<geck::resource::GameResources>();
+    geck::MainWindow window(resources, std::make_shared<geck::Settings>());
+    window.show();
+    QTest::qWait(250);
+
+    auto* mapInfoDock = window.findChild<QDockWidget*>("MapInfoDock");
+    auto* selectionDock = window.findChild<QDockWidget*>("SelectionDock");
+    auto* selectionAction = findAction(window, "Selection");
+    REQUIRE(mapInfoDock != nullptr);
+    REQUIRE(selectionDock != nullptr);
+    REQUIRE(selectionAction != nullptr);
+
+    window.tabifyDockWidget(mapInfoDock, selectionDock);
+    mapInfoDock->show();
+    selectionDock->show();
+    mapInfoDock->raise(); // Map Info is the tab on top, Selection is behind it
+    QApplication::processEvents();
+    QTest::qWait(50);
+
+    REQUIRE_FALSE(selectionDock->isHidden());          // visible to Qt...
+    REQUIRE(selectionDock->visibleRegion().isEmpty()); // ...but not on screen
+
+    selectionAction->trigger();
+    QApplication::processEvents();
+    QTest::qWait(50);
+
+    CHECK_FALSE(selectionDock->isHidden());
+    CHECK_FALSE(selectionDock->visibleRegion().isEmpty()); // raised to the front tab
+    CHECK(selectionAction->isChecked());
+
+    // Now that it is the tab on top, the same action puts it away.
+    selectionAction->trigger();
+    QApplication::processEvents();
+    QTest::qWait(50);
+
+    CHECK(selectionDock->isHidden());
+    CHECK_FALSE(selectionAction->isChecked());
+}
+
 // File > Close Map returns to the welcome screen. It must exist with the standard Close shortcut,
 // and triggering it with nothing open must be a safe no-op (no editor spawned, no crash) — the
 // handler guards on hasActiveMap() before touching the teardown path.
@@ -1322,6 +1402,64 @@ TEST_CASE("EditorWidget switches between the two exit-grid sub-modes", "[qt][exi
 
     editor->setMode(geck::EditorMode::Select);
     CHECK(editor->currentMode() == geck::EditorMode::Select);
+}
+
+// "Inspect the selection": Return (and numpad Enter, a distinct key code) reveals the Selection
+// panel. Both are scoped to the canvas so a Return typed in a panel's filter box is left alone, and
+// both must stand down in MarkExits mode, where Enter finalizes the in-progress Draw-edge polyline
+// (InputHandler). Constructing an EditorWidget eagerly loads art/misc/HEX.frm, so this needs game
+// data mounted; without it we skip.
+TEST_CASE("Inspect-selection keys live on the canvas and stand down in Draw-edge mode", "[qt][mainwindow][keys]") {
+    removeTestSettings();
+
+    auto resources = std::make_shared<geck::resource::GameResources>();
+    geck::MainWindow window(resources, std::make_shared<geck::Settings>());
+    window.show();
+    QTest::qWait(250);
+
+    std::unique_ptr<geck::EditorWidget> editor;
+    try {
+        editor = std::make_unique<geck::EditorWidget>(*resources, makeMap("inspect.map"));
+    } catch (const std::exception& e) {
+        SKIP(std::string("EditorWidget needs mounted game data (HEX.frm): ") + e.what());
+    }
+    window.setEditorWidget(std::move(editor));
+    QApplication::processEvents();
+
+    auto* editorWidget = window.findChild<geck::EditorWidget*>();
+    REQUIRE(editorWidget != nullptr);
+    geck::SFMLWidget* canvas = editorWidget->getSFMLWidget();
+    REQUIRE(canvas != nullptr);
+
+    // The keys hang off the canvas, not the window: WidgetWithChildrenShortcut is what keeps them
+    // out of the panels' text fields.
+    const QList<QShortcut*> canvasShortcuts = canvas->findChildren<QShortcut*>();
+    QList<QKeySequence> keys;
+    for (const QShortcut* shortcut : canvasShortcuts) {
+        CHECK(shortcut->context() == Qt::WidgetWithChildrenShortcut);
+        keys.append(shortcut->key());
+    }
+    CHECK(keys.contains(QKeySequence(Qt::Key_Return)));
+    CHECK(keys.contains(QKeySequence(Qt::Key_Enter)));
+
+    for (const QShortcut* shortcut : canvasShortcuts) {
+        CHECK(shortcut->isEnabled());
+    }
+
+    // Draw edge: Enter belongs to the polyline, so the reveal keys step aside.
+    editorWidget->setMarkExitsMode(true);
+    QApplication::processEvents();
+    REQUIRE(editorWidget->currentMode() == geck::EditorMode::MarkExits);
+    for (const QShortcut* shortcut : canvasShortcuts) {
+        CHECK_FALSE(shortcut->isEnabled());
+    }
+
+    // Leaving the mode hands them back.
+    editorWidget->setMode(geck::EditorMode::Select);
+    QApplication::processEvents();
+    for (const QShortcut* shortcut : canvasShortcuts) {
+        CHECK(shortcut->isEnabled());
+    }
 }
 
 TEST_CASE("MapInfoPanel edits a global variable value and persists it to the map's .gam", "[qt][mapinfo]") {

--- a/tests/qt/test_ui_regressions.cpp
+++ b/tests/qt/test_ui_regressions.cpp
@@ -1442,24 +1442,36 @@ TEST_CASE("Inspect-selection keys live on the canvas and stand down in Draw-edge
     CHECK(keys.contains(QKeySequence(Qt::Key_Return)));
     CHECK(keys.contains(QKeySequence(Qt::Key_Enter)));
 
-    for (const QShortcut* shortcut : canvasShortcuts) {
-        CHECK(shortcut->isEnabled());
-    }
+    // Only these two are asserted on by key rather than sweeping every canvas shortcut, so a
+    // shortcut added later for something else cannot fail this test.
+    const auto shortcutFor = [&canvasShortcuts](const QKeySequence& wanted) -> const QShortcut* {
+        for (const QShortcut* shortcut : canvasShortcuts) {
+            if (shortcut->key() == wanted) {
+                return shortcut;
+            }
+        }
+        return nullptr;
+    };
+
+    const QShortcut* inspectReturn = shortcutFor(QKeySequence(Qt::Key_Return));
+    const QShortcut* inspectEnter = shortcutFor(QKeySequence(Qt::Key_Enter));
+    REQUIRE(inspectReturn != nullptr);
+    REQUIRE(inspectEnter != nullptr);
+    CHECK(inspectReturn->isEnabled());
+    CHECK(inspectEnter->isEnabled());
 
     // Draw edge: Enter belongs to the polyline, so the reveal keys step aside.
     editorWidget->setMarkExitsMode(true);
     QApplication::processEvents();
     REQUIRE(editorWidget->currentMode() == geck::EditorMode::MarkExits);
-    for (const QShortcut* shortcut : canvasShortcuts) {
-        CHECK_FALSE(shortcut->isEnabled());
-    }
+    CHECK_FALSE(inspectReturn->isEnabled());
+    CHECK_FALSE(inspectEnter->isEnabled());
 
     // Leaving the mode hands them back.
     editorWidget->setMode(geck::EditorMode::Select);
     QApplication::processEvents();
-    for (const QShortcut* shortcut : canvasShortcuts) {
-        CHECK(shortcut->isEnabled());
-    }
+    CHECK(inspectReturn->isEnabled());
+    CHECK(inspectEnter->isEnabled());
 }
 
 TEST_CASE("MapInfoPanel edits a global variable value and persists it to the map's .gam", "[qt][mapinfo]") {


### PR DESCRIPTION
There is no keyboard shortcut to show or focus any panel today — only the `View › Panels` menu. This is the first of three slices from `docs/keybindings-plan.md`; each is independently shippable.

## What this adds

| Key | Action |
|---|---|
| `Alt+1` … `Alt+6` | Map Information / Selection / Scripts / Tile Palette / Object Palette / File Browser |
| `` Alt+` `` | Log panel |
| `Return`, numpad `Enter` | Inspect the selection (reveal the Selection panel), canvas-scoped |

`Alt+digit` rather than `Ctrl+digit` so `Ctrl+1..3` stays free for the elevations (slice 2), and because `Alt+digit` is not text, so a panel's filter box never swallows it.

## Reveal, not toggle

Panels are tabbed, so "visible" is not the same as "on screen". A plain toggle on a dock sitting behind another tab would hide the panel just as the user asked to see it. So: hidden → show + raise + focus; visible but tabbed behind → raise + focus; visible and on top → hide.

Two details this forced:

- The check state Qt flips before the handler runs is only a *request* — a raise fires no `visibilityChanged`, which is the only thing that re-syncs the checkmark. `revealPanel()` re-asserts it under a `QSignalBlocker`, and the handler moved from `toggled` to `triggered`.
- Deliberately **no "is it focused" test**. With one, a menu click on a ticked item (focus is elsewhere by then) would raise-and-focus instead of hiding, so putting a panel away from the menu would take two clicks. Menu behaviour is therefore unchanged, and its existing regression test passes untouched.

The Log dock gets its own checkable action rather than Qt's `toggleViewAction()`, which only plain-toggles.

## Inspect keys

Both hang off the SFML widget with `Qt::WidgetWithChildrenShortcut`, so a `Return` typed in a panel's filter box is untouched, and both stand down in `MarkExits` mode where `Enter` finalizes the in-progress Draw-edge polyline. `Return` and numpad `Enter` are distinct key codes, hence the pair.

## Tests

`tests/qt/test_ui_regressions.cpp`: the Alt family is on the actions; a tabbed-behind dock is raised rather than hidden, and hidden once it is the tab on top; the canvas keys carry the right context and stand down in Draw-edge mode (game-data gated like the existing `EditorWidget` case — verified locally against `master.dat`).

`qt_tests` 120 cases green; `general_tests` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xrioPDMqr7L4CS2Y1gJFc