### PR TITLE
Add the editor navigation keys and move the letter keys to the canvas

### DIFF
--- a/src/format/map/Map.cpp
+++ b/src/format/map/Map.cpp
@@ -21,6 +21,21 @@ const Map::MapFile& Map::getMapFile() const {
     return *mapFile;
 }
 
+std::optional<int> Map::scriptProgramIndexForSid(uint32_t sid) const {
+    const int section = MapScript::sidSection(sid);
+    if (!mapFile || section < 0 || section >= SCRIPT_SECTIONS) {
+        return std::nullopt;
+    }
+
+    for (const MapScript& script : mapFile->map_scripts[section]) {
+        if (script.pid == sid) {
+            return static_cast<int>(script.script_id);
+        }
+    }
+
+    return std::nullopt;
+}
+
 void Map::setMapFile(std::unique_ptr<MapFile> newMapFile) {
     mapFile = std::move(newMapFile);
 }

--- a/src/format/map/Map.h
+++ b/src/format/map/Map.h
@@ -92,6 +92,11 @@ public:
     const std::optional<MapEdge>& edge() const { return _edge; }
     void setEdge(std::optional<MapEdge> edge) { _edge = std::move(edge); }
 
+    /// The scripts.lst program index (0-based, what gecko speaks — see CLAUDE.md "Script Index
+    /// Bases") of the map script an object's SID names, or nullopt when this map has no script
+    /// with that SID. The SID's section picks which of the five script lists to search.
+    std::optional<int> scriptProgramIndexForSid(uint32_t sid) const;
+
     /// Builds a blank Fallout 2 map: default header, three empty elevations of
     /// EMPTY_TILE tiles, and no scripts or objects.
     static MapFile createEmptyMapFile();

--- a/src/ui/core/EditorHints.cpp
+++ b/src/ui/core/EditorHints.cpp
@@ -21,11 +21,13 @@ QString hintForContext(EditorMode mode, bool hasSelection, const QString& active
 
     switch (mode) {
         case Select:
-            // Only the keys that genuinely act on a selection: Rotate's "R" toolbar
-            // shortcut (live whenever not stamping) and Delete/Backspace. With nothing
-            // selected neither does anything, so the hint is empty.
+            // Only the keys that genuinely act on a selection: Rotate's canvas "R" (live
+            // whenever not stamping), Enter to inspect it in the Selection panel, and
+            // Delete/Backspace. With nothing selected none of them does anything, so the hint
+            // is empty.
             if (hasSelection) {
-                return joinHints({ QStringLiteral("R: rotate"),
+                return joinHints({ QStringLiteral("Enter: inspect"),
+                    QStringLiteral("R: rotate"),
                     QStringLiteral("Delete: remove") });
             }
             return QString();

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -18,6 +18,7 @@
 #include "ui/panels/CompletenessView.h"
 #include "resource/MapCompleteness.h"
 #include "ui/rendering/ThumbnailPrewarmer.h"
+#include "viewport/ViewportController.h"
 #ifdef GECK_SCRIPTING_ENABLED
 #include "ui/panels/ScriptConsoleWidget.h"
 #include "scripting/LuaScriptRuntime.h" // ScriptResult
@@ -381,6 +382,73 @@ void MainWindow::installCanvasShortcuts() {
     // Return and numpad Enter are distinct key codes; one QShortcut catches only its own.
     _inspectSelectionShortcut = addCanvasShortcut(QKeySequence(Qt::Key_Return), inspectSelection);
     _inspectSelectionEnterShortcut = addCanvasShortcut(QKeySequence(Qt::Key_Enter), inspectSelection);
+
+    // Navigation and tool keys. Single letters belong on the canvas: window-scoped they would fire
+    // while a palette grid, a tree or a non-editable combo has focus, and typing "b" in such a
+    // place would start placing scroll blockers.
+    addCanvasShortcut(QKeySequence(Qt::Key_S), [this]() {
+        if (_selectToolAction) {
+            _selectToolAction->trigger();
+        }
+    });
+    addCanvasShortcut(QKeySequence(Qt::Key_G), [this]() {
+        if (_showHexGridAction) {
+            _showHexGridAction->toggle();
+        }
+    });
+    addCanvasShortcut(QKeySequence(Qt::Key_B), [this]() {
+        if (_scrollBlockerRectAction) {
+            _scrollBlockerRectAction->trigger();
+        }
+    });
+    _rotateShortcut = addCanvasShortcut(QKeySequence(Qt::Key_R), [this]() {
+        if (_rotateAction) {
+            _rotateAction->trigger();
+        }
+    });
+
+    addCanvasShortcut(QKeySequence(Qt::Key_Home), [this]() {
+        if (_currentEditorWidget) {
+            _currentEditorWidget->centerViewOnPlayerPosition();
+        }
+    });
+    addCanvasShortcut(QKeySequence(Qt::Key_F), [this]() {
+        if (_currentEditorWidget) {
+            _currentEditorWidget->viewport().fitMapInView();
+        }
+    });
+}
+
+void MainWindow::editSelectedObjectScriptSource() {
+    if (!_currentEditorWidget || !_scriptSourceService) {
+        return;
+    }
+
+    const Map* map = _currentEditorWidget->getMap();
+    const selection::SelectionManager* selectionManager = _currentEditorWidget->getSelectionManager();
+    if (!map || !selectionManager) {
+        return;
+    }
+
+    // The first selected object that actually owns a script. A selection of tiles, or of objects
+    // with nothing attached, is a no-op with a word in the status bar rather than a dialog.
+    for (const selection::SelectedItem& item : selectionManager->getCurrentSelection().items) {
+        if (!item.isObject()) {
+            continue;
+        }
+        const std::shared_ptr<Object> object = item.getObject();
+        const std::shared_ptr<MapObject> mapObject = object ? object->getMapObjectPtr() : nullptr;
+        if (!mapObject || mapObject->map_scripts_pid == -1) {
+            continue;
+        }
+        const auto sid = static_cast<uint32_t>(mapObject->map_scripts_pid);
+        if (const std::optional<int> programIndex = map->scriptProgramIndexForSid(sid)) {
+            _scriptSourceService->editScriptSource(*programIndex);
+            return;
+        }
+    }
+
+    showStatusMessage(tr("No script attached to the selection"));
 }
 
 QAction* MainWindow::addPanelToggleAction(const QString& label, QDockWidget* dock, QAction*& actionRef,
@@ -539,9 +607,14 @@ void MainWindow::setupMenuBar() {
     addMenuAction(_editMenu, ":/icons/actions/deselect.svg", "&Deselect All", &MainWindow::deselectAllRequested, QKeySequence("Ctrl+D"), "Clear all selections");
 
     _editMenu->addSeparator();
-    addMenuAction(_editMenu, ":/icons/actions/scroll-blocker.svg", "Scroll &Blocker Rectangle", &MainWindow::toggleScrollBlockerRectangleMode, QKeySequence("B"), "Draw rectangle and place scroll blockers on borders");
+    // No shortcut on the action itself: "B" is canvas-scoped (installCanvasShortcuts), so it cannot
+    // fire while a palette grid or a tree has focus.
+    _scrollBlockerRectAction = addMenuAction(_editMenu, ":/icons/actions/scroll-blocker.svg", "Scroll &Blocker Rectangle", &MainWindow::toggleScrollBlockerRectangleMode, QKeySequence(), "Draw rectangle and place scroll blockers on borders (B)");
     addMenuAction(_editMenu, ":/icons/actions/save.svg", "Save Selection as &Pattern...", &MainWindow::showSavePatternDialog, QKeySequence(), "Save the current selection as a reusable prefab pattern");
     addMenuAction(_editMenu, ":/icons/actions/open.svg", "S&tamp Pattern...", &MainWindow::showStampPatternDialog, QKeySequence(), "Load a prefab pattern and click to place it");
+    // Jump from a scripted object straight to its .ssl. Window-scoped: it is a command, not a
+    // single letter, so it costs nothing while a filter box has focus.
+    addMenuAction(_editMenu, ":/icons/actions/settings.svg", "&Edit Script Source", &MainWindow::editSelectedObjectScriptSource, QKeySequence("Ctrl+Shift+E"), "Open the .ssl of the script attached to the selected object");
 #ifdef GECK_SCRIPTING_ENABLED
     // Fill is driven entirely by Luau fill scripts, so it is offered only when scripting is built in.
     // Every use of _fillSelectionAction below is null-guarded, so leaving it null disables the feature.
@@ -732,12 +805,16 @@ void MainWindow::setupMenuBar() {
         const char* text;
         int elevation;
         bool checked;
+        int shortcutKey;
     };
 
+    // Ctrl+digit, the counterpart to the panels' Alt+digit. updateElevationMenu() enables only the
+    // elevations the open map actually has, and a shortcut on a disabled action is a no-op — so a
+    // map with one elevation ignores Ctrl+2 rather than switching to a level that isn't there.
     const std::array<ElevationActionSpec, 3> elevationSpecs = { {
-        { &_elevation1Action, "Elevation &1", ELEVATION_1, true },
-        { &_elevation2Action, "Elevation &2", ELEVATION_2, false },
-        { &_elevation3Action, "Elevation &3", ELEVATION_3, false },
+        { &_elevation1Action, "Elevation &1", ELEVATION_1, true, Qt::Key_1 },
+        { &_elevation2Action, "Elevation &2", ELEVATION_2, false, Qt::Key_2 },
+        { &_elevation3Action, "Elevation &3", ELEVATION_3, false, Qt::Key_3 },
     } };
 
     for (const ElevationActionSpec& spec : elevationSpecs) {
@@ -745,6 +822,7 @@ void MainWindow::setupMenuBar() {
         action->setCheckable(true);
         action->setChecked(spec.checked);
         action->setData(spec.elevation);
+        action->setShortcut(QKeySequence(Qt::CTRL | static_cast<Qt::Key>(spec.shortcutKey)));
         action->setDisabled(true);
         elevationGroup->addAction(action);
         connect(action, &QAction::triggered, this, [this, elevation = spec.elevation]() { elevationChanged(elevation); });
@@ -887,9 +965,9 @@ void MainWindow::setupToolBar() {
 
     _mainToolBar->addSeparator();
 
-    // Stored so it can be disabled while stamping a pattern — otherwise its "R" shortcut
-    // swallows the key before it reaches the viewport, where R cycles pattern variants.
-    _rotateAction = addToolAction(":/icons/actions/rotate.svg", "Rotate", &MainWindow::rotateObjectRequested, "Rotate selected object", QKeySequence("R"));
+    // "R" is canvas-scoped (installCanvasShortcuts) rather than a shortcut on this action, so it
+    // only fires with the map view focused. The button itself stays enabled in every mode.
+    _rotateAction = addToolAction(":/icons/actions/rotate.svg", "Rotate", &MainWindow::rotateObjectRequested, "Rotate selected object (R)");
 
     _mainToolBar->addSeparator();
 
@@ -1067,9 +1145,11 @@ void MainWindow::syncToolModeActions(EditorMode mode) {
     }
 
     // Free up "R" for the viewport while stamping or while a registered tool runs (object
-    // placement); otherwise the toolbar shortcut would swallow the key before it reaches the editor.
-    if (_rotateAction) {
-        _rotateAction->setEnabled(mode != EditorMode::StampPattern && mode != EditorMode::PluginTool);
+    // placement); otherwise the shortcut would swallow the key before it reaches the editor, where
+    // R cycles a stamp's orientation variants. The toolbar button stays enabled either way — only
+    // the key stands down.
+    if (_rotateShortcut) {
+        _rotateShortcut->setEnabled(mode != EditorMode::StampPattern && mode != EditorMode::PluginTool);
     }
 }
 

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -242,6 +242,9 @@ private:
     // (Re)install the shortcuts scoped to the map canvas. Called whenever an EditorWidget is
     // installed, since the SFML widget they hang off is rebuilt with it.
     void installCanvasShortcuts();
+    // Ctrl+Shift+E: open the .ssl of the script attached to the selected object (the same
+    // ScriptSourceService flow as the Selection panel's "Edit Source..." button).
+    void editSelectedObjectScriptSource();
     std::array<QDockWidget*, 6> managedDocks() const;
     std::array<DockActionPair, 6> managedDockActionPairs() const;
     void applyDefaultDockPlacements();
@@ -386,12 +389,18 @@ private:
     QAction* _objectPalettePanelAction;
     QAction* _fileBrowserPanelAction;
     QAction* _logPanelAction = nullptr;
+    // Edit-menu "Scroll Blocker Rectangle"; its key lives on the canvas, so the action is held to
+    // be triggered from there.
+    QAction* _scrollBlockerRectAction = nullptr;
 
     // "Inspect the selection": reveals the Selection panel from the canvas. Lives on the SFML
     // widget (WidgetWithChildrenShortcut), so Return typed in a panel's filter box is untouched.
     // Return and numpad Enter are separate key codes, hence the pair.
     QPointer<QShortcut> _inspectSelectionShortcut;
     QPointer<QShortcut> _inspectSelectionEnterShortcut;
+    // Canvas "R". Held so it can stand down while stamping or while a registered tool runs, where
+    // R belongs to the viewport (stamp variants) instead.
+    QPointer<QShortcut> _rotateShortcut;
 
     // Toolbar actions
     QAction* _selectionModeAction;

--- a/src/ui/input/InputHandler.cpp
+++ b/src/ui/input/InputHandler.cpp
@@ -337,9 +337,9 @@ void InputHandler::handleKeyPressed(const sf::Event::KeyPressed& event) {
             _callbacks.onDeleteObjects();
         }
     } else if (event.code == sf::Keyboard::Key::R) {
-        // The Rotate toolbar shortcut is disabled by the editor while stamping (and while a
-        // registered tool runs), so R reaches us here: in stamp mode it cycles the pattern's
-        // orientation variants. A registered tool sees R first via onToolKeyPressed above.
+        // The canvas "R" shortcut stands down while stamping (and while a registered tool runs),
+        // so R reaches us here: in stamp mode it cycles the pattern's orientation variants.
+        // A registered tool sees R first via onToolKeyPressed above.
         if (_mode == EditorMode::StampPattern && _callbacks.onStampCycleVariant) {
             _callbacks.onStampCycleVariant();
         }

--- a/src/ui/panels/SelectionPanel.cpp
+++ b/src/ui/panels/SelectionPanel.cpp
@@ -1218,23 +1218,19 @@ void SelectionPanel::updateScriptSection() {
     _attachedScriptProgramIndex = -1;
     if (attached) {
         const uint32_t sid = static_cast<uint32_t>(mapObject->map_scripts_pid);
-        const int section = MapScript::sidSection(sid);
-        if (section >= 0 && section < Map::SCRIPT_SECTIONS) {
-            for (const auto& s : _map->getMapFile().map_scripts[section]) {
-                if (s.pid == sid) {
-                    _attachedScriptProgramIndex = static_cast<int>(s.script_id);
-                    auto* lst = _resources.repository().load<Lst>(ResourcePaths::Lst::SCRIPTS);
-                    if (lst && s.script_id < lst->list().size()) {
-                        text = QString::fromStdString(lst->list().at(s.script_id));
-                        const std::string desc = resource::scriptDescription(_resources, static_cast<int>(s.script_id));
-                        if (!desc.empty()) {
-                            text += " — " + QString::fromStdString(desc);
-                        }
-                    } else {
-                        text = QString("Script #%1").arg(s.script_id);
-                    }
-                    break;
+        // Shared with the Ctrl+Shift+E path in MainWindow, so the two resolve the same script.
+        if (const std::optional<int> programIndex = _map->scriptProgramIndexForSid(sid)) {
+            _attachedScriptProgramIndex = *programIndex;
+            const auto scriptId = static_cast<size_t>(*programIndex);
+            auto* lst = _resources.repository().load<Lst>(ResourcePaths::Lst::SCRIPTS);
+            if (lst && scriptId < lst->list().size()) {
+                text = QString::fromStdString(lst->list().at(scriptId));
+                const std::string desc = resource::scriptDescription(_resources, *programIndex);
+                if (!desc.empty()) {
+                    text += " — " + QString::fromStdString(desc);
                 }
+            } else {
+                text = QString("Script #%1").arg(*programIndex);
             }
         }
     }

--- a/src/viewport/ViewportController.cpp
+++ b/src/viewport/ViewportController.cpp
@@ -1,9 +1,12 @@
 #include "ViewportController.h"
 #include "editor/Hex.h"
 #include "util/Constants.h"
+#include "util/TileUtils.h"
 #include <spdlog/spdlog.h>
 #include <algorithm>
+#include <array>
 #include <cmath>
+#include <limits>
 
 using namespace geck;
 
@@ -31,6 +34,57 @@ void ViewportController::centerViewOnMap() {
 
     _view.setCenter(sf::Vector2f(centerX, centerY));
     spdlog::debug("ViewportController: Centered view on ({:.1f}, {:.1f})", centerX, centerY);
+}
+
+sf::FloatRect ViewportController::mapWorldBounds() {
+    // The projection is affine, so the grid's four corner tiles bound every tile between them.
+    const std::array<TileCoordinates, 4> corners = { {
+        TileCoordinates(0u, 0u),
+        TileCoordinates(0u, static_cast<unsigned int>(MAP_WIDTH - 1)),
+        TileCoordinates(static_cast<unsigned int>(MAP_HEIGHT - 1), 0u),
+        TileCoordinates(static_cast<unsigned int>(MAP_HEIGHT - 1), static_cast<unsigned int>(MAP_WIDTH - 1)),
+    } };
+
+    float minX = std::numeric_limits<float>::max();
+    float minY = std::numeric_limits<float>::max();
+    float maxX = std::numeric_limits<float>::lowest();
+    float maxY = std::numeric_limits<float>::lowest();
+
+    for (const TileCoordinates& corner : corners) {
+        const auto topLeft = coordinatesToScreenPosition(corner);
+        const float x = static_cast<float>(topLeft.x);
+        const float y = static_cast<float>(topLeft.y);
+        minX = std::min(minX, x);
+        minY = std::min(minY, y);
+        maxX = std::max(maxX, x + static_cast<float>(TILE_WIDTH));
+        maxY = std::max(maxY, y + static_cast<float>(TILE_HEIGHT));
+    }
+
+    return sf::FloatRect({ minX, minY }, { maxX - minX, maxY - minY });
+}
+
+void ViewportController::fitMapInView() {
+    if (_windowSize.x == 0 || _windowSize.y == 0) {
+        spdlog::warn("ViewportController: Cannot fit the map into a {}x{} window", _windowSize.x, _windowSize.y);
+        return;
+    }
+
+    const sf::FloatRect bounds = mapWorldBounds();
+    if (bounds.size.x <= 0.f || bounds.size.y <= 0.f) {
+        return;
+    }
+
+    // The tighter of the two axes decides, so the whole grid fits rather than just one dimension.
+    const float fitZoom = std::min(
+        static_cast<float>(_windowSize.x) / bounds.size.x,
+        static_cast<float>(_windowSize.y) / bounds.size.y);
+
+    setZoomLevel(fitZoom); // clamps, and resizes the view to match
+    // After the zoom: setZoomLevel keeps the old centre, and the map centre is what we want.
+    _view.setCenter(bounds.position + bounds.size / 2.0f);
+
+    spdlog::debug("ViewportController: Fit map ({:.0f}x{:.0f}) into {}x{} at zoom {:.2f}",
+        bounds.size.x, bounds.size.y, _windowSize.x, _windowSize.y, _zoomLevel);
 }
 
 void ViewportController::panBy(sf::Vector2f worldDelta) {

--- a/src/viewport/ViewportController.h
+++ b/src/viewport/ViewportController.h
@@ -45,6 +45,23 @@ public:
     void centerViewOnMap();
 
     /**
+     * @brief World-space bounds of the whole tile grid.
+     *
+     * Derived from the authoritative forward projection (coordinatesToScreenPosition) at the
+     * grid's four corners, which bound it because the projection is affine — so this cannot
+     * drift from where the tiles are actually drawn.
+     */
+    static sf::FloatRect mapWorldBounds();
+
+    /**
+     * @brief Zoom out far enough to show the whole tile grid, then centre it.
+     *
+     * The zoom is clamped like any other (MIN_ZOOM..MAX_ZOOM); at the clamp the map is centred
+     * but still overflows the view.
+     */
+    void fitMapInView();
+
+    /**
      * @brief Pan the view by a delta expressed in world units.
      *
      * The single place that moves the camera; both the drag-pan and the

--- a/tests/general/test_viewport_controller.cpp
+++ b/tests/general/test_viewport_controller.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
 
 #include <SFML/System/Vector2.hpp>
 
@@ -111,4 +112,51 @@ TEST_CASE("Tile placement uses the render projection, not hex-snapping", "[viewp
     // Zero divergences would mean the two algorithms are equivalent and the fix a no-op.
     // The whole point of WP-10 is that they are NOT: placement diverged from hover.
     CHECK(divergences > 0);
+}
+
+// "F" fits the whole map in view. The grid's extent comes from the same forward projection the
+// tiles are drawn with, so the two cannot drift apart.
+TEST_CASE("ViewportController fits the whole tile grid in view", "[viewport][zoom]") {
+    const sf::FloatRect bounds = ViewportController::mapWorldBounds();
+
+    // Every tile in the grid lands inside the reported bounds.
+    for (int index : { 0, MAP_WIDTH - 1, (MAP_HEIGHT - 1) * MAP_WIDTH, MAP_WIDTH * MAP_HEIGHT - 1, 5050 }) {
+        const auto topLeft = indexToScreenPosition(index);
+        CHECK(static_cast<float>(topLeft.x) >= bounds.position.x);
+        CHECK(static_cast<float>(topLeft.y) >= bounds.position.y);
+        CHECK(static_cast<float>(topLeft.x) + TILE_WIDTH <= bounds.position.x + bounds.size.x);
+        CHECK(static_cast<float>(topLeft.y) + TILE_HEIGHT <= bounds.position.y + bounds.size.y);
+    }
+
+    HexagonGrid grid;
+    ViewportController viewport(&grid);
+    viewport.initialize({ 1600u, 900u });
+    viewport.fitMapInView();
+
+    // The view now covers the grid on both axes, centred on it.
+    const sf::View& view = viewport.getView();
+    const sf::Vector2f half = view.getSize() / 2.0f;
+    CHECK(view.getCenter().x == Catch::Approx(bounds.position.x + bounds.size.x / 2.0f));
+    CHECK(view.getCenter().y == Catch::Approx(bounds.position.y + bounds.size.y / 2.0f));
+    CHECK(view.getCenter().x - half.x <= bounds.position.x);
+    CHECK(view.getCenter().x + half.x >= bounds.position.x + bounds.size.x);
+    CHECK(view.getCenter().y - half.y <= bounds.position.y);
+    CHECK(view.getCenter().y + half.y >= bounds.position.y + bounds.size.y);
+
+    // A 1600x900 viewport needs about 0.20x, comfortably inside the zoom clamp.
+    CHECK(viewport.getZoomLevel() > 0.1f);
+    CHECK(viewport.getZoomLevel() < 1.0f);
+}
+
+// A viewport far too small to ever show the map still ends centred on it, at the zoom floor
+// rather than at some unreachable value.
+TEST_CASE("ViewportController fit stops at the minimum zoom", "[viewport][zoom]") {
+    HexagonGrid grid;
+    ViewportController viewport(&grid);
+    viewport.initialize({ 64u, 64u });
+    viewport.fitMapInView();
+
+    const sf::FloatRect bounds = ViewportController::mapWorldBounds();
+    CHECK(viewport.getZoomLevel() == Catch::Approx(0.1f)); // MIN_ZOOM
+    CHECK(viewport.getView().getCenter().x == Catch::Approx(bounds.position.x + bounds.size.x / 2.0f));
 }

--- a/tests/qt/test_ui_regressions.cpp
+++ b/tests/qt/test_ui_regressions.cpp
@@ -1404,6 +1404,59 @@ TEST_CASE("EditorWidget switches between the two exit-grid sub-modes", "[qt][exi
     CHECK(editor->currentMode() == geck::EditorMode::Select);
 }
 
+// The editor-navigation keys. Elevation is the everyday one: Ctrl+digit, the counterpart of the
+// panels' Alt+digit. They start disabled and updateElevationMenu() enables only what the open map
+// has, so the key is a no-op on a map without that elevation rather than a switch to nothing.
+TEST_CASE("Elevation actions carry Ctrl+digit and stay no-ops until a map has that elevation", "[qt][mainwindow][keys]") {
+    removeTestSettings();
+
+    auto resources = std::make_shared<geck::resource::GameResources>();
+    geck::MainWindow window(resources, std::make_shared<geck::Settings>());
+    window.show();
+    QTest::qWait(250);
+
+    struct ExpectedShortcut {
+        const char* actionText;
+        QKeySequence keys;
+    };
+
+    const std::array<ExpectedShortcut, 3> expected = { {
+        { "Elevation 1", QKeySequence(Qt::CTRL | Qt::Key_1) },
+        { "Elevation 2", QKeySequence(Qt::CTRL | Qt::Key_2) },
+        { "Elevation 3", QKeySequence(Qt::CTRL | Qt::Key_3) },
+    } };
+
+    for (const ExpectedShortcut& entry : expected) {
+        QAction* action = findAction(window, entry.actionText);
+        REQUIRE(action != nullptr);
+        CHECK(action->shortcut() == entry.keys);
+        CHECK_FALSE(action->isEnabled()); // no map open
+    }
+}
+
+// B and R used to be window-scoped QAction shortcuts, which fired while a palette grid or a tree
+// had focus — typing "b" in such a place started placing scroll blockers. Both now live on the
+// canvas, so the actions themselves must carry no shortcut.
+TEST_CASE("Single-letter tool keys are off the window-scoped actions", "[qt][mainwindow][keys]") {
+    removeTestSettings();
+
+    auto resources = std::make_shared<geck::resource::GameResources>();
+    geck::MainWindow window(resources, std::make_shared<geck::Settings>());
+    window.show();
+    QTest::qWait(250);
+
+    for (const char* text : { "Scroll Blocker Rectangle", "Rotate" }) {
+        QAction* action = findAction(window, text);
+        REQUIRE(action != nullptr);
+        CHECK(action->shortcut().isEmpty());
+    }
+
+    // Ctrl+Shift+E is a command, not a single letter, so it stays window-scoped.
+    QAction* editSource = findAction(window, "Edit Script Source");
+    REQUIRE(editSource != nullptr);
+    CHECK(editSource->shortcut() == QKeySequence("Ctrl+Shift+E"));
+}
+
 // "Inspect the selection": Return (and numpad Enter, a distinct key code) reveals the Selection
 // panel. Both are scoped to the canvas so a Return typed in a panel's filter box is left alone, and
 // both must stand down in MarkExits mode, where Enter finalizes the in-progress Draw-edge polyline
@@ -1439,11 +1492,14 @@ TEST_CASE("Inspect-selection keys live on the canvas and stand down in Draw-edge
         CHECK(shortcut->context() == Qt::WidgetWithChildrenShortcut);
         keys.append(shortcut->key());
     }
-    CHECK(keys.contains(QKeySequence(Qt::Key_Return)));
-    CHECK(keys.contains(QKeySequence(Qt::Key_Enter)));
+    for (const QKeySequence& expected : { QKeySequence(Qt::Key_Return), QKeySequence(Qt::Key_Enter),
+             QKeySequence(Qt::Key_S), QKeySequence(Qt::Key_G), QKeySequence(Qt::Key_B),
+             QKeySequence(Qt::Key_R), QKeySequence(Qt::Key_Home), QKeySequence(Qt::Key_F) }) {
+        CHECK(keys.contains(expected));
+    }
 
-    // Only these two are asserted on by key rather than sweeping every canvas shortcut, so a
-    // shortcut added later for something else cannot fail this test.
+    // Shortcuts are looked up by key rather than swept as a group, so one added later for
+    // something else cannot fail this test.
     const auto shortcutFor = [&canvasShortcuts](const QKeySequence& wanted) -> const QShortcut* {
         for (const QShortcut* shortcut : canvasShortcuts) {
             if (shortcut->key() == wanted) {
@@ -1460,12 +1516,37 @@ TEST_CASE("Inspect-selection keys live on the canvas and stand down in Draw-edge
     CHECK(inspectReturn->isEnabled());
     CHECK(inspectEnter->isEnabled());
 
-    // Draw edge: Enter belongs to the polyline, so the reveal keys step aside.
+    // Stamping: R belongs to the viewport, where it cycles the pattern's orientation variants, so
+    // the canvas shortcut stands down and the key falls through to InputHandler. The toolbar
+    // button stays enabled — only the key steps aside.
+    const QShortcut* rotate = shortcutFor(QKeySequence(Qt::Key_R));
+    REQUIRE(rotate != nullptr);
+    QAction* rotateAction = findAction(window, "Rotate");
+    REQUIRE(rotateAction != nullptr);
+
+    editorWidget->setMode(geck::EditorMode::StampPattern);
+    QApplication::processEvents();
+    CHECK_FALSE(rotate->isEnabled());
+    CHECK(rotateAction->isEnabled());
+
+    editorWidget->setMode(geck::EditorMode::Select);
+    QApplication::processEvents();
+    CHECK(rotate->isEnabled());
+
+    // Draw edge: Enter belongs to the polyline, so the two reveal keys step aside.
     editorWidget->setMarkExitsMode(true);
     QApplication::processEvents();
     REQUIRE(editorWidget->currentMode() == geck::EditorMode::MarkExits);
     CHECK_FALSE(inspectReturn->isEnabled());
     CHECK_FALSE(inspectEnter->isEnabled());
+
+    // ...and only those two: the navigation keys are unaffected by the mode.
+    const QShortcut* centerOnPlayer = shortcutFor(QKeySequence(Qt::Key_Home));
+    const QShortcut* fitMap = shortcutFor(QKeySequence(Qt::Key_F));
+    REQUIRE(centerOnPlayer != nullptr);
+    REQUIRE(fitMap != nullptr);
+    CHECK(centerOnPlayer->isEnabled());
+    CHECK(fitMap->isEnabled());
 
     // Leaving the mode hands them back.
     editorWidget->setMode(geck::EditorMode::Select);


### PR DESCRIPTION
Slice 2 of `docs/keybindings-plan.md`. **Stacked on #137** — review that one first; this PR's diff is against it.

## What this adds

| Key | Action | Scope |
|---|---|---|
| `Ctrl+1` / `Ctrl+2` / `Ctrl+3` | Switch elevation | App |
| `S` | Return to Select mode | Canvas |
| `G` | Toggle hex grid | Canvas |
| `Home` | Centre on player start | Canvas |
| `F` | Fit the whole map in view | Canvas |
| `Ctrl+Shift+E` | Edit the selected object's script source | App |

Elevation was the biggest everyday gap — there was no shortcut at all. The actions stay disabled until `updateElevationMenu()` finds the map has that elevation, so a shortcut on a one-elevation map is a no-op rather than a switch to a level that isn't there.

## `B` and `R` move to the canvas

Both were window-scoped `QAction` shortcuts, so they fired while a palette grid or a tree had focus — typing "b" in one started placing scroll blockers. They are canvas shortcuts now.

One correction to the plan doc, noted inline: the `_rotateAction->setEnabled(...)` guard **cannot be deleted, only moved**. A canvas `QShortcut` consumes the key exactly as a window-scoped action shortcut does, so `R` still has to stand down in `StampPattern` / `PluginTool` for the viewport to see it (there it cycles a stamp's orientation variants). What the move buys is that the *shortcut* is disabled instead of the action, so the toolbar button no longer greys out.

## Fit map in view

`ViewportController::fitMapInView()` derives the grid's extent from the four corner tiles through `coordinatesToScreenPosition()` — the same forward projection the tiles are drawn with, so the two cannot drift. The zoom is clamped like any other; at the clamp the map is centred but still overflows.

## Shared script lookup

Resolving an object's SID to its `scripts.lst` program index is now one method on `Map`, shared by `Ctrl+Shift+E` and the Selection panel's "Edit Source..." button, so the two cannot disagree about which script an object owns. With no script attached the key is a no-op with a status-bar line, matching the `Return` convention.

## Tests

`tests/general/test_viewport_controller.cpp`: every tile is inside the reported bounds, the fitted view covers the grid on both axes centred on it, and a viewport too small to ever show the map stops at `MIN_ZOOM` still centred.

`tests/qt/test_ui_regressions.cpp`: the elevation actions carry `Ctrl+digit` and are disabled with no map; `B` / `R` carry no window-scoped shortcut while `Ctrl+Shift+E` does; the canvas `R` stands down while stamping and the toolbar button does not.

`qt_tests` 122 cases green, `general_tests` 470 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xrioPDMqr7L4CS2Y1gJFc