### PR TITLE
Add the missing editor shortcuts and make every key remappable from one table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,39 @@ Use the established base class hierarchy for consistency:
 | `BasePanel` | Palette/browser panels | `createSearchControls()`, `createPaginationControls()` |
 | `BasePaletteWidget` | Grid items (tiles, objects) | Selection painting, drag handling |
 
+### Keyboard Shortcuts
+
+Every shortcut is a row in one table — `src/ui/input/ActionSpec.h` (`actionSpecs()`) — read by the
+menus, the toolbar, the canvas and the Preferences page. Do **not** add a `QKeySequence` literal to
+`MainWindow`; add a row and bind a sink:
+
+```cpp
+#include "ui/input/ActionSpec.h"
+
+// A menu/toolbar action (window scope): the registry sets the key and re-keys it on rebind.
+_keyBindings->bind(actions::PANEL_SELECTION, action);
+
+// A canvas shortcut (only while the map view has focus) — see installCanvasShortcuts().
+auto* shortcut = new QShortcut(canvas);
+shortcut->setContext(Qt::WidgetWithChildrenShortcut);
+_keyBindings->bind(actions::TOOL_ROTATE, shortcut);
+```
+
+- **Scope**: single letters must be `ActionScope::Canvas`. Window-scoped, they fire while a palette
+  grid or a tree has focus (typing "b" in one would place scroll blockers). Commands with modifiers
+  can be `Application`.
+- **Ids are persisted** in `settings.json` (`"keyBindings"`, overrides only), so never rename one
+  that has shipped. Only entries differing from the default are written, so a later release can
+  still move a default for users who never rebound it.
+- **One key, one action** — across both scopes, since a window-scoped shortcut also fires while the
+  canvas has focus. `KeyBindingRegistry::conflictingActionId()` enforces this and `test_keybindings`
+  guards the shipped table; two actions on one key makes Qt fire neither.
+- **Tool state-machine keys stay out of the table**: `Esc`, `Space`, `Delete`/`Backspace`, the
+  Draw-edge `Enter` and the stamp `R` live in `InputHandler`, are dispatched as SFML key codes, and
+  are meaningful only inside their mode. A canvas `QShortcut` *consumes* the key before
+  `InputHandler` sees it, so any shortcut sharing one of those keys must be disabled for that mode
+  (see `syncToolModeActions`).
+
 ### MIME Types for Drag and Drop
 
 Use constants from `src/ui/dragdrop/MimeTypes.h`:
@@ -297,5 +330,5 @@ On feature branches, follow this workflow:
 
 ---
 
-*Last updated: 2026-06-10*
+*Last updated: 2026-08-28*
 *This file should be updated whenever significant architectural decisions or fixes are made.*

--- a/docs/keybindings-implementation.md
+++ b/docs/keybindings-implementation.md
@@ -1,0 +1,402 @@
+# Keyboard shortcuts — implementation plan
+
+*Implementation plan for `docs/keybindings-plan.md`: the new default bindings, and the
+Preferences page that makes them remappable. Three shippable slices; each one is useful on its
+own and each is a separate PR.*
+
+---
+
+## 0. Corrections to the source doc (verified against the code)
+
+Four things in `keybindings-plan.md`'s "Already-bound keys" table are wrong or incomplete. They
+change what the slices below can safely claim.
+
+| Claim in the doc | What the code actually does |
+|---|---|
+| `F11` / `F16` are bound (spatial-script dialog / kill-type) | **Not bound anywhere.** `F11` appears only in `SFMLWidget::convertQtKeyToSf()` (`src/ui/widgets/SFMLWidget.cpp:316`), which is a Qt→SFML key-code translation table, not a binding. Both keys are free. |
+| — (missing) | **`P` is bound**: eyedropper, samples whatever is under the cursor into the matching palette (`src/ui/input/InputHandler.cpp:346`). Canvas-scoped already. |
+| — (missing) | **`Space` is bound**: in "Draw edge" mode it flips which side the exit-grid bars sit on (`src/ui/input/InputHandler.cpp:352`). Tool-modal. |
+| `Enter` is free | **`Enter` is already bound in `MarkExits` mode** — it finalizes the in-progress Draw-edge polyline (`src/ui/input/InputHandler.cpp:330`). The proposed `Enter` → Selection panel *must* stand down while that tool is active. |
+
+One more, on the doc's design caveat ("typing `b` in a search field places scroll blockers"):
+the risk is real but narrower than stated. `QLineEdit` (and `QSpinBox`, which embeds one)
+accepts `QEvent::ShortcutOverride` for any key below `Qt::Key_Escape`, so a plain letter typed
+into a panel's filter box is **not** stolen by a window-scoped `QAction`. The keys *are* stolen
+when focus sits on a non-text widget — a palette grid, a `QTreeView`, a non-editable
+`QComboBox`, a dock title bar. That is still a good enough reason to scope single-letter keys to
+the canvas, and it means the existing `B` / `R` have the same latent bug today.
+
+---
+
+## 1. Final default table
+
+Scope column: **App** = window-scoped `QAction` shortcut; **Canvas** = `QShortcut` on the
+`SFMLWidget` with `Qt::WidgetWithChildrenShortcut`; **Tool** = stays inside `InputHandler`'s
+tool state machine, not user-remappable (see §5).
+
+| Key | Action id | Label | Scope | Slice |
+|---|---|---|---|---|
+| `Return` | `panel.selection.reveal` | Inspect selection (reveal Selection panel) | Canvas | 1 |
+| `Alt+1` | `panel.mapInfo` | Map Information panel | App | 1 |
+| `Alt+2` | `panel.selection` | Selection panel | App | 1 |
+| `Alt+3` | `panel.scripts` | Scripts panel | App | 1 |
+| `Alt+4` | `panel.tilePalette` | Tile Palette panel | App | 1 |
+| `Alt+5` | `panel.objectPalette` | Object Palette panel | App | 1 |
+| `Alt+6` | `panel.fileBrowser` | File Browser panel | App | 1 |
+| `` Alt+` `` | `panel.log` | Log panel | App | 1 |
+| `Ctrl+1` | `view.elevation1` | Elevation 1 | App | 2 |
+| `Ctrl+2` | `view.elevation2` | Elevation 2 | App | 2 |
+| `Ctrl+3` | `view.elevation3` | Elevation 3 | App | 2 |
+| `S` | `tool.select` | Select mode | Canvas | 2 |
+| `G` | `view.hexGrid` | Toggle hex grid | Canvas | 2 |
+| `Home` | `view.centerOnPlayer` | Center on player start | Canvas | 2 |
+| `F` | `view.fitMap` | Fit map in view | Canvas | 2 |
+| `Ctrl+Shift+E` | `script.editSource` | Edit script source of selection | App | 2 |
+| `B` | `tool.scrollBlockerRect` | Scroll-blocker rectangle | Canvas *(moved from App)* | 2 |
+| `R` | `tool.rotate` | Rotate selected object | Canvas *(moved from App)* | 2 |
+| `P` | `tool.pick` | Eyedropper | Canvas *(moved from InputHandler)* | 3 |
+
+Decisions folded in:
+
+- **`` Alt+` `` goes to the Log dock**, not the Script Console. The console is behind
+  `GECK_SCRIPTING_ENABLED` (`MainWindow.cpp:1222`) and would leave the key dead in a
+  scripting-off build; the Log dock is unconditional. The console keeps its View-menu entry.
+- **`Return` vs numpad Enter.** A `QShortcut` on `Qt::Key_Return` does not catch
+  `Qt::Key_Enter`. Register the reveal action with two `QShortcut` sinks; only the `Return` one
+  is rebindable.
+- **`B` and `R` move to canvas scope** in slice 2. This is a user-visible behaviour change —
+  they stop firing when a palette grid or tree has focus — and it retires the
+  `_rotateAction->setEnabled(...)` workaround at `MainWindow.cpp:999` that exists only because
+  `R` is currently window-scoped.
+
+---
+
+## 2. Slice 1 — panel reveal + `Return` (no new infrastructure)
+
+Everything lands in `MainWindow`. No `Settings` change, no new files.
+
+### 2.1 Reveal-and-focus semantics
+
+Today `addPanelToggleAction()` (`MainWindow.cpp:311`) makes a checkable menu action whose
+`toggled` handler shows or hides the dock. "Toggle" is the wrong verb for a keyboard shortcut on
+a **tabbed** dock: `Alt+1` on a Map Info dock that is visible-but-tabbed-behind Scripts would
+hide it rather than surface it.
+
+Add alongside it:
+
+```cpp
+// MainWindow.cpp
+void MainWindow::revealPanel(QDockWidget* dock) {
+    if (!dock) return;
+    const bool onTop = dock->isVisible() && !dock->visibleRegion().isEmpty();
+    const bool focused = dock->isAncestorOf(QApplication::focusWidget());
+    if (onTop && focused) {          // already the active, focused tab -> hide
+        dock->hide();
+        return;
+    }
+    dock->show();                    // hidden, or visible but tabbed behind / unfocused
+    dock->raise();
+    if (QWidget* w = dock->widget()) w->setFocus(Qt::ShortcutFocusReason);
+}
+```
+
+`dock->hide()` / `show()` both fire `QDockWidget::visibilityChanged`, which the existing handler
+at `MainWindow.cpp:344` already uses to re-sync the menu action's check state and persist the
+layout — so the menu checkmarks stay correct for free.
+
+### 2.2 Wiring the `Alt+…` family
+
+`addPanelToggleAction()` gains a `const QKeySequence& shortcut` parameter and calls
+`revealPanel()` instead of the inline `showDock` lambda. `setupPanelsMenu()`
+(`MainWindow.cpp:2308`) grows a `shortcut` field in its `PanelToggleSpec` array.
+
+Ordering gotcha: `setupPanelsMenu()` runs from `setupMenuBar()`, but `_logDock` is not created
+until `setupDockWidgets()` (`MainWindow.cpp:1242`). Attach `` Alt+` `` where the log action is
+already configured — `MainWindow.cpp:1252`, right after
+`logAction->setText(tr("&Log"))` — using `_logDock->toggleViewAction()`, and route it through
+`revealPanel()` rather than the raw toggle action so it gets the same reveal semantics.
+
+### 2.3 `Return` → reveal Selection panel
+
+```cpp
+// after the SFMLWidget exists (EditorWidget construction / setCurrentEditorWidget)
+_inspectSelectionShortcut = new QShortcut(QKeySequence(Qt::Key_Return), sfmlWidget);
+_inspectSelectionShortcut->setContext(Qt::WidgetWithChildrenShortcut);
+connect(_inspectSelectionShortcut, &QShortcut::activated, this, [this] {
+    if (!_currentEditorWidget || !_currentEditorWidget->hasSelection()) return;  // no-op, per plan
+    revealPanel(_selectionDock);
+});
+```
+
+Plus a second `QShortcut` on `Qt::Key_Enter` sharing the same lambda.
+
+**Must be disabled in `MarkExits` mode**, or it eats the Draw-edge finalize. `syncToolModeActions()`
+(`MainWindow.cpp:959`) already runs on every mode change and already does exactly this dance for
+`_rotateAction`; add:
+
+```cpp
+if (_inspectSelectionShortcut) {
+    _inspectSelectionShortcut->setEnabled(mode != EditorMode::MarkExits);
+}
+```
+
+`QShortcut` with `WidgetWithChildrenShortcut` only fires while the canvas has focus, so a
+`Return` pressed in a panel's filter box is untouched.
+
+**Files:** `src/ui/core/MainWindow.{h,cpp}`.
+**Test:** extend `tests/qt/test_ui_regressions.cpp:751` ("MainWindow panel toggles stay wired in
+the no-map layout") with reveal-semantics cases — hidden → shows+raises; tabbed-behind → raises
+without hiding; visible+focused → hides.
+
+---
+
+## 3. Slice 2 — editor navigation keys
+
+Still no registry; these are direct bindings that slice 3 later re-points at the table.
+
+| Binding | Where the behaviour already lives |
+|---|---|
+| `Ctrl+1/2/3` | `_elevation1Action`…`_elevation3Action` already exist (`MainWindow.cpp:673-688`). One-line `setShortcut()` each. They are `setDisabled(true)` until `updateElevationMenu()` enables the elevations the map actually has — a shortcut on a disabled action is correctly a no-op. |
+| `Home` | `EditorWidget::centerViewOnPlayerPosition()` already exists (`EditorWidget.cpp:2876`). Canvas `QShortcut` → call it. |
+| `S` | `_selectToolAction` already exists (`MainWindow.cpp:861`). Do **not** `setShortcut()` on it (that would be window scope); add a canvas `QShortcut` that calls `_selectToolAction->trigger()`. |
+| `G` | Same shape via `_showHexGridAction->toggle()`. |
+| `Ctrl+Shift+E` | Reuses the Scripts-panel / Map-Info "Edit Script Source" path from the SSL toolchain work; resolves the selected object's script and hands off to `ScriptSourceService`. Enabled only when the selection has a script. |
+
+### 3.1 `F` — fit map in view (the only new behaviour)
+
+`ViewportController` has `centerViewOnMap()` and `setZoomLevel()` but no fit-to-extent. Add:
+
+```cpp
+// src/viewport/ViewportController.{h,cpp}
+void fitMapInView();   // zoom so the whole 100x100 tile grid fits, then re-center
+```
+
+The tile grid spans roughly **7920 × 3576** world px (from `Constants.h`: `MAP_WIDTH/HEIGHT` 100,
+`TILE_X_OFFSET` 48, `TILE_Y_OFFSET_LARGE` 32, `TILE_Y_OFFSET_SMALL` 24, `TILE_Y_OFFSET_TINY` 12,
+plus `TILE_WIDTH` 80 / `TILE_HEIGHT` 36). At a 1600×900 viewport the required zoom is
+`min(1600/8000, 900/3612) ≈ 0.20` — comfortably inside the existing `MIN_ZOOM = 0.1` clamp, so
+no clamp change is needed. Derive the extents from the same `TileUtils` math
+`centerViewOnMap()` uses rather than hardcoding, so the two cannot drift.
+
+Unit-testable headless (no GL): `tests/general/test_viewport_controller.cpp` already exercises
+this class.
+
+### 3.2 Migrating `B` and `R` to canvas scope
+
+Drop the `QKeySequence("B")` at `MainWindow.cpp:482` and the `QKeySequence("R")` at
+`MainWindow.cpp:828`; replace with canvas `QShortcut`s triggering the same actions. Then delete
+the `_rotateAction->setEnabled(...)` guard at `MainWindow.cpp:999` and update the comment at
+`InputHandler.cpp:339-342`, which documents the workaround — `R` will now reach the viewport
+without the toolbar action being disabled first.
+
+**Files:** `src/ui/core/MainWindow.{h,cpp}`, `src/viewport/ViewportController.{h,cpp}`,
+`src/ui/input/InputHandler.cpp` (comment only).
+**Tests:** `tests/general/test_viewport_controller.cpp` (fit math, clamp behaviour);
+`tests/qt/test_ui_regressions.cpp` (elevation shortcuts are no-ops on a map without that
+elevation).
+
+---
+
+## 4. Slice 3 — central table + Preferences page
+
+This is `PLAN.md` "Editor limitations §7" and the prerequisite for §8 (customizable toolbar).
+
+### 4.1 New files
+
+```
+src/ui/input/ActionSpec.h              # the default table (id, label, category, keys, scope)
+src/ui/input/KeyBindingRegistry.h/.cpp # overrides, conflicts, persistence, live rebind
+src/ui/widgets/KeybindingsWidget.h/.cpp# the Preferences tab
+tests/qt/test_keybindings.cpp
+```
+
+All four get added to `src/CMakeLists.txt` (explicit source lists — no globbing) and
+`tests/CMakeLists.txt`'s `qt_tests` target.
+
+### 4.2 The table
+
+```cpp
+// src/ui/input/ActionSpec.h
+namespace geck {
+
+enum class ActionScope { Application, Canvas };
+
+struct ActionSpec {
+    const char* id;          // stable + persisted — never renamed once shipped
+    const char* label;       // "Selection Panel"
+    const char* category;    // "Panels" | "File" | "Edit" | "View" | "Navigation" | "Tools"
+    const char* defaultKeys; // QKeySequence portable text, "" = unbound by default
+    ActionScope scope;
+};
+
+std::span<const ActionSpec> actionSpecs();
+
+} // namespace geck
+```
+
+String ids rather than an enum because they are what lands in `settings.json`; a reordered enum
+would silently repoint every user's overrides.
+
+### 4.3 Registry
+
+```cpp
+class KeyBindingRegistry : public QObject {
+    Q_OBJECT
+public:
+    explicit KeyBindingRegistry(std::shared_ptr<Settings> settings, QObject* parent = nullptr);
+
+    QKeySequence shortcut(QStringView id) const;         // override if set, else default
+    QKeySequence defaultShortcut(QStringView id) const;
+    bool isCustomized(QStringView id) const;
+
+    // Empty result = no conflict. Canvas actions are checked against Application actions too:
+    // a window-scoped QAction shortcut fires even while the canvas has focus, so the two
+    // scopes are not independent namespaces.
+    QString conflictingActionId(QStringView id, const QKeySequence& seq) const;
+
+    void setShortcut(QStringView id, const QKeySequence& seq);  // empty sequence = unbound
+    void resetToDefault(QStringView id);
+    void resetAllToDefaults();
+    void save();
+
+    // Sinks: whatever is registered here is re-keyed automatically on rebind.
+    void bind(QStringView id, QAction* action);
+    void bind(QStringView id, QShortcut* shortcut);
+
+signals:
+    void bindingChanged(const QString& id, const QKeySequence& seq);
+};
+```
+
+`bind()` holds `QPointer` sinks and connects `bindingChanged` to `setShortcut()` /
+`setKey()`, so a rebind takes effect immediately with no restart and no re-walk of the menu bar.
+Owned by `MainWindow` (constructed next to `_settings`), injected into `SettingsDialog`.
+
+Migration is mechanical: every `QKeySequence("…")` literal in `setupMenuBar()`,
+`setupToolBar()`, `setupPanelsMenu()` and the slice-1/2 `QShortcut`s becomes
+`registry.bind(actions::X, action)` — the registry supplies the key. Slices 1 and 2 are written
+so this is a find-and-replace, not a redesign.
+
+### 4.4 Persistence
+
+Add to `Settings`:
+
+```cpp
+QMap<QString, QString> getKeyBindings() const;               // actionId -> portable text
+void setKeyBindings(const QMap<QString, QString>& bindings);
+```
+
+Stored as a top-level `"keyBindings"` object. **Write only entries that differ from the
+default** — that way changing a default in a later release still reaches users who never
+customized that action. An explicitly-unbound action persists as an empty string, which is
+distinct from absent.
+
+No `SETTINGS_VERSION` bump: an absent `"keyBindings"` key means "no overrides", which
+`Settings::fromJson()` already tolerates. Avoid touching the version — the 1.0→1.1 data-path
+migration at `Settings.cpp:178` keys off `_version != SETTINGS_VERSION` and would re-run
+`expandDataPaths()` on every existing install if the constant moved.
+
+### 4.5 Preferences page
+
+`src/ui/widgets/KeybindingsWidget` follows the shape of `DataPathsWidget` / `ScriptToolsWidget`
+(emit `changed()` + `statusChanged()`, edit an in-memory copy, commit on Apply/OK), and
+`SettingsDialog` gains `setupKeybindingsTab()` in `setupTabs()` (`SettingsDialog.cpp:74`). The
+registry pointer joins the constructor: `SettingsDialog(settings, registry, parent)`, null →
+tab omitted, so a bare-constructed dialog in a test still builds.
+
+Layout:
+
+- Filter `QLineEdit` at the top (matches label, category, and current keys).
+- `QTreeWidget` grouped by category — columns **Action / Shortcut / Default**, customized rows
+  shown bold with a per-row reset affordance.
+- Double-click the Shortcut cell → inline `QKeySequenceEdit` with
+  `setMaximumSequenceLength(1)` (single chord; multi-chord sequences are not wanted here).
+- Live conflict detection on `keySequenceChanged`: on a hit, mark the row with
+  `ui::theme::colors::ERROR` and set the status line to
+  *"Alt+2 is already assigned to Selection Panel"*, with a **Reassign** button that unbinds the
+  other action. Escape reverts the edit.
+- **Reset** (selected) and **Reset All** buttons.
+
+Use `ui::theme::spacing::*` and `ui::theme::styles::status*()` per `CLAUDE.md` — no hardcoded
+colours or paddings.
+
+### 4.6 Status-bar hints
+
+`hintForContext()` (`src/ui/core/EditorHints.h`) hardcodes key names and is explicitly
+documented as "kept in lockstep with InputHandler's handlers and the toolbar shortcuts". Once
+keys are remappable that comment becomes a lie. Give it a key-lookup callable
+(`std::function<QString(QStringView actionId)>`) so it stays pure and headless-testable while
+following rebinds. Small, and it keeps `tests/qt/test_editor_hints.cpp` meaningful.
+
+---
+
+## 5. What stays hardcoded, and why
+
+`InputHandler`'s remaining keys are **tool state-machine keys**, not commands: `Esc` (cancel /
+abandon the Draw-edge line), `Enter` (finalize that line), `Space` (flip the edge side), `R`
+while stamping (cycle pattern variant), `Delete`/`Backspace`. They are meaningful only inside a
+specific mode, they are dispatched in SFML key codes rather than `QKeySequence`, and rebinding
+them independently of their mode would produce incoherent states.
+
+Recommendation: leave them out of the registry and surface them in the Preferences page as a
+**read-only "Tool keys" section**, so they are discoverable without being editable. `P`
+(eyedropper) is the exception — it is a global canvas command wearing a tool key's clothes, so
+migrate it to a canvas `QShortcut` in slice 3 and make it rebindable.
+
+If tool keys are wanted as rebindable later, the migration path is a `CanvasShortcutDispatcher`
+consulted from `SFMLWidget::keyPressEvent()` *before* the Qt→SFML translation, returning
+handled/not-handled so unclaimed keys fall through to `InputHandler` unchanged.
+
+---
+
+## 6. Tests
+
+Added to `qt_tests` as `tests/qt/test_keybindings.cpp`:
+
+1. **Table integrity** — ids unique; every `defaultKeys` parses to a non-empty `QKeySequence`
+   (or is deliberately `""`); no two Application-scope defaults collide; no Canvas default
+   collides with an Application default.
+2. **Persistence round-trip** — set an override, `save()`, reload a fresh `Settings`, read it
+   back; confirm only the changed entry is written and a reset removes it from the JSON.
+3. **Conflict detection** — `conflictingActionId()` finds the collision, returns empty for the
+   action's own id, and treats an empty sequence as never conflicting.
+4. **Live rebind** — a `bind()`-registered `QAction` and `QShortcut` both pick up a new key
+   without re-registration.
+5. **Reveal semantics** (slice 1) — hidden → show+raise; tabbed-behind → raise; visible+focused
+   → hide.
+6. **`Return` stands down in `MarkExits`** — the guard that keeps the Draw-edge finalize working.
+7. **Fit-map math** (slice 2, in `tests/general/test_viewport_controller.cpp`) — the whole grid
+   is inside the view afterwards, and the zoom stays within the clamp.
+
+Existing suites that must stay green: `tests/qt/test_input_handler.cpp` (unchanged in slices 1–2;
+slice 3 touches it only if `P` moves), `tests/qt/test_editor_hints.cpp` (signature change in
+§4.6), `tests/qt/test_ui_regressions.cpp:751`.
+
+---
+
+## 7. Sequencing and effort
+
+| Slice | Scope | Files | Rough size |
+|---|---|---|---|
+| 1 | `Return` + `Alt+1…6` + `` Alt+` `` reveal-and-focus | `MainWindow.{h,cpp}` | ~150 lines + tests |
+| 2 | Elevation, `S`, `G`, `Home`, `F`, `Ctrl+Shift+E`; `B`/`R` → canvas | `MainWindow.{h,cpp}`, `ViewportController.{h,cpp}` | ~250 lines + tests |
+| 3 | Registry + Settings + Preferences page; migrate all literals | 4 new files, `MainWindow`, `SettingsDialog`, `Settings`, `EditorHints` | ~900 lines + tests |
+
+Slices 1 and 2 are independently shippable and answer the motivating gap. Slice 3 is the one
+that pays down `PLAN.md` §7 and unblocks §8 (customizable toolbar shares the same table).
+
+Per `CLAUDE.md`: run `./format.sh` before committing, open a PR per slice, wait for CI, and
+address Copilot / SonarCloud comments before considering a slice done.
+
+---
+
+## 8. Open decisions
+
+1. **`Ctrl+Shift+E` behaviour when the selection has no script** — no-op, or offer to attach one?
+   Recommend no-op with a status-bar message, matching the `Return` no-op convention.
+2. **Should slice 3 ship a "Keyboard shortcuts" reference (printable list)?** Cheap once the
+   table exists — a read-only view of the same tree — and it is the discoverability half of the
+   motivating gap. Recommend yes, in the Help menu.
+3. **macOS `Alt` = Option.** `Alt+digit` does not collide with menu mnemonics on macOS (there
+   are none) and `QLineEdit` will not see it as text, so the family is safe; worth a manual
+   check on the first macOS build since Option-digit types glyphs in some contexts.

--- a/docs/keybindings-implementation.md
+++ b/docs/keybindings-implementation.md
@@ -13,7 +13,7 @@ change what the slices below can safely claim.
 
 | Claim in the doc | What the code actually does |
 |---|---|
-| `F11` / `F16` are bound (spatial-script dialog / kill-type) | **Not bound anywhere.** `F11` appears only in `SFMLWidget::convertQtKeyToSf()` (`src/ui/widgets/SFMLWidget.cpp:316`), which is a Qt→SFML key-code translation table, not a binding. Both keys are free. |
+| `F11` / `F16` are bound (spatial-script dialog / kill-type) | **Not bound anywhere** (confirmed). `F11` appears only in `SFMLWidget::convertQtKeyToSf()` (`src/ui/widgets/SFMLWidget.cpp:316`), which is a Qt→SFML key-code translation table, not a binding. Both keys are free. |
 | — (missing) | **`P` is bound**: eyedropper, samples whatever is under the cursor into the matching palette (`src/ui/input/InputHandler.cpp:346`). Canvas-scoped already. |
 | — (missing) | **`Space` is bound**: in "Draw edge" mode it flips which side the exit-grid bars sit on (`src/ui/input/InputHandler.cpp:352`). Tool-modal. |
 | `Enter` is free | **`Enter` is already bound in `MarkExits` mode** — it finalizes the in-progress Draw-edge polyline (`src/ui/input/InputHandler.cpp:330`). The proposed `Enter` → Selection panel *must* stand down while that tool is active. |
@@ -102,7 +102,16 @@ void MainWindow::revealPanel(QDockWidget* dock) {
 
 `dock->hide()` / `show()` both fire `QDockWidget::visibilityChanged`, which the existing handler
 at `MainWindow.cpp:344` already uses to re-sync the menu action's check state and persist the
-layout — so the menu checkmarks stay correct for free.
+layout. ~~So the menu checkmarks stay correct for free.~~ **Not quite**: raising a tabbed-behind
+dock fires nothing, and a shortcut on a checkable `QAction` makes Qt flip the checkmark *before*
+the handler runs — so `revealPanel()` re-asserts `setChecked(!dock->isHidden())` under a
+`QSignalBlocker`, and the handler moved from `toggled` to `triggered` so the flipped state is
+treated as a request rather than the truth.
+
+**Semantics as shipped:** hidden → show + raise + focus; visible but tabbed behind → raise + focus;
+visible and on top → hide. Deliberately no "is it focused" test: with one, a *menu* click on a
+ticked item (focus is elsewhere by then) would raise-and-focus instead of hiding, so putting a
+panel away from the menu would take two clicks.
 
 ### 2.2 Wiring the `Alt+…` family
 
@@ -110,11 +119,12 @@ layout — so the menu checkmarks stay correct for free.
 `revealPanel()` instead of the inline `showDock` lambda. `setupPanelsMenu()`
 (`MainWindow.cpp:2308`) grows a `shortcut` field in its `PanelToggleSpec` array.
 
-Ordering gotcha: `setupPanelsMenu()` runs from `setupMenuBar()`, but `_logDock` is not created
-until `setupDockWidgets()` (`MainWindow.cpp:1242`). Attach `` Alt+` `` where the log action is
-already configured — `MainWindow.cpp:1252`, right after
-`logAction->setText(tr("&Log"))` — using `_logDock->toggleViewAction()`, and route it through
-`revealPanel()` rather than the raw toggle action so it gets the same reveal semantics.
+~~Ordering gotcha: `setupPanelsMenu()` runs from `setupMenuBar()`~~ — **not so**: `setupUI()` calls
+`setupMenuBar()`, `setupToolBar()`, `setupDockWidgets()`, *then* `setupPanelsMenu()`, so `_logDock`
+already exists. `` Alt+` `` is still attached where the log action is configured
+(`setupDockWidgets()`), but for a different reason: `_logDock->toggleViewAction()` is Qt's own
+plain-toggle action, so the Log dock gets its own checkable action routed through `revealPanel()`
+instead, with a `visibilityChanged` connection keeping the check state in step.
 
 ### 2.3 `Return` → reveal Selection panel
 
@@ -184,10 +194,12 @@ this class.
 ### 3.2 Migrating `B` and `R` to canvas scope
 
 Drop the `QKeySequence("B")` at `MainWindow.cpp:482` and the `QKeySequence("R")` at
-`MainWindow.cpp:828`; replace with canvas `QShortcut`s triggering the same actions. Then delete
-the `_rotateAction->setEnabled(...)` guard at `MainWindow.cpp:999` and update the comment at
-`InputHandler.cpp:339-342`, which documents the workaround — `R` will now reach the viewport
-without the toolbar action being disabled first.
+`MainWindow.cpp:828`; replace with canvas `QShortcut`s triggering the same actions. ~~Then delete
+the `_rotateAction->setEnabled(...)` guard at `MainWindow.cpp:999`.~~ **The guard cannot be
+deleted, only moved**: a canvas `QShortcut` consumes the key just as a window-scoped `QAction`
+shortcut does, so `R` still has to stand down in `StampPattern` / `PluginTool` for the viewport to
+see it. What the move buys is that the *shortcut* is disabled instead of the action, so the
+toolbar button no longer greys out. The comment at `InputHandler.cpp:339-342` is updated to match.
 
 **Files:** `src/ui/core/MainWindow.{h,cpp}`, `src/viewport/ViewportController.{h,cpp}`,
 `src/ui/input/InputHandler.cpp` (comment only).
@@ -392,11 +404,18 @@ address Copilot / SonarCloud comments before considering a slice done.
 
 ## 8. Open decisions
 
+*(Answered during implementation — see the resolutions under each.)*
+
 1. **`Ctrl+Shift+E` behaviour when the selection has no script** — no-op, or offer to attach one?
    Recommend no-op with a status-bar message, matching the `Return` no-op convention.
+   → **Shipped as the no-op**: the first selected object that owns a script wins; otherwise the
+   status bar says "No script attached to the selection".
 2. **Should slice 3 ship a "Keyboard shortcuts" reference (printable list)?** Cheap once the
    table exists — a read-only view of the same tree — and it is the discoverability half of the
    motivating gap. Recommend yes, in the Help menu.
+   → **Help › Keyboard Shortcuts… shipped**, but as a jump to the Preferences page rather than a
+   second read-only view: same table, nothing to drift, and the list is where rebinding happens.
+   A printable/exportable list was not built.
 3. **macOS `Alt` = Option.** `Alt+digit` does not collide with menu mnemonics on macOS (there
    are none) and `QLineEdit` will not see it as text, so the family is safe; worth a manual
    check on the first macOS build since Option-digit types glyphs in some contexts.

--- a/docs/keybindings-plan.md
+++ b/docs/keybindings-plan.md
@@ -1,0 +1,98 @@
+# Keyboard shortcuts plan
+
+*Proposal for the default keybindings the editor should ship, and the one gap that motivated it:
+there is currently **no keyboard shortcut to show/focus any panel** — only the `View › Panels` menu
+mnemonics. This doc is the source list for the default bindings; every one is intended to be
+user-remappable through the configurable-keybindings work package (see the last section).*
+
+## Already-bound keys (do not collide)
+
+| Key | Action |
+|---|---|
+| `Ctrl+N` / `Ctrl+O` / `Ctrl+B` | New map / Open map / Browse Maps |
+| `Ctrl+S` / `Ctrl+Shift+S` / `Ctrl+W` | Save / Save As / Close map |
+| `Ctrl+,` / `Ctrl+Q` | Preferences / Quit |
+| `Ctrl+A` / `Ctrl+D` | Select All / Deselect All |
+| `Ctrl+Z` / `Ctrl+Y` | Undo / Redo |
+| `Ctrl+E` | Show Exit Grids (view toggle) |
+| `B` | Scroll-blocker rectangle mode |
+| `R` | Cycle stamp variant |
+| `F5` | Save & Play in Fallout 2 |
+| `F11` / `F16` | Spatial-script dialog / kill-type (legacy) |
+| `Esc` | Cancel current mode |
+| `Delete` / `Backspace` | Delete selected objects |
+
+Everything proposed below avoids these.
+
+---
+
+## 1. The motivating case: selected object → Selection panel
+
+Bind this two ways, because they serve different moments:
+
+- **`Enter` / `Return` — "inspect the selection."** After clicking a critter/object on the canvas,
+  `Enter` shows *and* focuses the Selection panel (raising it if hidden or tabbed behind another
+  dock). No number to remember — it reads as "open what I just selected," and is a no-op when
+  nothing is selected. This is the binding that fits the scenario most naturally.
+- **`Alt+2` — direct toggle of the Selection panel** regardless of selection (part of the numbered
+  family below).
+
+## 2. Panel family — `Alt+1…6`, `` Alt+` ``
+
+One consistent, discoverable group; each toggles **and** focuses its dock.
+
+| Key | Panel |
+|---|---|
+| `Alt+1` | Map Information |
+| `Alt+2` | Selection |
+| `Alt+3` | Scripts |
+| `Alt+4` | Tile Palette |
+| `Alt+5` | Object Palette |
+| `Alt+6` | File Browser |
+| `` Alt+` `` | Log / Script Console |
+
+`Alt+digit` is chosen deliberately so `Ctrl+digit` stays free for elevation, and so it rarely
+collides with text entry.
+
+## 3. Other high-value gaps
+
+Not panels, but the shortcuts a map editor is expected to have and Gecko currently lacks.
+
+| Key | Action | Why |
+|---|---|---|
+| `Ctrl+1` / `Ctrl+2` / `Ctrl+3` | Switch to elevation 1 / 2 / 3 | No elevation shortcut exists today — the biggest everyday gap |
+| `S` | Return to Select mode | Complements the existing `B` / `R` canvas keys; faster than `Esc` |
+| `G` | Toggle grid | Universal editor convention |
+| `Home` | Center view on player start | Fast "where's the entrance" jump |
+| `F` | Fit whole map in view | Quick zoom-to-extent |
+| `Ctrl+Shift+E` | Edit Script Source of the selected object's script | Jump from a scripted critter straight to its `.ssl` (ties into the SSL toolchain work) |
+
+---
+
+## Design caveats to build in
+
+- **Scope single-letter keys to the canvas.** `S` / `G` (like the existing `B` / `R`) must fire
+  only when the map view has focus, not while typing in a panel's filter box or a spin field —
+  otherwise typing "b" in a search field places scroll blockers. These should be editor-widget
+  shortcuts, not application-global `QAction`s.
+- **Toggle + focus semantics for panels.** A panel shortcut should raise a hidden/tabbed dock and
+  give it focus; pressing it again may hide it. "Show and focus" matters more than "toggle" for the
+  `Enter`-on-selection case.
+
+## Relationship to the configurable-keybindings work package
+
+This list is the intended set of **defaults** for the central command/action table proposed in
+`PLAN.md` (Editor limitations §7): a stable `action id → default QKeySequence + label/category`
+table, a Preferences page to rebind with live conflict detection, and persistence via `Settings`,
+driving both the menu/toolbar `QAction`s and the `InputHandler` dispatch. Rather than scattering
+more `QKeySequence` literals through `MainWindow::setupMenuBar()` and `InputHandler`, these bindings
+should land as rows in that table so they are discoverable and remappable from day one.
+
+### Suggested sequencing
+
+1. **Cheapest first slice (standalone):** `Enter` → reveal+focus the Selection panel, and the
+   `Alt+1…6` / `` Alt+` `` panel family. Directly answers the motivating gap; no new infrastructure.
+2. **Editor-navigation slice:** elevation `Ctrl+1/2/3`, `S` select, `G` grid, `Home` center, `F` fit
+   — all canvas-scoped.
+3. **Full slice:** fold everything above into the central keybinding table + Preferences rebind UI,
+   so the defaults become user-remappable.

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -221,7 +221,9 @@ void Application::checkDataConfiguration() {
 }
 
 bool Application::showStartupSettingsDialog() {
-    SettingsDialog dialog(_settings, _mainWindow.get());
+    // The first-run dialog has no registry to offer (the window's is built with it, and rebinding
+    // before any data path is configured is not the point of this dialog), so no shortcuts tab.
+    SettingsDialog dialog(_settings, nullptr, _mainWindow.get());
 
     bool dataPathsChanged = false;
     QObject::connect(&dialog, &SettingsDialog::settingsSaved, [&dataPathsChanged](bool changed) {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -141,6 +141,8 @@ set(GECK_APP_SOURCES
     ui/widgets/LoadingWidget.cpp
     ui/widgets/DataPathsWidget.h
     ui/widgets/DataPathsWidget.cpp
+    ui/widgets/KeybindingsWidget.h
+    ui/widgets/KeybindingsWidget.cpp
     ui/widgets/IntCellDelegate.h
     ui/widgets/IntCellDelegate.cpp
     ui/widgets/GameLocationWidget.h
@@ -200,6 +202,10 @@ set(GECK_APP_SOURCES
 
     ui/input/InputHandler.h
     ui/input/InputHandler.cpp
+    ui/input/ActionSpec.h
+    ui/input/ActionSpec.cpp
+    ui/input/KeyBindingRegistry.h
+    ui/input/KeyBindingRegistry.cpp
     ui/dragdrop/DragDropContext.h
     ui/dragdrop/DragDropManager.h
     ui/dragdrop/DragDropManager.cpp

--- a/src/format/map/Map.cpp
+++ b/src/format/map/Map.cpp
@@ -21,6 +21,21 @@ const Map::MapFile& Map::getMapFile() const {
     return *mapFile;
 }
 
+std::optional<int> Map::scriptProgramIndexForSid(uint32_t sid) const {
+    const int section = MapScript::sidSection(sid);
+    if (!mapFile || section < 0 || section >= SCRIPT_SECTIONS) {
+        return std::nullopt;
+    }
+
+    for (const MapScript& script : mapFile->map_scripts[section]) {
+        if (script.pid == sid) {
+            return static_cast<int>(script.script_id);
+        }
+    }
+
+    return std::nullopt;
+}
+
 void Map::setMapFile(std::unique_ptr<MapFile> newMapFile) {
     mapFile = std::move(newMapFile);
 }

--- a/src/format/map/Map.h
+++ b/src/format/map/Map.h
@@ -92,6 +92,11 @@ public:
     const std::optional<MapEdge>& edge() const { return _edge; }
     void setEdge(std::optional<MapEdge> edge) { _edge = std::move(edge); }
 
+    /// The scripts.lst program index (0-based, what gecko speaks — see CLAUDE.md "Script Index
+    /// Bases") of the map script an object's SID names, or nullopt when this map has no script
+    /// with that SID. The SID's section picks which of the five script lists to search.
+    std::optional<int> scriptProgramIndexForSid(uint32_t sid) const;
+
     /// Builds a blank Fallout 2 map: default header, three empty elevations of
     /// EMPTY_TILE tiles, and no scripts or objects.
     static MapFile createEmptyMapFile();

--- a/src/ui/Settings.cpp
+++ b/src/ui/Settings.cpp
@@ -153,6 +153,14 @@ QJsonObject Settings::toJson() const {
     }
     json["selectionColors"] = selectionColors;
 
+    // Overrides only — an action left at its default is simply absent, so a later release can
+    // change that default and have it take effect.
+    QJsonObject keyBindings;
+    for (auto it = _keyBindings.constBegin(); it != _keyBindings.constEnd(); ++it) {
+        keyBindings[it.key()] = it.value();
+    }
+    json["keyBindings"] = keyBindings;
+
     return json;
 }
 
@@ -259,6 +267,18 @@ void Settings::fromJson(const QJsonObject& json) {
             QColor color(it.value().toString());
             if (color.isValid()) {
                 _selectionColors[it.key()] = color;
+            }
+        }
+    }
+
+    // An absent "keyBindings" means "no overrides" — which is also every settings file written
+    // before this existed, so no version bump is needed to read one.
+    _keyBindings.clear();
+    if (json.contains("keyBindings") && json["keyBindings"].isObject()) {
+        const QJsonObject keyBindings = json["keyBindings"].toObject();
+        for (auto it = keyBindings.constBegin(); it != keyBindings.constEnd(); ++it) {
+            if (it.value().isString()) {
+                _keyBindings[it.key()] = it.value().toString();
             }
         }
     }
@@ -440,6 +460,14 @@ QColor Settings::getSelectionColor(const QString& key, const QColor& fallback) c
 
 void Settings::setSelectionColor(const QString& key, const QColor& color) {
     _selectionColors[key] = color;
+}
+
+QMap<QString, QString> Settings::getKeyBindings() const {
+    return _keyBindings;
+}
+
+void Settings::setKeyBindings(const QMap<QString, QString>& bindings) {
+    _keyBindings = bindings;
 }
 
 bool Settings::validateDataPath(const std::filesystem::path& path) const {

--- a/src/ui/Settings.h
+++ b/src/ui/Settings.h
@@ -100,6 +100,13 @@ public:
 
     // Selection highlight colours (preferences). Keys: "object", "wall", "critter", "tile".
     // Returns @p fallback when the colour has not been configured.
+    // Keyboard-shortcut overrides: action id -> QKeySequence portable text. Only entries that
+    // differ from the shipped default are stored, so changing a default in a later release still
+    // reaches everyone who never rebound that action. An action the user deliberately unbound is
+    // stored as an empty string, which is distinct from absent.
+    QMap<QString, QString> getKeyBindings() const;
+    void setKeyBindings(const QMap<QString, QString>& bindings);
+
     QColor getSelectionColor(const QString& key, const QColor& fallback) const;
     void setSelectionColor(const QString& key, const QColor& color);
 
@@ -154,6 +161,7 @@ private:
 
     // Selection highlight colour overrides (empty = use the renderer defaults).
     QMap<QString, QColor> _selectionColors;
+    QMap<QString, QString> _keyBindings;
 
     // Game location configuration
     std::filesystem::path _executableGameLocation;

--- a/src/ui/core/EditorHints.cpp
+++ b/src/ui/core/EditorHints.cpp
@@ -2,9 +2,21 @@
 
 #include <QStringList>
 
+#include "ui/input/ActionSpec.h"
+
 namespace geck {
 
 namespace {
+
+    // The key an action is currently on, named the way the status bar should show it. Falls back
+    // to the shipped name when no lookup was supplied or the action has been unbound.
+    QString keyName(const HintKeyLookup& keyFor, const char* actionId, const QString& fallback) {
+        if (!keyFor) {
+            return fallback;
+        }
+        const QString bound = keyFor(QString::fromLatin1(actionId));
+        return bound.isEmpty() ? fallback : bound;
+    }
 
     QString joinHints(const QStringList& parts) {
         // A middle dot (U+00B7) flanked by spaces. Built from QChar so it's encoding-safe regardless
@@ -16,7 +28,8 @@ namespace {
 
 } // namespace
 
-QString hintForContext(EditorMode mode, bool hasSelection, const QString& activeToolHint) {
+QString hintForContext(EditorMode mode, bool hasSelection, const QString& activeToolHint,
+    const HintKeyLookup& keyFor) {
     using enum EditorMode;
 
     switch (mode) {
@@ -26,8 +39,8 @@ QString hintForContext(EditorMode mode, bool hasSelection, const QString& active
             // Delete/Backspace. With nothing selected none of them does anything, so the hint
             // is empty.
             if (hasSelection) {
-                return joinHints({ QStringLiteral("Enter: inspect"),
-                    QStringLiteral("R: rotate"),
+                return joinHints({ keyName(keyFor, actions::PANEL_SELECTION_REVEAL, QStringLiteral("Enter")) + QStringLiteral(": inspect"),
+                    keyName(keyFor, actions::TOOL_ROTATE, QStringLiteral("R")) + QStringLiteral(": rotate"),
                     QStringLiteral("Delete: remove") });
             }
             return QString();
@@ -54,6 +67,9 @@ QString hintForContext(EditorMode mode, bool hasSelection, const QString& active
         case StampPattern:
             // R cycles the prefab's orientation variants (the Rotate shortcut is disabled
             // while stamping so the key reaches the viewport); Esc cancels.
+            // R here is the viewport's own stamp key, not the Rotate binding — the Rotate shortcut
+            // stands down while stamping precisely so this one reaches InputHandler — so it is
+            // written out rather than looked up.
             return joinHints({ QStringLiteral("R: cycle variant"),
                 QStringLiteral("Esc: cancel") });
 

--- a/src/ui/core/EditorHints.cpp
+++ b/src/ui/core/EditorHints.cpp
@@ -21,11 +21,13 @@ QString hintForContext(EditorMode mode, bool hasSelection, const QString& active
 
     switch (mode) {
         case Select:
-            // Only the keys that genuinely act on a selection: Rotate's "R" toolbar
-            // shortcut (live whenever not stamping) and Delete/Backspace. With nothing
-            // selected neither does anything, so the hint is empty.
+            // Only the keys that genuinely act on a selection: Rotate's canvas "R" (live
+            // whenever not stamping), Enter to inspect it in the Selection panel, and
+            // Delete/Backspace. With nothing selected none of them does anything, so the hint
+            // is empty.
             if (hasSelection) {
-                return joinHints({ QStringLiteral("R: rotate"),
+                return joinHints({ QStringLiteral("Enter: inspect"),
+                    QStringLiteral("R: rotate"),
                     QStringLiteral("Delete: remove") });
             }
             return QString();

--- a/src/ui/core/EditorHints.h
+++ b/src/ui/core/EditorHints.h
@@ -2,6 +2,8 @@
 
 #include <QString>
 
+#include <functional>
+
 #include "ui/core/EditorMode.h"
 
 namespace geck {
@@ -15,6 +17,15 @@ namespace geck {
 // For EditorMode::PluginTool, `activeToolHint` carries the active tool's own hint items
 // (ITool::statusHint(), one per line); when non-empty they are joined with the standard
 // separator, otherwise the generic PluginTool hint is returned.
-QString hintForContext(EditorMode mode, bool hasSelection, const QString& activeToolHint = {});
+//
+// `keyFor` resolves a keybinding-table action id (ui/input/ActionSpec.h) to the key it is
+// currently on, so the hint follows a rebind instead of advertising a key that no longer works.
+// Left unset — as tests do — the shipped defaults are named. The keys that are NOT table rows
+// (Esc, Space, Delete, the Draw-edge Enter) are tool state-machine keys: they are meaningful only
+// inside their mode, are dispatched in SFML key codes rather than QKeySequence, and are not
+// rebindable, so they stay written out here.
+using HintKeyLookup = std::function<QString(const QString& actionId)>;
+QString hintForContext(EditorMode mode, bool hasSelection, const QString& activeToolHint = {},
+    const HintKeyLookup& keyFor = {});
 
 } // namespace geck

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -1499,15 +1499,6 @@ void EditorWidget::bindToolModeCallbacks(InputHandler::Callbacks& callbacks) {
         }
     };
 
-    // Eyedropper: sample what is under the cursor and load it into the matching palette.
-    callbacks.onPick = [this](sf::Vector2f worldPos) {
-        pickAtCursor(worldPos);
-        // Raising a palette dock can move keyboard focus off the viewport; put it back so the next
-        // P / Esc / placement click still arrives here (these keys flow through the SFML widget).
-        if (auto* sfml = getSFMLWidget()) {
-            sfml->setFocus();
-        }
-    };
     callbacks.onToolMousePressed = [this](sf::Vector2f worldPos, sf::Mouse::Button button) {
         return dispatchToolMousePressed(worldPos, button);
     };
@@ -1951,7 +1942,12 @@ QString EditorWidget::currentHintText() const {
             toolHint = QString::fromUtf8(tool->statusHint().data(), static_cast<qsizetype>(tool->statusHint().size()));
         }
     }
-    return hintForContext(_mode, hasSelection, toolHint);
+    return hintForContext(_mode, hasSelection, toolHint, _hintKeyLookup);
+}
+
+void EditorWidget::setHintKeyLookup(HintKeyLookup lookup) {
+    _hintKeyLookup = std::move(lookup);
+    emitHintChanged(); // the hint on screen was written with the old names
 }
 
 void EditorWidget::setTilePlacementMode(bool enabled, int tileIndex, bool isRoof) {
@@ -2568,6 +2564,17 @@ void EditorWidget::clearMarkExitsLinePreview() {
     _exitGridLineVertices.clear();
     _exitGridPreviewHexes.clear();
     _exitGridPreviewFrmPids.clear();
+}
+
+void EditorWidget::pickAtLastCursor() {
+    // Key events carry no view to convert pixels with, so sample at the position InputHandler
+    // tracked on the last mouse move.
+    pickAtCursor(_inputHandler->lastCursorWorldPos());
+    // Raising a palette dock can move keyboard focus off the viewport; put it back so the next
+    // eyedropper press / Esc / placement click still arrives here.
+    if (auto* sfml = getSFMLWidget()) {
+        sfml->setFocus();
+    }
 }
 
 void EditorWidget::pickAtCursor(sf::Vector2f worldPos) {

--- a/src/ui/core/EditorWidget.h
+++ b/src/ui/core/EditorWidget.h
@@ -22,6 +22,7 @@
 #include "format/pro/Pro.h"
 #include "selection/SelectionManager.h"
 #include "selection/SelectionDataProvider.h"
+#include "ui/core/EditorHints.h"
 #include "util/Constants.h"
 #include "util/UndoStack.h"
 #include "rendering/RenderingEngine.h"
@@ -176,9 +177,12 @@ public:
     // Object placement functionality
     void placeObjectAtPosition(sf::Vector2f worldPos) override;
 
-    // Eyedropper (P): sample the topmost object/tile under the cursor and load it into its palette.
+    // Eyedropper: sample the topmost object/tile under the cursor and load it into its palette.
     // A tile arms tile painting; an object arms click-to-place via beginObjectPlacement().
     void pickAtCursor(sf::Vector2f worldPos);
+    // Eyedropper, driven by its canvas shortcut: sample whatever sits under the last known cursor
+    // position into the matching palette, then hand focus back to the viewport.
+    void pickAtLastCursor();
     // Activate the registered object-placement tool for the given proto: reveal it in the palette
     // and show a cursor ghost whose left-click drops a copy (runs as EditorMode::PluginTool).
     void beginObjectPlacement(uint32_t pid, sf::Vector2f worldPos);
@@ -186,6 +190,10 @@ public:
     // The status-bar hint for the current mode/selection, including the active registered
     // tool's own hint while one runs. The same text hintChanged carries.
     [[nodiscard]] QString currentHintText() const;
+    // How the hint names a rebindable key. MainWindow feeds this from the KeyBindingRegistry, so
+    // the hint advertises the key that actually works rather than the shipped one; unset, the
+    // shipped names are used.
+    void setHintKeyLookup(HintKeyLookup lookup);
 
     // Load the freehand fill brush with the palette's tile and activate it. False when the brush is
     // unavailable or no tile is selected.
@@ -549,6 +557,7 @@ private:
 
     // Input + drag/drop + tile/exit-grid placement systems (the Qt-coupled managers).
     std::unique_ptr<InputHandler> _inputHandler;
+    HintKeyLookup _hintKeyLookup;
     // RenderingEngine, MapSpriteLoader, ObjectCommandController and ViewportController now live
     // in _controller (the Qt-free editor core).
     std::unique_ptr<DragDropManager> _dragDropManager;

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -18,6 +18,7 @@
 #include "ui/panels/CompletenessView.h"
 #include "resource/MapCompleteness.h"
 #include "ui/rendering/ThumbnailPrewarmer.h"
+#include "viewport/ViewportController.h"
 #ifdef GECK_SCRIPTING_ENABLED
 #include "ui/panels/ScriptConsoleWidget.h"
 #include "scripting/LuaScriptRuntime.h" // ScriptResult
@@ -381,6 +382,73 @@ void MainWindow::installCanvasShortcuts() {
     // Return and numpad Enter are distinct key codes; one QShortcut catches only its own.
     _inspectSelectionShortcut = addCanvasShortcut(QKeySequence(Qt::Key_Return), inspectSelection);
     _inspectSelectionEnterShortcut = addCanvasShortcut(QKeySequence(Qt::Key_Enter), inspectSelection);
+
+    // Navigation and tool keys. Single letters belong on the canvas: window-scoped they would fire
+    // while a palette grid, a tree or a non-editable combo has focus, and typing "b" in such a
+    // place would start placing scroll blockers.
+    addCanvasShortcut(QKeySequence(Qt::Key_S), [this]() {
+        if (_selectToolAction) {
+            _selectToolAction->trigger();
+        }
+    });
+    addCanvasShortcut(QKeySequence(Qt::Key_G), [this]() {
+        if (_showHexGridAction) {
+            _showHexGridAction->toggle();
+        }
+    });
+    addCanvasShortcut(QKeySequence(Qt::Key_B), [this]() {
+        if (_scrollBlockerRectAction) {
+            _scrollBlockerRectAction->trigger();
+        }
+    });
+    _rotateShortcut = addCanvasShortcut(QKeySequence(Qt::Key_R), [this]() {
+        if (_rotateAction) {
+            _rotateAction->trigger();
+        }
+    });
+
+    addCanvasShortcut(QKeySequence(Qt::Key_Home), [this]() {
+        if (_currentEditorWidget) {
+            _currentEditorWidget->centerViewOnPlayerPosition();
+        }
+    });
+    addCanvasShortcut(QKeySequence(Qt::Key_F), [this]() {
+        if (_currentEditorWidget) {
+            _currentEditorWidget->viewport().fitMapInView();
+        }
+    });
+}
+
+void MainWindow::editSelectedObjectScriptSource() {
+    if (!_currentEditorWidget || !_scriptSourceService) {
+        return;
+    }
+
+    const Map* map = _currentEditorWidget->getMap();
+    const selection::SelectionManager* selectionManager = _currentEditorWidget->getSelectionManager();
+    if (!map || !selectionManager) {
+        return;
+    }
+
+    // The first selected object that actually owns a script. A selection of tiles, or of objects
+    // with nothing attached, is a no-op with a word in the status bar rather than a dialog.
+    for (const selection::SelectedItem& item : selectionManager->getCurrentSelection().items) {
+        if (!item.isObject()) {
+            continue;
+        }
+        const std::shared_ptr<Object> object = item.getObject();
+        const std::shared_ptr<MapObject> mapObject = object ? object->getMapObjectPtr() : nullptr;
+        if (!mapObject || mapObject->map_scripts_pid == -1) {
+            continue;
+        }
+        const auto sid = static_cast<uint32_t>(mapObject->map_scripts_pid);
+        if (const std::optional<int> programIndex = map->scriptProgramIndexForSid(sid)) {
+            _scriptSourceService->editScriptSource(*programIndex);
+            return;
+        }
+    }
+
+    showStatusMessage(tr("No script attached to the selection"));
 }
 
 QAction* MainWindow::addPanelToggleAction(const QString& label, QDockWidget* dock, QAction*& actionRef,
@@ -539,9 +607,14 @@ void MainWindow::setupMenuBar() {
     addMenuAction(_editMenu, ":/icons/actions/deselect.svg", "&Deselect All", &MainWindow::deselectAllRequested, QKeySequence("Ctrl+D"), "Clear all selections");
 
     _editMenu->addSeparator();
-    addMenuAction(_editMenu, ":/icons/actions/scroll-blocker.svg", "Scroll &Blocker Rectangle", &MainWindow::toggleScrollBlockerRectangleMode, QKeySequence("B"), "Draw rectangle and place scroll blockers on borders");
+    // No shortcut on the action itself: "B" is canvas-scoped (installCanvasShortcuts), so it cannot
+    // fire while a palette grid or a tree has focus.
+    _scrollBlockerRectAction = addMenuAction(_editMenu, ":/icons/actions/scroll-blocker.svg", "Scroll &Blocker Rectangle", &MainWindow::toggleScrollBlockerRectangleMode, QKeySequence(), "Draw rectangle and place scroll blockers on borders (B)");
     addMenuAction(_editMenu, ":/icons/actions/save.svg", "Save Selection as &Pattern...", &MainWindow::showSavePatternDialog, QKeySequence(), "Save the current selection as a reusable prefab pattern");
     addMenuAction(_editMenu, ":/icons/actions/open.svg", "S&tamp Pattern...", &MainWindow::showStampPatternDialog, QKeySequence(), "Load a prefab pattern and click to place it");
+    // Jump from a scripted object straight to its .ssl. Window-scoped: it is a command, not a
+    // single letter, so it costs nothing while a filter box has focus.
+    addMenuAction(_editMenu, ":/icons/actions/settings.svg", "&Edit Script Source", &MainWindow::editSelectedObjectScriptSource, QKeySequence("Ctrl+Shift+E"), "Open the .ssl of the script attached to the selected object");
 #ifdef GECK_SCRIPTING_ENABLED
     // Fill is driven entirely by Luau fill scripts, so it is offered only when scripting is built in.
     // Every use of _fillSelectionAction below is null-guarded, so leaving it null disables the feature.
@@ -732,12 +805,16 @@ void MainWindow::setupMenuBar() {
         const char* text;
         int elevation;
         bool checked;
+        int shortcutKey;
     };
 
+    // Ctrl+digit, the counterpart to the panels' Alt+digit. updateElevationMenu() enables only the
+    // elevations the open map actually has, and a shortcut on a disabled action is a no-op — so a
+    // map with one elevation ignores Ctrl+2 rather than switching to a level that isn't there.
     const std::array<ElevationActionSpec, 3> elevationSpecs = { {
-        { &_elevation1Action, "Elevation &1", ELEVATION_1, true },
-        { &_elevation2Action, "Elevation &2", ELEVATION_2, false },
-        { &_elevation3Action, "Elevation &3", ELEVATION_3, false },
+        { &_elevation1Action, "Elevation &1", ELEVATION_1, true, Qt::Key_1 },
+        { &_elevation2Action, "Elevation &2", ELEVATION_2, false, Qt::Key_2 },
+        { &_elevation3Action, "Elevation &3", ELEVATION_3, false, Qt::Key_3 },
     } };
 
     for (const ElevationActionSpec& spec : elevationSpecs) {
@@ -745,6 +822,7 @@ void MainWindow::setupMenuBar() {
         action->setCheckable(true);
         action->setChecked(spec.checked);
         action->setData(spec.elevation);
+        action->setShortcut(QKeySequence(Qt::CTRL | static_cast<Qt::Key>(spec.shortcutKey)));
         action->setDisabled(true);
         elevationGroup->addAction(action);
         connect(action, &QAction::triggered, this, [this, elevation = spec.elevation]() { elevationChanged(elevation); });
@@ -887,9 +965,9 @@ void MainWindow::setupToolBar() {
 
     _mainToolBar->addSeparator();
 
-    // Stored so it can be disabled while stamping a pattern — otherwise its "R" shortcut
-    // swallows the key before it reaches the viewport, where R cycles pattern variants.
-    _rotateAction = addToolAction(":/icons/actions/rotate.svg", "Rotate", &MainWindow::rotateObjectRequested, "Rotate selected object", QKeySequence("R"));
+    // "R" is canvas-scoped (installCanvasShortcuts) rather than a shortcut on this action, so it
+    // only fires with the map view focused. The button itself stays enabled in every mode.
+    _rotateAction = addToolAction(":/icons/actions/rotate.svg", "Rotate", &MainWindow::rotateObjectRequested, "Rotate selected object (R)");
 
     _mainToolBar->addSeparator();
 
@@ -1067,9 +1145,11 @@ void MainWindow::syncToolModeActions(EditorMode mode) {
     }
 
     // Free up "R" for the viewport while stamping or while a registered tool runs (object
-    // placement); otherwise the toolbar shortcut would swallow the key before it reaches the editor.
-    if (_rotateAction) {
-        _rotateAction->setEnabled(mode != EditorMode::StampPattern && mode != EditorMode::PluginTool);
+    // placement); otherwise the shortcut would swallow the key before it reaches the editor, where
+    // R cycles a stamp's orientation variants. The toolbar button stays enabled either way — only
+    // the key stands down.
+    if (_rotateShortcut) {
+        _rotateShortcut->setEnabled(mode != EditorMode::StampPattern && mode != EditorMode::PluginTool);
     }
 }
 

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -862,9 +862,9 @@ void MainWindow::setupMenuBar() {
     // elevations the open map actually has, and a shortcut on a disabled action is a no-op — so a
     // map with one elevation ignores Ctrl+2 rather than switching to a level that isn't there.
     const std::array<ElevationActionSpec, 3> elevationSpecs = { {
-        { &_elevation1Action, "Elevation &1", ELEVATION_1, true, actions::ELEVATION_1 },
-        { &_elevation2Action, "Elevation &2", ELEVATION_2, false, actions::ELEVATION_2 },
-        { &_elevation3Action, "Elevation &3", ELEVATION_3, false, actions::ELEVATION_3 },
+        { &_elevation1Action, "Elevation &1", ELEVATION_1, true, actions::SET_ELEVATION_1 },
+        { &_elevation2Action, "Elevation &2", ELEVATION_2, false, actions::SET_ELEVATION_2 },
+        { &_elevation3Action, "Elevation &3", ELEVATION_3, false, actions::SET_ELEVATION_3 },
     } };
 
     for (const ElevationActionSpec& spec : elevationSpecs) {

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -131,9 +131,12 @@ MainWindow::MainWindow(std::shared_ptr<resource::GameResources> resources, std::
     // Before setupUI(): every menu, toolbar and canvas binding below asks the registry for its
     // key rather than carrying a literal, so it has to exist first.
     _keyBindings = std::make_unique<KeyBindingRegistry>(_settings, this);
-    connect(_keyBindings.get(), &KeyBindingRegistry::bindingChanged, this, [this](const QString&, const QKeySequence&) {
+    connect(_keyBindings.get(), &KeyBindingRegistry::bindingChanged, this, [this](const QString& id, const QKeySequence&) {
         if (_hintLabel && _currentEditorWidget) {
             _hintLabel->setText(_currentEditorWidget->currentHintText());
+        }
+        if (id == QLatin1StringView(actions::PANEL_SELECTION_REVEAL)) {
+            syncInspectSelectionCompanionKey();
         }
     });
 
@@ -400,11 +403,15 @@ void MainWindow::installCanvasShortcuts() {
     };
 
     _inspectSelectionShortcut = addCanvasShortcut(actions::PANEL_SELECTION_REVEAL, inspectSelection);
+
     // Numpad Enter is a distinct key code that no QKeySequence on Return catches, and it is the
-    // same command rather than a second binding — so it is a fixed companion, not a table row.
-    _inspectSelectionEnterShortcut = new QShortcut(QKeySequence(Qt::Key_Enter), canvas);
+    // same command rather than a second binding — so it is a companion of the reveal key, not a
+    // table row of its own. It exists only while that key IS Return: rebound elsewhere, the
+    // companion clears, so numpad Enter never keeps working a shortcut the user moved away.
+    _inspectSelectionEnterShortcut = new QShortcut(canvas);
     _inspectSelectionEnterShortcut->setContext(Qt::WidgetWithChildrenShortcut);
     connect(_inspectSelectionEnterShortcut, &QShortcut::activated, this, inspectSelection);
+    syncInspectSelectionCompanionKey();
 
     // Navigation and tool keys. Single letters belong on the canvas: window-scoped they would fire
     // while a palette grid, a tree or a non-editable combo has focus, and typing "b" in such a
@@ -448,6 +455,15 @@ void MainWindow::installCanvasShortcuts() {
             _currentEditorWidget->viewport().fitMapInView();
         }
     });
+}
+
+void MainWindow::syncInspectSelectionCompanionKey() {
+    if (!_inspectSelectionEnterShortcut || !_keyBindings) {
+        return;
+    }
+    const bool revealIsOnReturn = (_keyBindings->shortcut(actions::PANEL_SELECTION_REVEAL)
+        == QKeySequence(Qt::Key_Return));
+    _inspectSelectionEnterShortcut->setKey(revealIsOnReturn ? QKeySequence(Qt::Key_Enter) : QKeySequence());
 }
 
 void MainWindow::editSelectedObjectScriptSource() {

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -176,6 +176,11 @@ void MainWindow::setEditorWidget(std::unique_ptr<EditorWidget> editorWidget) {
             std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - initStart).count());
     }
 
+    // The canvas exists only once init() has built it, and it is rebuilt per map, so the
+    // canvas-scoped shortcuts are re-installed here (parented to the widget, so the old ones go
+    // with it). Before connectToEditorWidget(), whose syncToolModeActions() seeds their enabled state.
+    installCanvasShortcuts();
+
     connectToEditorWidget();
     connect(_currentEditorWidget, &EditorWidget::undoStackChanged, this, &MainWindow::updateUndoRedoActions);
     // Any edit (or undo/redo) marks the map dirty for the close/title prompts.
@@ -314,37 +319,88 @@ void MainWindow::connectMenuSignals() {
     updateUndoRedoActions();
 }
 
-QAction* MainWindow::addPanelToggleAction(const QString& label, QDockWidget* dock, QAction*& actionRef) {
-    auto showDock = [this](QDockWidget* targetDock, bool visible) {
-        if (!targetDock) {
+void MainWindow::revealPanel(QDockWidget* dock, QAction* action) {
+    if (!dock) {
+        return;
+    }
+
+    // Panels are tabbed, so "visible" is not the same as "on screen": a dock sitting behind
+    // another tab is visible to Qt but hidden to the user, and a plain toggle would take it away
+    // just as they asked for it. Raise those instead, and hide only the tab already on top.
+    const bool onTop = !dock->isHidden() && !dock->visibleRegion().isEmpty();
+
+    if (onTop) {
+        dock->hide();
+    } else {
+        dock->show();
+        if (!dock->isFloating() && dockWidgetArea(dock) != Qt::NoDockWidgetArea) {
+            dock->raise();
+        }
+        // Put the caret in the panel so it can be used straight away. A panel whose widget takes
+        // no focus simply keeps it where it was.
+        if (QWidget* panel = dock->widget()) {
+            panel->setFocus(Qt::ShortcutFocusReason);
+        }
+    }
+
+    // show()/hide() fire visibilityChanged, which re-syncs the menu check state; a raise fires
+    // nothing, so re-assert it here for the tabbed-behind case.
+    if (action) {
+        const QSignalBlocker blocker(*action);
+        action->setChecked(!dock->isHidden());
+    }
+}
+
+void MainWindow::installCanvasShortcuts() {
+    SFMLWidget* canvas = _currentEditorWidget ? _currentEditorWidget->getSFMLWidget() : nullptr;
+    if (!canvas) {
+        return;
+    }
+
+    // "Inspect the selection": reveal the Selection panel for whatever was just clicked. Scoped to
+    // the canvas so a Return pressed in a panel's filter box or a spin box is left alone, and a
+    // no-op with an empty selection (there is nothing to inspect).
+    const auto inspectSelection = [this]() {
+        if (!_currentEditorWidget) {
             return;
         }
-
-        if (visible) {
-            targetDock->show();
-            if (!targetDock->isFloating() && dockWidgetArea(targetDock) != Qt::NoDockWidgetArea) {
-                targetDock->raise();
-            }
+        const selection::SelectionManager* selectionManager = _currentEditorWidget->getSelectionManager();
+        if (!selectionManager || !selectionManager->hasSelection()) {
             return;
         }
-
-        targetDock->hide();
+        revealPanel(_selectionDock, _selectionPanelAction);
     };
 
+    const auto addCanvasShortcut = [this, canvas](QKeySequence keys, auto handler) {
+        auto* shortcut = new QShortcut(std::move(keys), canvas);
+        shortcut->setContext(Qt::WidgetWithChildrenShortcut);
+        connect(shortcut, &QShortcut::activated, this, std::move(handler));
+        return shortcut;
+    };
+
+    // Return and numpad Enter are distinct key codes; one QShortcut catches only its own.
+    _inspectSelectionShortcut = addCanvasShortcut(QKeySequence(Qt::Key_Return), inspectSelection);
+    _inspectSelectionEnterShortcut = addCanvasShortcut(QKeySequence(Qt::Key_Enter), inspectSelection);
+}
+
+QAction* MainWindow::addPanelToggleAction(const QString& label, QDockWidget* dock, QAction*& actionRef,
+    const QKeySequence& shortcut) {
     actionRef = _panelsMenu->addAction(label);
     actionRef->setCheckable(true);
     actionRef->setChecked(true);
     QAction* action = actionRef;
+    if (!shortcut.isEmpty()) {
+        action->setShortcut(shortcut);
+    }
 
-    connect(action, &QAction::toggled, this, [this, dock, showDock](bool visible) {
-        if (_suppressDockStateSave) {
-            return;
-        }
-
-        spdlog::debug("{} action toggled: {}", dock->windowTitle().toStdString(), visible);
-        // showDock() flips the dock, which fires QDockWidget::visibilityChanged below; that handler
-        // persists the new layout, so there's nothing to save here.
-        showDock(dock, visible);
+    // triggered(), not toggled(): the check state Qt flips before this runs is only a request —
+    // revealPanel() decides from the dock's own state and re-asserts the box. Using triggered()
+    // also means the programmatic setChecked() calls elsewhere cannot reach here.
+    connect(action, &QAction::triggered, this, [this, dock, action]() {
+        spdlog::debug("{} panel action triggered", dock->windowTitle().toStdString());
+        // revealPanel() flips the dock, which fires QDockWidget::visibilityChanged below; that
+        // handler persists the new layout, so there's nothing to save here.
+        revealPanel(dock, action);
     });
 
     connect(dock, &QDockWidget::visibilityChanged, this, [this, dock, action](bool visible) {
@@ -1002,6 +1058,14 @@ void MainWindow::syncToolModeActions(EditorMode mode) {
         }
     }
 
+    // Enter finalizes the in-progress "Draw edge" polyline (InputHandler), so the inspect-selection
+    // shortcut must stand down in that mode rather than eat the key.
+    for (QShortcut* shortcut : { _inspectSelectionShortcut.data(), _inspectSelectionEnterShortcut.data() }) {
+        if (shortcut) {
+            shortcut->setEnabled(mode != EditorMode::MarkExits);
+        }
+    }
+
     // Free up "R" for the viewport while stamping or while a registered tool runs (object
     // placement); otherwise the toolbar shortcut would swallow the key before it reaches the editor.
     if (_rotateAction) {
@@ -1255,9 +1319,22 @@ void MainWindow::setupDockWidgets() {
         consoleAction->setText(tr("Script &Console"));
         _viewMenu->addAction(consoleAction);
 #endif
-        QAction* logAction = _logDock->toggleViewAction();
-        logAction->setText(tr("&Log"));
-        _viewMenu->addAction(logAction);
+        // Not _logDock->toggleViewAction(): that one plain-toggles, and the Log dock shares the
+        // bottom area with the Script Console, so Alt+` needs to raise it when it is tabbed
+        // behind. The check state is kept in step with the dock below instead.
+        _logPanelAction = _viewMenu->addAction(tr("&Log"));
+        _logPanelAction->setCheckable(true);
+        _logPanelAction->setChecked(!_logDock->isHidden());
+        _logPanelAction->setShortcut(QKeySequence(Qt::ALT | Qt::Key_QuoteLeft));
+        connect(_logPanelAction, &QAction::triggered, this, [this]() { revealPanel(_logDock, _logPanelAction); });
+        // The Log dock sits outside the managed-layout persistence, so this only mirrors state.
+        connect(_logDock, &QDockWidget::visibilityChanged, this, [this](bool visible) {
+            if (!_logPanelAction) {
+                return;
+            }
+            const QSignalBlocker blocker(*_logPanelAction);
+            _logPanelAction->setChecked(visible);
+        });
     }
 
     // MainWindow signals → current editor widget (connected once; both sender
@@ -2325,19 +2402,23 @@ void MainWindow::setupPanelsMenu() {
         const char* label;
         QDockWidget* dock;
         QAction** actionRef;
+        int shortcutKey; // Alt+<digit>; the family is deliberate, see docs/keybindings-plan.md
     };
 
+    // Alt+digit rather than Ctrl+digit: it keeps Ctrl+1..3 free for the elevations, and Alt+digit
+    // is not text, so a panel's filter box never swallows it.
     const std::array<PanelToggleSpec, 6> panelToggleSpecs = { {
-        { "Map &Information", _mapInfoDock, &_mapInfoPanelAction },
-        { "Scri&pts", _scriptsDock, &_scriptsPanelAction },
-        { "&Selection", _selectionDock, &_selectionPanelAction },
-        { "&Tile Palette", _tilePaletteDock, &_tilePalettePanelAction },
-        { "&Object Palette", _objectPaletteDock, &_objectPalettePanelAction },
-        { "&Virtual File System Browser", _fileBrowserDock, &_fileBrowserPanelAction },
+        { "Map &Information", _mapInfoDock, &_mapInfoPanelAction, Qt::Key_1 },
+        { "Scri&pts", _scriptsDock, &_scriptsPanelAction, Qt::Key_3 },
+        { "&Selection", _selectionDock, &_selectionPanelAction, Qt::Key_2 },
+        { "&Tile Palette", _tilePaletteDock, &_tilePalettePanelAction, Qt::Key_4 },
+        { "&Object Palette", _objectPaletteDock, &_objectPalettePanelAction, Qt::Key_5 },
+        { "&Virtual File System Browser", _fileBrowserDock, &_fileBrowserPanelAction, Qt::Key_6 },
     } };
 
     for (const PanelToggleSpec& spec : panelToggleSpecs) {
-        addPanelToggleAction(spec.label, spec.dock, *spec.actionRef);
+        addPanelToggleAction(spec.label, spec.dock, *spec.actionRef,
+            QKeySequence(Qt::ALT | static_cast<Qt::Key>(spec.shortcutKey)));
     }
 }
 

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -19,6 +19,8 @@
 #include "resource/MapCompleteness.h"
 #include "ui/rendering/ThumbnailPrewarmer.h"
 #include "viewport/ViewportController.h"
+#include "ui/input/ActionSpec.h"
+#include "ui/input/KeyBindingRegistry.h"
 #ifdef GECK_SCRIPTING_ENABLED
 #include "ui/panels/ScriptConsoleWidget.h"
 #include "scripting/LuaScriptRuntime.h" // ScriptResult
@@ -126,6 +128,15 @@ MainWindow::MainWindow(std::shared_ptr<resource::GameResources> resources, std::
 
     setTabPosition(Qt::AllDockWidgetAreas, QTabWidget::North);
 
+    // Before setupUI(): every menu, toolbar and canvas binding below asks the registry for its
+    // key rather than carrying a literal, so it has to exist first.
+    _keyBindings = std::make_unique<KeyBindingRegistry>(_settings, this);
+    connect(_keyBindings.get(), &KeyBindingRegistry::bindingChanged, this, [this](const QString&, const QKeySequence&) {
+        if (_hintLabel && _currentEditorWidget) {
+            _hintLabel->setText(_currentEditorWidget->currentHintText());
+        }
+    });
+
     setupUI();
 
     // The unique_ptr owns the launcher, so it has no QObject parent (it still
@@ -182,6 +193,12 @@ void MainWindow::setEditorWidget(std::unique_ptr<EditorWidget> editorWidget) {
     // with it). Before connectToEditorWidget(), whose syncToolModeActions() seeds their enabled state.
     installCanvasShortcuts();
 
+    // Status-bar hints name the key that is actually bound, so they follow a rebind. Native text
+    // ("⌥1" on macOS, "Alt+1" elsewhere) because this is read, not parsed.
+    _currentEditorWidget->setHintKeyLookup([this](const QString& actionId) {
+        return _keyBindings ? _keyBindings->shortcut(actionId).toString(QKeySequence::NativeText) : QString();
+    });
+
     connectToEditorWidget();
     connect(_currentEditorWidget, &EditorWidget::undoStackChanged, this, &MainWindow::updateUndoRedoActions);
     // Any edit (or undo/redo) marks the map dirty for the close/title prompts.
@@ -231,7 +248,7 @@ void MainWindow::setupUI() {
             _worldMapAction->setChecked(true);
         }
     });
-    connect(_welcomeWidget, &WelcomeWidget::preferencesRequested, this, &MainWindow::showPreferences);
+    connect(_welcomeWidget, &WelcomeWidget::preferencesRequested, this, [this]() { showPreferences(); });
     _centralStack->addWidget(_welcomeWidget);
     _centralStack->setCurrentWidget(_welcomeWidget);
 
@@ -372,47 +389,61 @@ void MainWindow::installCanvasShortcuts() {
         revealPanel(_selectionDock, _selectionPanelAction);
     };
 
-    const auto addCanvasShortcut = [this, canvas](QKeySequence keys, auto handler) {
-        auto* shortcut = new QShortcut(std::move(keys), canvas);
+    // The registry supplies each key and re-keys the shortcut if the user rebinds it. The shortcut
+    // is parented to the canvas, so it dies with the map view and the registry drops the dead sink.
+    const auto addCanvasShortcut = [this, canvas](const char* actionId, auto handler) {
+        auto* shortcut = new QShortcut(canvas);
         shortcut->setContext(Qt::WidgetWithChildrenShortcut);
         connect(shortcut, &QShortcut::activated, this, std::move(handler));
+        _keyBindings->bind(QString::fromLatin1(actionId), shortcut);
         return shortcut;
     };
 
-    // Return and numpad Enter are distinct key codes; one QShortcut catches only its own.
-    _inspectSelectionShortcut = addCanvasShortcut(QKeySequence(Qt::Key_Return), inspectSelection);
-    _inspectSelectionEnterShortcut = addCanvasShortcut(QKeySequence(Qt::Key_Enter), inspectSelection);
+    _inspectSelectionShortcut = addCanvasShortcut(actions::PANEL_SELECTION_REVEAL, inspectSelection);
+    // Numpad Enter is a distinct key code that no QKeySequence on Return catches, and it is the
+    // same command rather than a second binding — so it is a fixed companion, not a table row.
+    _inspectSelectionEnterShortcut = new QShortcut(QKeySequence(Qt::Key_Enter), canvas);
+    _inspectSelectionEnterShortcut->setContext(Qt::WidgetWithChildrenShortcut);
+    connect(_inspectSelectionEnterShortcut, &QShortcut::activated, this, inspectSelection);
 
     // Navigation and tool keys. Single letters belong on the canvas: window-scoped they would fire
     // while a palette grid, a tree or a non-editable combo has focus, and typing "b" in such a
     // place would start placing scroll blockers.
-    addCanvasShortcut(QKeySequence(Qt::Key_S), [this]() {
+    addCanvasShortcut(actions::TOOL_SELECT, [this]() {
         if (_selectToolAction) {
             _selectToolAction->trigger();
         }
     });
-    addCanvasShortcut(QKeySequence(Qt::Key_G), [this]() {
+    addCanvasShortcut(actions::HEX_GRID, [this]() {
         if (_showHexGridAction) {
             _showHexGridAction->toggle();
         }
     });
-    addCanvasShortcut(QKeySequence(Qt::Key_B), [this]() {
+    addCanvasShortcut(actions::TOOL_SCROLL_BLOCKER_RECT, [this]() {
         if (_scrollBlockerRectAction) {
             _scrollBlockerRectAction->trigger();
         }
     });
-    _rotateShortcut = addCanvasShortcut(QKeySequence(Qt::Key_R), [this]() {
+    _rotateShortcut = addCanvasShortcut(actions::TOOL_ROTATE, [this]() {
         if (_rotateAction) {
             _rotateAction->trigger();
         }
     });
+    // Eyedropper: sample whatever is under the cursor into the matching palette. It used to be
+    // dispatched inside InputHandler with the tool-state keys, but it is a canvas command like the
+    // rest of these, so it belongs here where it is rebindable.
+    addCanvasShortcut(actions::TOOL_PICK, [this]() {
+        if (_currentEditorWidget) {
+            _currentEditorWidget->pickAtLastCursor();
+        }
+    });
 
-    addCanvasShortcut(QKeySequence(Qt::Key_Home), [this]() {
+    addCanvasShortcut(actions::CENTER_ON_PLAYER, [this]() {
         if (_currentEditorWidget) {
             _currentEditorWidget->centerViewOnPlayerPosition();
         }
     });
-    addCanvasShortcut(QKeySequence(Qt::Key_F), [this]() {
+    addCanvasShortcut(actions::FIT_MAP, [this]() {
         if (_currentEditorWidget) {
             _currentEditorWidget->viewport().fitMapInView();
         }
@@ -452,13 +483,13 @@ void MainWindow::editSelectedObjectScriptSource() {
 }
 
 QAction* MainWindow::addPanelToggleAction(const QString& label, QDockWidget* dock, QAction*& actionRef,
-    const QKeySequence& shortcut) {
+    const char* actionId) {
     actionRef = _panelsMenu->addAction(label);
     actionRef->setCheckable(true);
     actionRef->setChecked(true);
     QAction* action = actionRef;
-    if (!shortcut.isEmpty()) {
-        action->setShortcut(shortcut);
+    if (actionId != nullptr) {
+        _keyBindings->bind(QString::fromLatin1(actionId), action);
     }
 
     // triggered(), not toggled(): the check state Qt flips before this runs is only a request —
@@ -563,10 +594,13 @@ void MainWindow::applyDefaultPanelDockLayout() {
 void MainWindow::setupMenuBar() {
     _menuBar = menuBar();
 
-    auto addMenuAction = [this](QMenu* menu, const QString& iconPath, const QString& text, auto slot, const QKeySequence& shortcut = QKeySequence(), const QString& statusTip = QString()) {
+    // `actionId` names a row of the shipped keybinding table (ui/input/ActionSpec.h); the registry
+    // supplies the key and re-keys the action if the user rebinds it. Pass nullptr for the actions
+    // that have no shortcut.
+    auto addMenuAction = [this](QMenu* menu, const QString& iconPath, const QString& text, auto slot, const char* actionId = nullptr, const QString& statusTip = QString()) {
         QAction* action = menu->addAction(createIcon(iconPath), text);
-        if (!shortcut.isEmpty()) {
-            action->setShortcut(shortcut);
+        if (actionId != nullptr) {
+            _keyBindings->bind(QString::fromLatin1(actionId), action);
         }
         if (!statusTip.isEmpty()) {
             action->setStatusTip(statusTip);
@@ -575,56 +609,56 @@ void MainWindow::setupMenuBar() {
         return action;
     };
 
-    auto addViewToggleAction = [this](QAction*& actionRef, const QString& iconPath, const QString& text, bool checked, auto signal, const QString& statusTip = QString(), const QKeySequence& shortcut = QKeySequence()) {
+    auto addViewToggleAction = [this](QAction*& actionRef, const QString& iconPath, const QString& text, bool checked, auto signal, const QString& statusTip = QString(), const char* actionId = nullptr) {
         actionRef = _viewMenu->addAction(createIcon(iconPath), text);
         actionRef->setCheckable(true);
         actionRef->setChecked(checked);
         if (!statusTip.isEmpty()) {
             actionRef->setStatusTip(statusTip);
         }
-        if (!shortcut.isEmpty()) {
-            actionRef->setShortcut(shortcut);
+        if (actionId != nullptr) {
+            _keyBindings->bind(QString::fromLatin1(actionId), actionRef);
         }
         connect(actionRef, &QAction::toggled, this, signal);
     };
 
     _fileMenu = _menuBar->addMenu("&File");
-    addMenuAction(_fileMenu, ":/icons/actions/new.svg", "&New Map", &MainWindow::newMapRequested, QKeySequence::New, "Create a new map");
-    addMenuAction(_fileMenu, ":/icons/actions/open.svg", "&Open Map", &MainWindow::openMapRequested, QKeySequence::Open, "Open an existing map");
-    addMenuAction(_fileMenu, ":/icons/actions/open.svg", "&Browse Maps...", &MainWindow::showMapBrowserDialog, QKeySequence("Ctrl+B"), "Browse available maps as thumbnails");
-    addMenuAction(_fileMenu, ":/icons/actions/save.svg", "&Save Map", &MainWindow::saveMapRequested, QKeySequence::Save, "Save current map");
-    addMenuAction(_fileMenu, ":/icons/actions/save.svg", "Save Map &As...", &MainWindow::saveMapAsRequested, QKeySequence::SaveAs, "Save the current map to a chosen file");
-    addMenuAction(_fileMenu, ":/icons/actions/close.svg", "&Close Map", &MainWindow::closeMapRequested, QKeySequence::Close, "Close the current map and return to the welcome screen");
+    addMenuAction(_fileMenu, ":/icons/actions/new.svg", "&New Map", &MainWindow::newMapRequested, actions::NEW_MAP, "Create a new map");
+    addMenuAction(_fileMenu, ":/icons/actions/open.svg", "&Open Map", &MainWindow::openMapRequested, actions::OPEN_MAP, "Open an existing map");
+    addMenuAction(_fileMenu, ":/icons/actions/open.svg", "&Browse Maps...", &MainWindow::showMapBrowserDialog, actions::BROWSE_MAPS, "Browse available maps as thumbnails");
+    addMenuAction(_fileMenu, ":/icons/actions/save.svg", "&Save Map", &MainWindow::saveMapRequested, actions::SAVE_MAP, "Save current map");
+    addMenuAction(_fileMenu, ":/icons/actions/save.svg", "Save Map &As...", &MainWindow::saveMapAsRequested, actions::SAVE_MAP_AS, "Save the current map to a chosen file");
+    addMenuAction(_fileMenu, ":/icons/actions/close.svg", "&Close Map", &MainWindow::closeMapRequested, actions::CLOSE_MAP, "Close the current map and return to the welcome screen");
 
     _fileMenu->addSeparator();
-    addMenuAction(_fileMenu, ":/icons/actions/settings.svg", "&Preferences...", &MainWindow::showPreferences, QKeySequence::Preferences, "Open application preferences");
+    addMenuAction(_fileMenu, ":/icons/actions/settings.svg", "&Preferences...", [this]() { showPreferences(); }, actions::PREFERENCES, "Open application preferences");
 
     _fileMenu->addSeparator();
-    addMenuAction(_fileMenu, ":/icons/actions/quit.svg", "&Quit", &QWidget::close, QKeySequence::Quit, "Exit the application");
+    addMenuAction(_fileMenu, ":/icons/actions/quit.svg", "&Quit", &QWidget::close, actions::QUIT, "Exit the application");
 
     _editMenu = _menuBar->addMenu("&Edit");
-    addMenuAction(_editMenu, ":/icons/actions/select-all.svg", "Select &All", &MainWindow::selectAllRequested, QKeySequence("Ctrl+A"), "Select all items of current type");
-    addMenuAction(_editMenu, ":/icons/actions/deselect.svg", "&Deselect All", &MainWindow::deselectAllRequested, QKeySequence("Ctrl+D"), "Clear all selections");
+    addMenuAction(_editMenu, ":/icons/actions/select-all.svg", "Select &All", &MainWindow::selectAllRequested, actions::SELECT_ALL, "Select all items of current type");
+    addMenuAction(_editMenu, ":/icons/actions/deselect.svg", "&Deselect All", &MainWindow::deselectAllRequested, actions::DESELECT_ALL, "Clear all selections");
 
     _editMenu->addSeparator();
     // No shortcut on the action itself: "B" is canvas-scoped (installCanvasShortcuts), so it cannot
     // fire while a palette grid or a tree has focus.
-    _scrollBlockerRectAction = addMenuAction(_editMenu, ":/icons/actions/scroll-blocker.svg", "Scroll &Blocker Rectangle", &MainWindow::toggleScrollBlockerRectangleMode, QKeySequence(), "Draw rectangle and place scroll blockers on borders (B)");
-    addMenuAction(_editMenu, ":/icons/actions/save.svg", "Save Selection as &Pattern...", &MainWindow::showSavePatternDialog, QKeySequence(), "Save the current selection as a reusable prefab pattern");
-    addMenuAction(_editMenu, ":/icons/actions/open.svg", "S&tamp Pattern...", &MainWindow::showStampPatternDialog, QKeySequence(), "Load a prefab pattern and click to place it");
+    _scrollBlockerRectAction = addMenuAction(_editMenu, ":/icons/actions/scroll-blocker.svg", "Scroll &Blocker Rectangle", &MainWindow::toggleScrollBlockerRectangleMode, nullptr, "Draw rectangle and place scroll blockers on borders (B)");
+    addMenuAction(_editMenu, ":/icons/actions/save.svg", "Save Selection as &Pattern...", &MainWindow::showSavePatternDialog, nullptr, "Save the current selection as a reusable prefab pattern");
+    addMenuAction(_editMenu, ":/icons/actions/open.svg", "S&tamp Pattern...", &MainWindow::showStampPatternDialog, nullptr, "Load a prefab pattern and click to place it");
     // Jump from a scripted object straight to its .ssl. Window-scoped: it is a command, not a
     // single letter, so it costs nothing while a filter box has focus.
-    addMenuAction(_editMenu, ":/icons/actions/settings.svg", "&Edit Script Source", &MainWindow::editSelectedObjectScriptSource, QKeySequence("Ctrl+Shift+E"), "Open the .ssl of the script attached to the selected object");
+    addMenuAction(_editMenu, ":/icons/actions/settings.svg", "&Edit Script Source", &MainWindow::editSelectedObjectScriptSource, actions::EDIT_SCRIPT_SOURCE, "Open the .ssl of the script attached to the selected object");
 #ifdef GECK_SCRIPTING_ENABLED
     // Fill is driven entirely by Luau fill scripts, so it is offered only when scripting is built in.
     // Every use of _fillSelectionAction below is null-guarded, so leaving it null disables the feature.
-    _fillSelectionAction = addMenuAction(_editMenu, ":/icons/actions/paint.svg", "&Fill Selection...", &MainWindow::showFillDialog, QKeySequence(), "Fill the selected area with a Luau fill script");
+    _fillSelectionAction = addMenuAction(_editMenu, ":/icons/actions/paint.svg", "&Fill Selection...", &MainWindow::showFillDialog, nullptr, "Fill the selected area with a Luau fill script");
 #endif
 
     _editMenu->addSeparator();
 
     _undoAction = _editMenu->addAction("&Undo");
-    _undoAction->setShortcut(QKeySequence::Undo);
+    _keyBindings->bind(actions::UNDO, _undoAction);
     _undoAction->setStatusTip("Undo last edit");
     connect(_undoAction, &QAction::triggered, [this]() {
         if (_currentEditorWidget) {
@@ -638,7 +672,7 @@ void MainWindow::setupMenuBar() {
     });
 
     _redoAction = _editMenu->addAction("&Redo");
-    _redoAction->setShortcut(QKeySequence::Redo);
+    _keyBindings->bind(actions::REDO, _redoAction);
     _redoAction->setStatusTip("Redo last edit");
     connect(_redoAction, &QAction::triggered, [this]() {
         if (_currentEditorWidget) {
@@ -660,7 +694,7 @@ void MainWindow::setupMenuBar() {
     // separated from the rendering switches below. It needs mounted game data, not an open map.
     _worldMapAction = _viewMenu->addAction(createIcon(":/icons/actions/world-map.svg"), "&World Map");
     _worldMapAction->setCheckable(true);
-    _worldMapAction->setShortcut(QKeySequence("Ctrl+Shift+M"));
+    _keyBindings->bind(actions::WORLD_MAP, _worldMapAction);
     _worldMapAction->setStatusTip("Show the Fallout 2 world map with its area markers");
     connect(_worldMapAction, &QAction::toggled, this, &MainWindow::toggleWorldMap);
     _viewMenu->addSeparator();
@@ -672,26 +706,26 @@ void MainWindow::setupMenuBar() {
         bool checked;
         void (MainWindow::*signal)(bool);
         QString statusTip;
-        QKeySequence shortcut;
+        const char* actionId;
     };
 
     const std::array<ViewToggleSpec, 12> viewToggleSpecs = { {
-        { &_showObjectsAction, ":/icons/actions/view-objects.svg", "Show &Objects", UI::DEFAULT_SHOW_OBJECTS, &MainWindow::showObjectsToggled, {}, {} },
-        { &_showCrittersAction, ":/icons/actions/view-critters.svg", "Show &Critters", UI::DEFAULT_SHOW_CRITTERS, &MainWindow::showCrittersToggled, {}, {} },
-        { &_showWallsAction, ":/icons/actions/view-walls.svg", "Show &Walls", UI::DEFAULT_SHOW_WALLS, &MainWindow::showWallsToggled, {}, {} },
-        { &_showRoofsAction, ":/icons/actions/view-roofs.svg", "Show &Roofs", UI::DEFAULT_SHOW_ROOF, &MainWindow::showRoofsToggled, {}, {} },
-        { &_showScrollBlockersAction, ":/icons/actions/view-scroll-blockers.svg", "Show Scroll &Blockers", UI::DEFAULT_SHOW_SCROLL_BLK, &MainWindow::showScrollBlockersToggled, {}, {} },
-        { &_showWallBlockersAction, ":/icons/actions/view-wall-blockers.svg", "Show &Wall Blockers", UI::DEFAULT_SHOW_WALL_BLK, &MainWindow::showWallBlockersToggled, {}, {} },
-        { &_showHexGridAction, ":/icons/actions/view-grid.svg", "Show &Hex Grid", UI::DEFAULT_SHOW_HEX_GRID, &MainWindow::showHexGridToggled, {}, {} },
-        { &_showLightOverlaysAction, ":/icons/actions/view-light.svg", "Show &Light Overlays", false, &MainWindow::showLightOverlaysToggled, {}, {} },
-        { &_showExitGridsAction, ":/icons/actions/view-exits.svg", "Show &Exit Grids", false, &MainWindow::showExitGridsToggled, "Show exit grid markers", QKeySequence("Ctrl+E") },
-        { &_showSpatialScriptsAction, ":/icons/actions/target-arrow.svg", "Show Spatial &Scripts", false, &MainWindow::showSpatialScriptsToggled, "Show spatial-script trigger markers and their radius", {} },
-        { &_showMapEdgesAction, ":/icons/actions/map-edges.svg", "Show Map &Edges", false, &MainWindow::showMapEdgesToggled, "Show the .edg scroll-boundary zones and clip rect", {} },
-        { &_showUnreachableAction, ":/icons/actions/view-unreachable.svg", "Highlight &Unreachable Areas", false, &MainWindow::showUnreachableToggled, "Shade walkable hexes cut off from the player start and every exit grid", {} },
+        { &_showObjectsAction, ":/icons/actions/view-objects.svg", "Show &Objects", UI::DEFAULT_SHOW_OBJECTS, &MainWindow::showObjectsToggled, {}, nullptr },
+        { &_showCrittersAction, ":/icons/actions/view-critters.svg", "Show &Critters", UI::DEFAULT_SHOW_CRITTERS, &MainWindow::showCrittersToggled, {}, nullptr },
+        { &_showWallsAction, ":/icons/actions/view-walls.svg", "Show &Walls", UI::DEFAULT_SHOW_WALLS, &MainWindow::showWallsToggled, {}, nullptr },
+        { &_showRoofsAction, ":/icons/actions/view-roofs.svg", "Show &Roofs", UI::DEFAULT_SHOW_ROOF, &MainWindow::showRoofsToggled, {}, nullptr },
+        { &_showScrollBlockersAction, ":/icons/actions/view-scroll-blockers.svg", "Show Scroll &Blockers", UI::DEFAULT_SHOW_SCROLL_BLK, &MainWindow::showScrollBlockersToggled, {}, nullptr },
+        { &_showWallBlockersAction, ":/icons/actions/view-wall-blockers.svg", "Show &Wall Blockers", UI::DEFAULT_SHOW_WALL_BLK, &MainWindow::showWallBlockersToggled, {}, nullptr },
+        { &_showHexGridAction, ":/icons/actions/view-grid.svg", "Show &Hex Grid", UI::DEFAULT_SHOW_HEX_GRID, &MainWindow::showHexGridToggled, {}, nullptr },
+        { &_showLightOverlaysAction, ":/icons/actions/view-light.svg", "Show &Light Overlays", false, &MainWindow::showLightOverlaysToggled, {}, nullptr },
+        { &_showExitGridsAction, ":/icons/actions/view-exits.svg", "Show &Exit Grids", false, &MainWindow::showExitGridsToggled, "Show exit grid markers", actions::SHOW_EXIT_GRIDS },
+        { &_showSpatialScriptsAction, ":/icons/actions/target-arrow.svg", "Show Spatial &Scripts", false, &MainWindow::showSpatialScriptsToggled, "Show spatial-script trigger markers and their radius", nullptr },
+        { &_showMapEdgesAction, ":/icons/actions/map-edges.svg", "Show Map &Edges", false, &MainWindow::showMapEdgesToggled, "Show the .edg scroll-boundary zones and clip rect", nullptr },
+        { &_showUnreachableAction, ":/icons/actions/view-unreachable.svg", "Highlight &Unreachable Areas", false, &MainWindow::showUnreachableToggled, "Shade walkable hexes cut off from the player start and every exit grid", nullptr },
     } };
 
     for (const ViewToggleSpec& spec : viewToggleSpecs) {
-        addViewToggleAction(*spec.actionRef, spec.iconPath, spec.text, spec.checked, spec.signal, spec.statusTip, spec.shortcut);
+        addViewToggleAction(*spec.actionRef, spec.iconPath, spec.text, spec.checked, spec.signal, spec.statusTip, spec.actionId);
     }
 
     _viewMenu->addSeparator();
@@ -805,16 +839,16 @@ void MainWindow::setupMenuBar() {
         const char* text;
         int elevation;
         bool checked;
-        int shortcutKey;
+        const char* actionId;
     };
 
     // Ctrl+digit, the counterpart to the panels' Alt+digit. updateElevationMenu() enables only the
     // elevations the open map actually has, and a shortcut on a disabled action is a no-op — so a
     // map with one elevation ignores Ctrl+2 rather than switching to a level that isn't there.
     const std::array<ElevationActionSpec, 3> elevationSpecs = { {
-        { &_elevation1Action, "Elevation &1", ELEVATION_1, true, Qt::Key_1 },
-        { &_elevation2Action, "Elevation &2", ELEVATION_2, false, Qt::Key_2 },
-        { &_elevation3Action, "Elevation &3", ELEVATION_3, false, Qt::Key_3 },
+        { &_elevation1Action, "Elevation &1", ELEVATION_1, true, actions::ELEVATION_1 },
+        { &_elevation2Action, "Elevation &2", ELEVATION_2, false, actions::ELEVATION_2 },
+        { &_elevation3Action, "Elevation &3", ELEVATION_3, false, actions::ELEVATION_3 },
     } };
 
     for (const ElevationActionSpec& spec : elevationSpecs) {
@@ -822,7 +856,7 @@ void MainWindow::setupMenuBar() {
         action->setCheckable(true);
         action->setChecked(spec.checked);
         action->setData(spec.elevation);
-        action->setShortcut(QKeySequence(Qt::CTRL | static_cast<Qt::Key>(spec.shortcutKey)));
+        _keyBindings->bind(QString::fromLatin1(spec.actionId), action);
         action->setDisabled(true);
         elevationGroup->addAction(action);
         connect(action, &QAction::triggered, this, [this, elevation = spec.elevation]() { elevationChanged(elevation); });
@@ -830,6 +864,12 @@ void MainWindow::setupMenuBar() {
     }
 
     _helpMenu = _menuBar->addMenu("&Help");
+    // The discoverability half of the keybinding work: one place that lists every shortcut, which
+    // is the same table the user rebinds from rather than a second copy that can drift.
+    QAction* shortcutsAction = _helpMenu->addAction("&Keyboard Shortcuts...");
+    shortcutsAction->setStatusTip("List every keyboard shortcut, and rebind them");
+    connect(shortcutsAction, &QAction::triggered, this, &MainWindow::showKeyboardShortcuts);
+    _helpMenu->addSeparator();
     QAction* aboutAction = _helpMenu->addAction("&About Gecko...");
     aboutAction->setStatusTip("Show information about the application");
     connect(aboutAction, &QAction::triggered, this, &MainWindow::showAbout);
@@ -888,22 +928,24 @@ void MainWindow::setupToolBar() {
         const char* iconPath;
         const char* text;
         const char* statusTip;
-        QKeySequence shortcut;
+        const char* actionId;
         std::function<void()> trigger;
     };
 
+    // New / Browse / Save duplicate File-menu actions that already carry the key, so only Play
+    // binds here — two sinks on one id would be an ambiguous shortcut, and Qt would fire neither.
     const std::array<ToolbarActionSpec, 4> primaryToolbarActions = { {
-        { ":/icons/actions/new.svg", "New", "Create a new map", {}, [this]() { newMapRequested(); } },
-        { ":/icons/actions/open.svg", "Browse Maps", "Browse available maps as thumbnails", {}, [this]() { showMapBrowserDialog(); } },
-        { ":/icons/actions/save.svg", "Save", "Save the current map", {}, [this]() { saveMapRequested(); } },
-        { ":/icons/actions/play.svg", "Play", "Save and play the current map in Fallout 2", QKeySequence("F5"), [this]() { onPlayGame(); } },
+        { ":/icons/actions/new.svg", "New", "Create a new map", nullptr, [this]() { newMapRequested(); } },
+        { ":/icons/actions/open.svg", "Browse Maps", "Browse available maps as thumbnails", nullptr, [this]() { showMapBrowserDialog(); } },
+        { ":/icons/actions/save.svg", "Save", "Save the current map", nullptr, [this]() { saveMapRequested(); } },
+        { ":/icons/actions/play.svg", "Play", "Save and play the current map in Fallout 2", actions::PLAY_MAP, [this]() { onPlayGame(); } },
     } };
 
     for (const ToolbarActionSpec& spec : primaryToolbarActions) {
         QAction* action = _mainToolBar->addAction(createIcon(spec.iconPath), spec.text);
         action->setStatusTip(spec.statusTip);
-        if (!spec.shortcut.isEmpty()) {
-            action->setShortcut(spec.shortcut);
+        if (spec.actionId != nullptr) {
+            _keyBindings->bind(QString::fromLatin1(spec.actionId), action);
         }
         connect(action, &QAction::triggered, this, [trigger = spec.trigger]() { trigger(); });
     }
@@ -1405,7 +1447,7 @@ void MainWindow::setupDockWidgets() {
         _logPanelAction = _viewMenu->addAction(tr("&Log"));
         _logPanelAction->setCheckable(true);
         _logPanelAction->setChecked(!_logDock->isHidden());
-        _logPanelAction->setShortcut(QKeySequence(Qt::ALT | Qt::Key_QuoteLeft));
+        _keyBindings->bind(actions::PANEL_LOG, _logPanelAction);
         connect(_logPanelAction, &QAction::triggered, this, [this]() { revealPanel(_logDock, _logPanelAction); });
         // The Log dock sits outside the managed-layout persistence, so this only mirrors state.
         connect(_logDock, &QDockWidget::visibilityChanged, this, [this](bool visible) {
@@ -1781,8 +1823,9 @@ void MainWindow::raiseTilePalette() {
 }
 
 void MainWindow::keyPressEvent(QKeyEvent* event) {
-    // Viewport shortcuts (the "P" eyedropper, ...) are handled by InputHandler on the forwarded SFML
-    // key stream: a focused child consumes key events before this override. This only forwards.
+    // The viewport's own tool-state keys (Esc, Space, the stamp "R") are handled by InputHandler on
+    // the forwarded SFML key stream: a focused child consumes key events before this override.
+    // This only forwards.
     if (_currentEditorWidget) {
         SFMLWidget* sfmlWidget = _currentEditorWidget->getSFMLWidget();
         if (sfmlWidget) {
@@ -2482,23 +2525,20 @@ void MainWindow::setupPanelsMenu() {
         const char* label;
         QDockWidget* dock;
         QAction** actionRef;
-        int shortcutKey; // Alt+<digit>; the family is deliberate, see docs/keybindings-plan.md
+        const char* actionId; // the Alt+<digit> family; see docs/keybindings-plan.md
     };
 
-    // Alt+digit rather than Ctrl+digit: it keeps Ctrl+1..3 free for the elevations, and Alt+digit
-    // is not text, so a panel's filter box never swallows it.
     const std::array<PanelToggleSpec, 6> panelToggleSpecs = { {
-        { "Map &Information", _mapInfoDock, &_mapInfoPanelAction, Qt::Key_1 },
-        { "Scri&pts", _scriptsDock, &_scriptsPanelAction, Qt::Key_3 },
-        { "&Selection", _selectionDock, &_selectionPanelAction, Qt::Key_2 },
-        { "&Tile Palette", _tilePaletteDock, &_tilePalettePanelAction, Qt::Key_4 },
-        { "&Object Palette", _objectPaletteDock, &_objectPalettePanelAction, Qt::Key_5 },
-        { "&Virtual File System Browser", _fileBrowserDock, &_fileBrowserPanelAction, Qt::Key_6 },
+        { "Map &Information", _mapInfoDock, &_mapInfoPanelAction, actions::PANEL_MAP_INFO },
+        { "Scri&pts", _scriptsDock, &_scriptsPanelAction, actions::PANEL_SCRIPTS },
+        { "&Selection", _selectionDock, &_selectionPanelAction, actions::PANEL_SELECTION },
+        { "&Tile Palette", _tilePaletteDock, &_tilePalettePanelAction, actions::PANEL_TILE_PALETTE },
+        { "&Object Palette", _objectPaletteDock, &_objectPalettePanelAction, actions::PANEL_OBJECT_PALETTE },
+        { "&Virtual File System Browser", _fileBrowserDock, &_fileBrowserPanelAction, actions::PANEL_FILE_BROWSER },
     } };
 
     for (const PanelToggleSpec& spec : panelToggleSpecs) {
-        addPanelToggleAction(spec.label, spec.dock, *spec.actionRef,
-            QKeySequence(Qt::ALT | static_cast<Qt::Key>(spec.shortcutKey)));
+        addPanelToggleAction(spec.label, spec.dock, *spec.actionRef, spec.actionId);
     }
 }
 
@@ -2729,8 +2769,15 @@ bool MainWindow::hasActiveMap() const {
     return _currentEditorWidget != nullptr;
 }
 
-void MainWindow::showPreferences() {
-    SettingsDialog dialog(_settings, this);
+void MainWindow::showKeyboardShortcuts() {
+    showPreferences(QStringLiteral("Keyboard Shortcuts"));
+}
+
+void MainWindow::showPreferences(const QString& initialTab) {
+    SettingsDialog dialog(_settings, _keyBindings.get(), this);
+    if (!initialTab.isEmpty()) {
+        dialog.selectTab(initialTab);
+    }
 
     connect(&dialog, &SettingsDialog::settingsSaved, this, [this](bool dataPathsChanged) {
         if (dataPathsChanged) {

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -9,6 +9,8 @@
 #include <QIcon>
 #include <QTimer>
 #include <QKeyEvent>
+#include <QKeySequence>
+#include <QShortcut>
 #include <QPointer>
 #include <QStackedWidget>
 #include <QStatusBar>
@@ -231,7 +233,15 @@ private:
     void showPanelsForMap();
     void hidePanelsForNoMap();
     void setDockVisibility(QDockWidget* dock, QAction* action, bool visible);
-    QAction* addPanelToggleAction(const QString& label, QDockWidget* dock, QAction*& actionRef);
+    QAction* addPanelToggleAction(const QString& label, QDockWidget* dock, QAction*& actionRef,
+        const QKeySequence& shortcut = {});
+    // Show/raise/hide a panel dock for its menu item or keyboard shortcut. Docks are tabbed, so a
+    // dock Qt calls visible may be sitting behind another tab: raise it rather than hide it, and
+    // only hide when it is already the tab on top. `action` (optional) is re-checked to match.
+    void revealPanel(QDockWidget* dock, QAction* action);
+    // (Re)install the shortcuts scoped to the map canvas. Called whenever an EditorWidget is
+    // installed, since the SFML widget they hang off is rebuilt with it.
+    void installCanvasShortcuts();
     std::array<QDockWidget*, 6> managedDocks() const;
     std::array<DockActionPair, 6> managedDockActionPairs() const;
     void applyDefaultDockPlacements();
@@ -375,6 +385,13 @@ private:
     QAction* _tilePalettePanelAction;
     QAction* _objectPalettePanelAction;
     QAction* _fileBrowserPanelAction;
+    QAction* _logPanelAction = nullptr;
+
+    // "Inspect the selection": reveals the Selection panel from the canvas. Lives on the SFML
+    // widget (WidgetWithChildrenShortcut), so Return typed in a panel's filter box is untouched.
+    // Return and numpad Enter are separate key codes, hence the pair.
+    QPointer<QShortcut> _inspectSelectionShortcut;
+    QPointer<QShortcut> _inspectSelectionEnterShortcut;
 
     // Toolbar actions
     QAction* _selectionModeAction;

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -40,6 +40,7 @@ namespace resource {
 }
 
 class Settings;
+class KeyBindingRegistry;
 class GameLauncher;
 class ExternalEditorLauncher;
 class ScriptSourceService;
@@ -158,7 +159,10 @@ private slots:
     void handleMapLoadRequest(const std::string& mapPath, bool forceFilesystem = false);
     void updateHexIndexDisplay(int hexIndex);
     void updateModeDisplay(const QString& modeText, const QString& iconPath);
-    void showPreferences();
+    /// `initialTab` names the tab to open on (empty = whichever was last shown).
+    void showPreferences(const QString& initialTab = {});
+    /// Help > Keyboard Shortcuts: the Preferences page listing every binding.
+    void showKeyboardShortcuts();
     void showAbout();
     void onPlayGame();
     void showSavePatternDialog();
@@ -234,7 +238,7 @@ private:
     void hidePanelsForNoMap();
     void setDockVisibility(QDockWidget* dock, QAction* action, bool visible);
     QAction* addPanelToggleAction(const QString& label, QDockWidget* dock, QAction*& actionRef,
-        const QKeySequence& shortcut = {});
+        const char* actionId = nullptr);
     // Show/raise/hide a panel dock for its menu item or keyboard shortcut. Docks are tabbed, so a
     // dock Qt calls visible may be sitting behind another tab: raise it rather than hide it, and
     // only hide when it is already the tab on top. `action` (optional) is re-checked to match.
@@ -300,6 +304,9 @@ private:
     std::unique_ptr<GameLauncher> _gameLauncher;
     std::unique_ptr<ExternalEditorLauncher> _externalEditorLauncher;
     std::unique_ptr<ScriptSourceService> _scriptSourceService;
+    // The single source of truth for which key runs which command: shipped defaults plus the
+    // user's overrides, re-keying every menu/toolbar/canvas sink the moment one changes.
+    std::unique_ptr<KeyBindingRegistry> _keyBindings;
 
     // Current widgets
     EditorWidget* _currentEditorWidget;

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -242,6 +242,9 @@ private:
     // (Re)install the shortcuts scoped to the map canvas. Called whenever an EditorWidget is
     // installed, since the SFML widget they hang off is rebuilt with it.
     void installCanvasShortcuts();
+    // Ctrl+Shift+E: open the .ssl of the script attached to the selected object (the same
+    // ScriptSourceService flow as the Selection panel's "Edit Source..." button).
+    void editSelectedObjectScriptSource();
     std::array<QDockWidget*, 6> managedDocks() const;
     std::array<DockActionPair, 6> managedDockActionPairs() const;
     void applyDefaultDockPlacements();
@@ -386,12 +389,18 @@ private:
     QAction* _objectPalettePanelAction;
     QAction* _fileBrowserPanelAction;
     QAction* _logPanelAction = nullptr;
+    // Edit-menu "Scroll Blocker Rectangle"; its key lives on the canvas, so the action is held to
+    // be triggered from there.
+    QAction* _scrollBlockerRectAction = nullptr;
 
     // "Inspect the selection": reveals the Selection panel from the canvas. Lives on the SFML
     // widget (WidgetWithChildrenShortcut), so Return typed in a panel's filter box is untouched.
     // Return and numpad Enter are separate key codes, hence the pair.
     QPointer<QShortcut> _inspectSelectionShortcut;
     QPointer<QShortcut> _inspectSelectionEnterShortcut;
+    // Canvas "R". Held so it can stand down while stamping or while a registered tool runs, where
+    // R belongs to the viewport (stamp variants) instead.
+    QPointer<QShortcut> _rotateShortcut;
 
     // Toolbar actions
     QAction* _selectionModeAction;

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -246,6 +246,9 @@ private:
     // (Re)install the shortcuts scoped to the map canvas. Called whenever an EditorWidget is
     // installed, since the SFML widget they hang off is rebuilt with it.
     void installCanvasShortcuts();
+    // Numpad Enter mirrors the inspect-selection key, but only while that key is Return — see
+    // installCanvasShortcuts(). Re-run whenever that binding changes.
+    void syncInspectSelectionCompanionKey();
     // Ctrl+Shift+E: open the .ssl of the script attached to the selected object (the same
     // ScriptSourceService flow as the Selection panel's "Edit Source..." button).
     void editSelectedObjectScriptSource();

--- a/src/ui/dialogs/SettingsDialog.cpp
+++ b/src/ui/dialogs/SettingsDialog.cpp
@@ -1,5 +1,6 @@
 #include "SettingsDialog.h"
 #include "ui/widgets/DataPathsWidget.h"
+#include "ui/widgets/KeybindingsWidget.h"
 #include "ui/widgets/GameLocationWidget.h"
 #include "ui/widgets/TextEditorWidget.h"
 #include "ui/theme/ThemeManager.h"
@@ -21,7 +22,7 @@ namespace geck {
 using namespace ui::constants;
 using namespace ui::defaults;
 
-SettingsDialog::SettingsDialog(std::shared_ptr<Settings> settings, QWidget* parent)
+SettingsDialog::SettingsDialog(std::shared_ptr<Settings> settings, KeyBindingRegistry* registry, QWidget* parent)
     : QDialog(parent)
     , _mainLayout(nullptr)
     , _tabWidget(nullptr)
@@ -37,6 +38,7 @@ SettingsDialog::SettingsDialog(std::shared_ptr<Settings> settings, QWidget* pare
     , _buttonBox(nullptr)
     , _applyButton(nullptr)
     , _resetButton(nullptr)
+    , _keyBindingRegistry(registry)
     , _settings(std::move(settings))
     , _hasChanges(false) {
 
@@ -93,6 +95,7 @@ void SettingsDialog::setupTabs() {
     setupViewportTab();
     setupEditorTab();
     setupColorsTab();
+    setupKeybindingsTab();
 
     _mainLayout->addWidget(_tabWidget);
 }
@@ -221,6 +224,36 @@ void SettingsDialog::setupEditorTab() {
     connect(_textEditorWidget, &TextEditorWidget::configurationChanged, this, &SettingsDialog::onWidgetChanged);
 }
 
+void SettingsDialog::selectTab(const QString& title) {
+    for (int index = 0; index < _tabWidget->count(); ++index) {
+        if (_tabWidget->tabText(index) == title) {
+            _tabWidget->setCurrentIndex(index);
+            return;
+        }
+    }
+}
+
+void SettingsDialog::setupKeybindingsTab() {
+    if (_keyBindingRegistry == nullptr) {
+        return; // no registry (a bare-constructed dialog) -> no tab, rather than an empty one
+    }
+
+    _keybindingsWidget = new KeybindingsWidget(_keyBindingRegistry);
+    _keybindingsWidget->setFlat(true);
+    _keybindingsWidget->setStyleSheet(ui::theme::styles::sectionGroupBox());
+
+    auto* tab = new QWidget();
+    auto* layout = new QVBoxLayout(tab);
+    layout->setContentsMargins(SPACING_LOOSE, SPACING_LOOSE, SPACING_LOOSE, SPACING_LOOSE);
+    layout->setSpacing(SPACING_LOOSE);
+    layout->addWidget(_keybindingsWidget, /*stretch=*/1);
+
+    _tabWidget->addTab(tab, "Keyboard Shortcuts");
+
+    connect(_keybindingsWidget, &KeybindingsWidget::changed, this, &SettingsDialog::onWidgetChanged);
+    connect(_keybindingsWidget, &KeybindingsWidget::statusChanged, this, &SettingsDialog::setMainStatus);
+}
+
 void SettingsDialog::setupButtonBox() {
     _buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
 
@@ -267,6 +300,10 @@ void SettingsDialog::loadSettings() {
         updateColorButton(it.key());
     }
 
+    if (_keybindingsWidget) {
+        _keybindingsWidget->reload();
+    }
+
     _hasChanges = false;
     updateUI();
 }
@@ -299,6 +336,12 @@ void SettingsDialog::saveSettings() {
 
     for (auto it = _selectionColors.constBegin(); it != _selectionColors.constEnd(); ++it) {
         settings.setSelectionColor(it.key(), it.value());
+    }
+
+    // Rebinds take effect here (the registry re-keys every menu, toolbar and canvas sink) and are
+    // written through to Settings, which the save() below puts on disk.
+    if (_keybindingsWidget) {
+        _keybindingsWidget->applyChanges();
     }
 
     settings.save();

--- a/src/ui/dialogs/SettingsDialog.cpp
+++ b/src/ui/dialogs/SettingsDialog.cpp
@@ -33,12 +33,12 @@ SettingsDialog::SettingsDialog(std::shared_ptr<Settings> settings, KeyBindingReg
     , _editorTab(nullptr)
     , _editorTabLayout(nullptr)
     , _textEditorWidget(nullptr)
+    , _keyBindingRegistry(registry)
     , _statusLabel(nullptr)
     , _progressBar(nullptr)
     , _buttonBox(nullptr)
     , _applyButton(nullptr)
     , _resetButton(nullptr)
-    , _keyBindingRegistry(registry)
     , _settings(std::move(settings))
     , _hasChanges(false) {
 

--- a/src/ui/dialogs/SettingsDialog.h
+++ b/src/ui/dialogs/SettingsDialog.h
@@ -20,6 +20,8 @@ QT_END_NAMESPACE
 
 namespace geck {
 class DataPathsWidget;
+class KeyBindingRegistry;
+class KeybindingsWidget;
 class GameLocationWidget;
 class TextEditorWidget;
 class Settings;
@@ -39,8 +41,15 @@ class SettingsDialog : public QDialog {
     Q_OBJECT
 
 public:
-    explicit SettingsDialog(std::shared_ptr<Settings> settings, QWidget* parent = nullptr);
+    /// `registry` may be null (a bare-constructed dialog in a test): the Keyboard Shortcuts tab
+    /// is then simply omitted rather than half-built.
+    explicit SettingsDialog(std::shared_ptr<Settings> settings, KeyBindingRegistry* registry = nullptr,
+        QWidget* parent = nullptr);
     ~SettingsDialog() = default;
+
+    /// Open on the tab with this title (no-op when there is none, e.g. Keyboard Shortcuts in a
+    /// dialog built without a registry).
+    void selectTab(const QString& title);
 
 signals:
     void settingsSaved(bool dataPathsChanged);
@@ -61,6 +70,7 @@ private:
     void setupViewportTab();
     void setupEditorTab();
     void setupColorsTab();
+    void setupKeybindingsTab();
     void updateColorButton(const QString& key) const;
     void setupButtonBox();
 
@@ -87,6 +97,10 @@ private:
     QWidget* _editorTab;
     QVBoxLayout* _editorTabLayout;
     TextEditorWidget* _textEditorWidget;
+
+    // Keyboard shortcuts tab
+    KeyBindingRegistry* _keyBindingRegistry = nullptr;
+    KeybindingsWidget* _keybindingsWidget = nullptr;
 
     // Selection colours tab
     QWidget* _colorsTab = nullptr;

--- a/src/ui/input/ActionSpec.cpp
+++ b/src/ui/input/ActionSpec.cpp
@@ -32,9 +32,9 @@ namespace {
         // View
         { actions::SHOW_EXIT_GRIDS, "Show Exit Grids", "View", "Ctrl+E", QKeySequence::UnknownKey, ActionScope::Application },
         { actions::WORLD_MAP, "World Map", "View", "Ctrl+Shift+M", QKeySequence::UnknownKey, ActionScope::Application },
-        { actions::ELEVATION_1, "Elevation 1", "View", "Ctrl+1", QKeySequence::UnknownKey, ActionScope::Application },
-        { actions::ELEVATION_2, "Elevation 2", "View", "Ctrl+2", QKeySequence::UnknownKey, ActionScope::Application },
-        { actions::ELEVATION_3, "Elevation 3", "View", "Ctrl+3", QKeySequence::UnknownKey, ActionScope::Application },
+        { actions::SET_ELEVATION_1, "Elevation 1", "View", "Ctrl+1", QKeySequence::UnknownKey, ActionScope::Application },
+        { actions::SET_ELEVATION_2, "Elevation 2", "View", "Ctrl+2", QKeySequence::UnknownKey, ActionScope::Application },
+        { actions::SET_ELEVATION_3, "Elevation 3", "View", "Ctrl+3", QKeySequence::UnknownKey, ActionScope::Application },
         { actions::HEX_GRID, "Toggle Hex Grid", "View", "G", QKeySequence::UnknownKey, ActionScope::Canvas },
 
         // Panels

--- a/src/ui/input/ActionSpec.cpp
+++ b/src/ui/input/ActionSpec.cpp
@@ -1,0 +1,67 @@
+#include "ActionSpec.h"
+
+#include <array>
+
+namespace geck {
+
+namespace {
+
+    // The shipped defaults. Kept in one place so the menus, the toolbar, the canvas shortcuts and
+    // the Preferences page all read the same table — see docs/keybindings-plan.md for the rationale
+    // behind the families (Alt+digit for panels, Ctrl+digit for elevations, bare letters on the
+    // canvas only).
+    constexpr std::array<ActionSpec, 34> SPECS = { {
+        // File
+        { actions::NEW_MAP, "New Map", "File", "", QKeySequence::New, ActionScope::Application },
+        { actions::OPEN_MAP, "Open Map", "File", "", QKeySequence::Open, ActionScope::Application },
+        { actions::BROWSE_MAPS, "Browse Maps", "File", "Ctrl+B", QKeySequence::UnknownKey, ActionScope::Application },
+        { actions::SAVE_MAP, "Save Map", "File", "", QKeySequence::Save, ActionScope::Application },
+        { actions::SAVE_MAP_AS, "Save Map As", "File", "", QKeySequence::SaveAs, ActionScope::Application },
+        { actions::CLOSE_MAP, "Close Map", "File", "", QKeySequence::Close, ActionScope::Application },
+        { actions::PREFERENCES, "Preferences", "File", "", QKeySequence::Preferences, ActionScope::Application },
+        { actions::QUIT, "Quit", "File", "", QKeySequence::Quit, ActionScope::Application },
+        { actions::PLAY_MAP, "Save and Play in Fallout 2", "File", "F5", QKeySequence::UnknownKey, ActionScope::Application },
+
+        // Edit
+        { actions::SELECT_ALL, "Select All", "Edit", "Ctrl+A", QKeySequence::UnknownKey, ActionScope::Application },
+        { actions::DESELECT_ALL, "Deselect All", "Edit", "Ctrl+D", QKeySequence::UnknownKey, ActionScope::Application },
+        { actions::UNDO, "Undo", "Edit", "", QKeySequence::Undo, ActionScope::Application },
+        { actions::REDO, "Redo", "Edit", "", QKeySequence::Redo, ActionScope::Application },
+        { actions::EDIT_SCRIPT_SOURCE, "Edit Script Source", "Edit", "Ctrl+Shift+E", QKeySequence::UnknownKey, ActionScope::Application },
+
+        // View
+        { actions::SHOW_EXIT_GRIDS, "Show Exit Grids", "View", "Ctrl+E", QKeySequence::UnknownKey, ActionScope::Application },
+        { actions::WORLD_MAP, "World Map", "View", "Ctrl+Shift+M", QKeySequence::UnknownKey, ActionScope::Application },
+        { actions::ELEVATION_1, "Elevation 1", "View", "Ctrl+1", QKeySequence::UnknownKey, ActionScope::Application },
+        { actions::ELEVATION_2, "Elevation 2", "View", "Ctrl+2", QKeySequence::UnknownKey, ActionScope::Application },
+        { actions::ELEVATION_3, "Elevation 3", "View", "Ctrl+3", QKeySequence::UnknownKey, ActionScope::Application },
+        { actions::HEX_GRID, "Toggle Hex Grid", "View", "G", QKeySequence::UnknownKey, ActionScope::Canvas },
+
+        // Panels
+        { actions::PANEL_MAP_INFO, "Map Information Panel", "Panels", "Alt+1", QKeySequence::UnknownKey, ActionScope::Application },
+        { actions::PANEL_SELECTION, "Selection Panel", "Panels", "Alt+2", QKeySequence::UnknownKey, ActionScope::Application },
+        { actions::PANEL_SCRIPTS, "Scripts Panel", "Panels", "Alt+3", QKeySequence::UnknownKey, ActionScope::Application },
+        { actions::PANEL_TILE_PALETTE, "Tile Palette Panel", "Panels", "Alt+4", QKeySequence::UnknownKey, ActionScope::Application },
+        { actions::PANEL_OBJECT_PALETTE, "Object Palette Panel", "Panels", "Alt+5", QKeySequence::UnknownKey, ActionScope::Application },
+        { actions::PANEL_FILE_BROWSER, "File Browser Panel", "Panels", "Alt+6", QKeySequence::UnknownKey, ActionScope::Application },
+        { actions::PANEL_LOG, "Log Panel", "Panels", "Alt+`", QKeySequence::UnknownKey, ActionScope::Application },
+        { actions::PANEL_SELECTION_REVEAL, "Inspect Selection", "Panels", "Return", QKeySequence::UnknownKey, ActionScope::Canvas },
+
+        // Navigation
+        { actions::CENTER_ON_PLAYER, "Center on Player Start", "Navigation", "Home", QKeySequence::UnknownKey, ActionScope::Canvas },
+        { actions::FIT_MAP, "Fit Map in View", "Navigation", "F", QKeySequence::UnknownKey, ActionScope::Canvas },
+
+        // Tools
+        { actions::TOOL_SELECT, "Select Mode", "Tools", "S", QKeySequence::UnknownKey, ActionScope::Canvas },
+        { actions::TOOL_ROTATE, "Rotate Selected Object", "Tools", "R", QKeySequence::UnknownKey, ActionScope::Canvas },
+        { actions::TOOL_SCROLL_BLOCKER_RECT, "Scroll Blocker Rectangle", "Tools", "B", QKeySequence::UnknownKey, ActionScope::Canvas },
+        { actions::TOOL_PICK, "Eyedropper", "Tools", "P", QKeySequence::UnknownKey, ActionScope::Canvas },
+    } };
+
+} // namespace
+
+std::span<const ActionSpec> actionSpecs() {
+    return SPECS;
+}
+
+} // namespace geck

--- a/src/ui/input/ActionSpec.h
+++ b/src/ui/input/ActionSpec.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <QKeySequence>
+#include <span>
+
+namespace geck {
+
+/// Where a binding is listened for.
+///
+/// Application shortcuts are window-scoped QAction shortcuts: they fire wherever focus is.
+/// Canvas shortcuts hang off the map view (Qt::WidgetWithChildrenShortcut) and fire only while it
+/// has focus, which is what keeps a single letter from being stolen out of a palette grid or a
+/// tree. The two are not independent namespaces — an Application binding fires while the canvas
+/// has focus too — so conflicts are checked across both.
+enum class ActionScope {
+    Application,
+    Canvas
+};
+
+/// One row of the shipped keyboard-shortcut table.
+struct ActionSpec {
+    /// Stable identifier. Persisted in settings.json, so it is never renamed once shipped.
+    const char* id;
+    /// What the Preferences page shows, e.g. "Selection Panel".
+    const char* label;
+    /// Preferences grouping: "File" | "Edit" | "View" | "Panels" | "Navigation" | "Tools".
+    const char* category;
+    /// QKeySequence portable text ("Ctrl+S", "Alt+1"); empty means "use standardKey".
+    const char* defaultKeys;
+    /// Set instead of defaultKeys where Qt's platform-correct binding is the default: several of
+    /// these differ per platform (Preferences is Ctrl+, only on macOS, Quit is unbound on Windows),
+    /// so resolving at runtime keeps each platform's convention instead of freezing one of them
+    /// into the table. UnknownKey with empty defaultKeys means unbound by default.
+    QKeySequence::StandardKey standardKey = QKeySequence::UnknownKey;
+    ActionScope scope = ActionScope::Application;
+};
+
+/// The shipped table, in the order the Preferences page lists it.
+///
+/// Ids are strings rather than an enum because they are what lands in settings.json: a reordered
+/// enum would silently repoint every user's overrides at the wrong action.
+std::span<const ActionSpec> actionSpecs();
+
+/// Action ids. Compile-time names for the rows above, so a typo is a build error rather than a
+/// binding that silently never fires.
+namespace actions {
+    inline constexpr const char* NEW_MAP = "file.newMap";
+    inline constexpr const char* OPEN_MAP = "file.openMap";
+    inline constexpr const char* BROWSE_MAPS = "file.browseMaps";
+    inline constexpr const char* SAVE_MAP = "file.saveMap";
+    inline constexpr const char* SAVE_MAP_AS = "file.saveMapAs";
+    inline constexpr const char* CLOSE_MAP = "file.closeMap";
+    inline constexpr const char* PREFERENCES = "file.preferences";
+    inline constexpr const char* QUIT = "file.quit";
+    inline constexpr const char* PLAY_MAP = "file.playMap";
+
+    inline constexpr const char* SELECT_ALL = "edit.selectAll";
+    inline constexpr const char* DESELECT_ALL = "edit.deselectAll";
+    inline constexpr const char* UNDO = "edit.undo";
+    inline constexpr const char* REDO = "edit.redo";
+    inline constexpr const char* EDIT_SCRIPT_SOURCE = "edit.scriptSource";
+
+    inline constexpr const char* SHOW_EXIT_GRIDS = "view.exitGrids";
+    inline constexpr const char* WORLD_MAP = "view.worldMap";
+    inline constexpr const char* HEX_GRID = "view.hexGrid";
+    inline constexpr const char* ELEVATION_1 = "view.elevation1";
+    inline constexpr const char* ELEVATION_2 = "view.elevation2";
+    inline constexpr const char* ELEVATION_3 = "view.elevation3";
+
+    inline constexpr const char* PANEL_MAP_INFO = "panel.mapInfo";
+    inline constexpr const char* PANEL_SELECTION = "panel.selection";
+    inline constexpr const char* PANEL_SCRIPTS = "panel.scripts";
+    inline constexpr const char* PANEL_TILE_PALETTE = "panel.tilePalette";
+    inline constexpr const char* PANEL_OBJECT_PALETTE = "panel.objectPalette";
+    inline constexpr const char* PANEL_FILE_BROWSER = "panel.fileBrowser";
+    inline constexpr const char* PANEL_LOG = "panel.log";
+    inline constexpr const char* PANEL_SELECTION_REVEAL = "panel.selection.reveal";
+
+    inline constexpr const char* CENTER_ON_PLAYER = "view.centerOnPlayer";
+    inline constexpr const char* FIT_MAP = "view.fitMap";
+
+    inline constexpr const char* TOOL_SELECT = "tool.select";
+    inline constexpr const char* TOOL_ROTATE = "tool.rotate";
+    inline constexpr const char* TOOL_SCROLL_BLOCKER_RECT = "tool.scrollBlockerRect";
+    inline constexpr const char* TOOL_PICK = "tool.pick";
+} // namespace actions
+
+} // namespace geck

--- a/src/ui/input/ActionSpec.h
+++ b/src/ui/input/ActionSpec.h
@@ -20,13 +20,13 @@ enum class ActionScope {
 /// One row of the shipped keyboard-shortcut table.
 struct ActionSpec {
     /// Stable identifier. Persisted in settings.json, so it is never renamed once shipped.
-    const char* id;
+    const char* id = nullptr;
     /// What the Preferences page shows, e.g. "Selection Panel".
-    const char* label;
+    const char* label = nullptr;
     /// Preferences grouping: "File" | "Edit" | "View" | "Panels" | "Navigation" | "Tools".
-    const char* category;
+    const char* category = nullptr;
     /// QKeySequence portable text ("Ctrl+S", "Alt+1"); empty means "use standardKey".
-    const char* defaultKeys;
+    const char* defaultKeys = nullptr;
     /// Set instead of defaultKeys where Qt's platform-correct binding is the default: several of
     /// these differ per platform (Preferences is Ctrl+, only on macOS, Quit is unbound on Windows),
     /// so resolving at runtime keeps each platform's convention instead of freezing one of them

--- a/src/ui/input/ActionSpec.h
+++ b/src/ui/input/ActionSpec.h
@@ -63,9 +63,9 @@ namespace actions {
     inline constexpr const char* SHOW_EXIT_GRIDS = "view.exitGrids";
     inline constexpr const char* WORLD_MAP = "view.worldMap";
     inline constexpr const char* HEX_GRID = "view.hexGrid";
-    inline constexpr const char* ELEVATION_1 = "view.elevation1";
-    inline constexpr const char* ELEVATION_2 = "view.elevation2";
-    inline constexpr const char* ELEVATION_3 = "view.elevation3";
+    inline constexpr const char* SET_ELEVATION_1 = "view.elevation1";
+    inline constexpr const char* SET_ELEVATION_2 = "view.elevation2";
+    inline constexpr const char* SET_ELEVATION_3 = "view.elevation3";
 
     inline constexpr const char* PANEL_MAP_INFO = "panel.mapInfo";
     inline constexpr const char* PANEL_SELECTION = "panel.selection";

--- a/src/ui/input/InputHandler.cpp
+++ b/src/ui/input/InputHandler.cpp
@@ -337,9 +337,9 @@ void InputHandler::handleKeyPressed(const sf::Event::KeyPressed& event) {
             _callbacks.onDeleteObjects();
         }
     } else if (event.code == sf::Keyboard::Key::R) {
-        // The Rotate toolbar shortcut is disabled by the editor while stamping (and while a
-        // registered tool runs), so R reaches us here: in stamp mode it cycles the pattern's
-        // orientation variants. A registered tool sees R first via onToolKeyPressed above.
+        // The canvas "R" shortcut stands down while stamping (and while a registered tool runs),
+        // so R reaches us here: in stamp mode it cycles the pattern's orientation variants.
+        // A registered tool sees R first via onToolKeyPressed above.
         if (_mode == EditorMode::StampPattern && _callbacks.onStampCycleVariant) {
             _callbacks.onStampCycleVariant();
         }

--- a/src/ui/input/InputHandler.cpp
+++ b/src/ui/input/InputHandler.cpp
@@ -343,12 +343,6 @@ void InputHandler::handleKeyPressed(const sf::Event::KeyPressed& event) {
         if (_mode == EditorMode::StampPattern && _callbacks.onStampCycleVariant) {
             _callbacks.onStampCycleVariant();
         }
-    } else if (event.code == sf::Keyboard::Key::P) {
-        // Eyedropper: sample whatever is under the cursor. Key events carry no view/target to convert
-        // pixels, so reuse the last cursor position tracked on mouse move (like the flip key).
-        if (_callbacks.onPick) {
-            _callbacks.onPick(_mouseLastWorldPos);
-        }
     } else if (event.code == sf::Keyboard::Key::Space) {
         // In "Draw edge" mode, Space flips which side the edge's bars sit on, then re-fires the preview
         // at the last cursor so the flipped side is visible before finalising.

--- a/src/ui/input/InputHandler.h
+++ b/src/ui/input/InputHandler.h
@@ -68,9 +68,6 @@ public:
         std::function<void()> onStampPatternCancel;
         std::function<void()> onStampCycleVariant;
 
-        // Eyedropper (P): sample whatever is under the cursor and load it into the matching palette.
-        std::function<void(sf::Vector2f worldPos)> onPick;
-
         // Dynamic registered tool dispatch. The host owns the active tool registry; InputHandler only
         // does pixel->world conversion and forwards the event while EditorMode::PluginTool is active.
         std::function<bool(sf::Vector2f worldPos, sf::Mouse::Button button)> onToolMousePressed;
@@ -135,6 +132,9 @@ public:
     // The "Draw edge" flip toggle: false = auto/outward side, true = opposite. Toggled by the flip key;
     // exposed for tests.
     bool isMarkExitsFlipped() const { return _markExitsFlip; }
+    // Last cursor position in world coordinates. Key events carry no view to convert pixels with,
+    // so a key-driven command that acts "under the cursor" (the eyedropper) reads it from here.
+    sf::Vector2f lastCursorWorldPos() const { return _mouseLastWorldPos; }
 
     /**
      * @brief Mode setters
@@ -197,7 +197,7 @@ private:
     sf::Vector2i _mouseStartPos{ 0, 0 };
     sf::Vector2i _mouseLastPos{ 0, 0 };
     // Last cursor position in WORLD coordinates. Key events carry no view/target to convert pixels, so
-    // the flip key reuses this to re-fire the live edge preview at the current cursor.
+    // the flip key and the eyedropper reuse this to act at the current cursor.
     sf::Vector2f _mouseLastWorldPos;
     sf::Vector2f _dragStartWorldPos;
     bool _isDragging = false;

--- a/src/ui/input/KeyBindingRegistry.cpp
+++ b/src/ui/input/KeyBindingRegistry.cpp
@@ -2,6 +2,9 @@
 
 #include <spdlog/spdlog.h>
 
+#include <cstddef>
+#include <span>
+
 #include "ui/Settings.h"
 
 namespace geck {
@@ -26,9 +29,13 @@ KeyBindingRegistry::KeyBindingRegistry(std::shared_ptr<Settings> settings, QObje
 }
 
 const ActionSpec* KeyBindingRegistry::spec(const QString& id) {
-    for (const ActionSpec& candidate : actionSpecs()) {
-        if (id == QLatin1StringView(candidate.id)) {
-            return &candidate;
+    // Indexed off the span's data pointer rather than by taking the address of a range-for
+    // reference: the table it views has static storage, but the span itself is a temporary, and
+    // returning &element out of a loop over one reads as a dangling return to cppcheck.
+    const std::span<const ActionSpec> specs = actionSpecs();
+    for (std::size_t index = 0; index < specs.size(); ++index) {
+        if (id == QLatin1StringView(specs[index].id)) {
+            return specs.data() + index;
         }
     }
     return nullptr;

--- a/src/ui/input/KeyBindingRegistry.cpp
+++ b/src/ui/input/KeyBindingRegistry.cpp
@@ -129,7 +129,11 @@ void KeyBindingRegistry::bind(const QString& id, QAction* action) {
     if (!action || spec(id) == nullptr) {
         return;
     }
-    _actionSinks[id].append(QPointer<QAction>(action));
+    // Prune here as well as on rebind: canvas shortcuts are re-bound on every map load, so a list
+    // whose dead entries were only cleared by a rebind would grow with nulls across a session.
+    QList<QPointer<QAction>>& sinks = _actionSinks[id];
+    sinks.removeIf([](const QPointer<QAction>& sink) { return sink.isNull(); });
+    sinks.append(QPointer<QAction>(action));
     action->setShortcut(shortcut(id));
 }
 
@@ -137,7 +141,9 @@ void KeyBindingRegistry::bind(const QString& id, QShortcut* shortcutSink) {
     if (!shortcutSink || spec(id) == nullptr) {
         return;
     }
-    _shortcutSinks[id].append(QPointer<QShortcut>(shortcutSink));
+    QList<QPointer<QShortcut>>& sinks = _shortcutSinks[id];
+    sinks.removeIf([](const QPointer<QShortcut>& sink) { return sink.isNull(); });
+    sinks.append(QPointer<QShortcut>(shortcutSink));
     shortcutSink->setKey(shortcut(id));
 }
 

--- a/src/ui/input/KeyBindingRegistry.cpp
+++ b/src/ui/input/KeyBindingRegistry.cpp
@@ -1,0 +1,159 @@
+#include "KeyBindingRegistry.h"
+
+#include <spdlog/spdlog.h>
+
+#include "ui/Settings.h"
+
+namespace geck {
+
+KeyBindingRegistry::KeyBindingRegistry(std::shared_ptr<Settings> settings, QObject* parent)
+    : QObject(parent)
+    , _settings(std::move(settings)) {
+    if (!_settings) {
+        return;
+    }
+
+    // Stored overrides are portable text; an entry for an id the table no longer has is dropped
+    // rather than kept, so a renamed or retired action cannot resurrect a key nothing listens for.
+    const QMap<QString, QString> stored = _settings->getKeyBindings();
+    for (auto it = stored.constBegin(); it != stored.constEnd(); ++it) {
+        if (spec(it.key()) == nullptr) {
+            spdlog::debug("KeyBindingRegistry: dropping override for unknown action '{}'", it.key().toStdString());
+            continue;
+        }
+        _overrides.insert(it.key(), QKeySequence::fromString(it.value(), QKeySequence::PortableText));
+    }
+}
+
+const ActionSpec* KeyBindingRegistry::spec(const QString& id) {
+    for (const ActionSpec& candidate : actionSpecs()) {
+        if (id == QLatin1StringView(candidate.id)) {
+            return &candidate;
+        }
+    }
+    return nullptr;
+}
+
+QKeySequence KeyBindingRegistry::defaultShortcut(const QString& id) const {
+    const ActionSpec* found = spec(id);
+    if (!found) {
+        return {};
+    }
+    if (found->standardKey != QKeySequence::UnknownKey) {
+        return QKeySequence(found->standardKey);
+    }
+    return QKeySequence::fromString(QLatin1StringView(found->defaultKeys), QKeySequence::PortableText);
+}
+
+QKeySequence KeyBindingRegistry::shortcut(const QString& id) const {
+    const auto stored = _overrides.constFind(id);
+    return stored != _overrides.constEnd() ? stored.value() : defaultShortcut(id);
+}
+
+bool KeyBindingRegistry::isCustomized(const QString& id) const {
+    return _overrides.contains(id);
+}
+
+QString KeyBindingRegistry::conflictingActionId(const QString& id, const QKeySequence& seq) const {
+    if (seq.isEmpty()) {
+        return {}; // any number of actions may be unbound
+    }
+
+    for (const ActionSpec& candidate : actionSpecs()) {
+        const QString candidateId = QString::fromLatin1(candidate.id);
+        if (candidateId == id) {
+            continue;
+        }
+        if (shortcut(candidateId) == seq) {
+            return candidateId;
+        }
+    }
+
+    return {};
+}
+
+void KeyBindingRegistry::setShortcut(const QString& id, const QKeySequence& seq) {
+    if (spec(id) == nullptr) {
+        spdlog::warn("KeyBindingRegistry: ignoring rebind of unknown action '{}'", id.toStdString());
+        return;
+    }
+    const bool isDefault = (seq == defaultShortcut(id));
+    if (shortcut(id) == seq && _overrides.contains(id) != isDefault) {
+        return; // already exactly this, and already stored the way it should be
+    }
+
+    if (isDefault) {
+        // Back on the default: forget the override so a later release changing that default is
+        // still free to move this user's key.
+        _overrides.remove(id);
+    } else {
+        _overrides.insert(id, seq);
+    }
+
+    applyToSinks(id, seq);
+    Q_EMIT bindingChanged(id, seq);
+}
+
+void KeyBindingRegistry::resetToDefault(const QString& id) {
+    setShortcut(id, defaultShortcut(id));
+}
+
+void KeyBindingRegistry::resetAllToDefaults() {
+    const QList<QString> customized = _overrides.keys();
+    for (const QString& id : customized) {
+        resetToDefault(id);
+    }
+}
+
+void KeyBindingRegistry::save() {
+    if (!_settings) {
+        return;
+    }
+
+    QMap<QString, QString> stored;
+    for (auto it = _overrides.constBegin(); it != _overrides.constEnd(); ++it) {
+        // An unbound action persists as an empty string, which is distinct from being absent.
+        stored.insert(it.key(), it.value().toString(QKeySequence::PortableText));
+    }
+    _settings->setKeyBindings(stored);
+}
+
+void KeyBindingRegistry::bind(const QString& id, QAction* action) {
+    if (!action || spec(id) == nullptr) {
+        return;
+    }
+    _actionSinks[id].append(QPointer<QAction>(action));
+    action->setShortcut(shortcut(id));
+}
+
+void KeyBindingRegistry::bind(const QString& id, QShortcut* shortcutSink) {
+    if (!shortcutSink || spec(id) == nullptr) {
+        return;
+    }
+    _shortcutSinks[id].append(QPointer<QShortcut>(shortcutSink));
+    shortcutSink->setKey(shortcut(id));
+}
+
+void KeyBindingRegistry::applyToSinks(const QString& id, const QKeySequence& seq) {
+    // Sinks are held as QPointers because a canvas shortcut dies with the map view it hangs off;
+    // clear the dead ones as we go rather than growing the list across map loads.
+    QList<QPointer<QAction>>& actions = _actionSinks[id];
+    actions.removeIf([&seq](const QPointer<QAction>& action) {
+        if (!action) {
+            return true;
+        }
+        action->setShortcut(seq);
+        return false;
+    });
+
+    QList<QPointer<QShortcut>>& shortcuts = _shortcutSinks[id];
+    shortcuts.removeIf([&seq](const QPointer<QShortcut>& sink) {
+        if (!sink) {
+            return true;
+        }
+        sink->setKey(seq);
+        return false;
+    });
+}
+
+} // namespace geck

--- a/src/ui/input/KeyBindingRegistry.h
+++ b/src/ui/input/KeyBindingRegistry.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <QAction>
+#include <QHash>
+#include <QKeySequence>
+#include <QList>
+#include <QMap>
+#include <QObject>
+#include <QPointer>
+#include <QShortcut>
+#include <QString>
+
+#include <memory>
+
+#include "ActionSpec.h"
+
+namespace geck {
+
+class Settings;
+
+/**
+ * @brief The one place that decides which keys run which commands.
+ *
+ * Holds the shipped defaults (ActionSpec) plus the user's overrides, answers "what key is this
+ * action on" for the menus, the toolbar and the canvas, and re-keys every registered sink the
+ * moment a binding changes — so a rebind takes effect without a restart and without walking the
+ * menu bar.
+ *
+ * Owned by MainWindow and injected into SettingsDialog.
+ */
+class KeyBindingRegistry : public QObject {
+    Q_OBJECT
+
+public:
+    explicit KeyBindingRegistry(std::shared_ptr<Settings> settings, QObject* parent = nullptr);
+
+    /// The action's current key: the user's override where there is one, else the shipped default.
+    /// An empty sequence means unbound.
+    QKeySequence shortcut(const QString& id) const;
+    /// The shipped default, resolved for this platform (see ActionSpec::standardKey).
+    QKeySequence defaultShortcut(const QString& id) const;
+    /// True when the user has moved this action off its default (including unbinding it).
+    bool isCustomized(const QString& id) const;
+
+    /// The action `seq` is already assigned to, or an empty string when nothing is. An action never
+    /// conflicts with itself, and an empty sequence never conflicts — any number of actions may be
+    /// unbound. Canvas actions are checked against Application ones too: a window-scoped shortcut
+    /// fires while the canvas has focus, so the two scopes share one namespace.
+    QString conflictingActionId(const QString& id, const QKeySequence& seq) const;
+
+    /// Rebind (an empty sequence unbinds). Setting an action back to its default drops the
+    /// override, so a later release changing that default still reaches this user.
+    void setShortcut(const QString& id, const QKeySequence& seq);
+    void resetToDefault(const QString& id);
+    void resetAllToDefaults();
+    /// Write the overrides through to Settings (the caller saves).
+    void save();
+
+    /// Register a sink: it takes the action's current key now, and every later one automatically.
+    void bind(const QString& id, QAction* action);
+    void bind(const QString& id, QShortcut* shortcut);
+
+    /// The spec row for an id, or nullptr when the id is unknown.
+    static const ActionSpec* spec(const QString& id);
+
+signals:
+    void bindingChanged(const QString& id, const QKeySequence& seq);
+
+private:
+    void applyToSinks(const QString& id, const QKeySequence& seq);
+
+    std::shared_ptr<Settings> _settings;
+    /// Overrides only. A present-but-empty sequence is a deliberate unbind, which is not the same
+    /// as an absent entry (= "use the default").
+    QMap<QString, QKeySequence> _overrides;
+    QHash<QString, QList<QPointer<QAction>>> _actionSinks;
+    QHash<QString, QList<QPointer<QShortcut>>> _shortcutSinks;
+};
+
+} // namespace geck

--- a/src/ui/panels/SelectionPanel.cpp
+++ b/src/ui/panels/SelectionPanel.cpp
@@ -1218,23 +1218,19 @@ void SelectionPanel::updateScriptSection() {
     _attachedScriptProgramIndex = -1;
     if (attached) {
         const uint32_t sid = static_cast<uint32_t>(mapObject->map_scripts_pid);
-        const int section = MapScript::sidSection(sid);
-        if (section >= 0 && section < Map::SCRIPT_SECTIONS) {
-            for (const auto& s : _map->getMapFile().map_scripts[section]) {
-                if (s.pid == sid) {
-                    _attachedScriptProgramIndex = static_cast<int>(s.script_id);
-                    auto* lst = _resources.repository().load<Lst>(ResourcePaths::Lst::SCRIPTS);
-                    if (lst && s.script_id < lst->list().size()) {
-                        text = QString::fromStdString(lst->list().at(s.script_id));
-                        const std::string desc = resource::scriptDescription(_resources, static_cast<int>(s.script_id));
-                        if (!desc.empty()) {
-                            text += " — " + QString::fromStdString(desc);
-                        }
-                    } else {
-                        text = QString("Script #%1").arg(s.script_id);
-                    }
-                    break;
+        // Shared with the Ctrl+Shift+E path in MainWindow, so the two resolve the same script.
+        if (const std::optional<int> programIndex = _map->scriptProgramIndexForSid(sid)) {
+            _attachedScriptProgramIndex = *programIndex;
+            const auto scriptId = static_cast<size_t>(*programIndex);
+            auto* lst = _resources.repository().load<Lst>(ResourcePaths::Lst::SCRIPTS);
+            if (lst && scriptId < lst->list().size()) {
+                text = QString::fromStdString(lst->list().at(scriptId));
+                const std::string desc = resource::scriptDescription(_resources, *programIndex);
+                if (!desc.empty()) {
+                    text += " — " + QString::fromStdString(desc);
                 }
+            } else {
+                text = QString("Script #%1").arg(*programIndex);
             }
         }
     }

--- a/src/ui/panels/SelectionPanel.cpp
+++ b/src/ui/panels/SelectionPanel.cpp
@@ -1216,22 +1216,23 @@ void SelectionPanel::updateScriptSection() {
 
     QString text;
     _attachedScriptProgramIndex = -1;
-    if (attached) {
-        const uint32_t sid = static_cast<uint32_t>(mapObject->map_scripts_pid);
-        // Shared with the Ctrl+Shift+E path in MainWindow, so the two resolve the same script.
-        if (const std::optional<int> programIndex = _map->scriptProgramIndexForSid(sid)) {
-            _attachedScriptProgramIndex = *programIndex;
-            const auto scriptId = static_cast<size_t>(*programIndex);
-            auto* lst = _resources.repository().load<Lst>(ResourcePaths::Lst::SCRIPTS);
-            if (lst && scriptId < lst->list().size()) {
-                text = QString::fromStdString(lst->list().at(scriptId));
-                const std::string desc = resource::scriptDescription(_resources, *programIndex);
-                if (!desc.empty()) {
-                    text += " — " + QString::fromStdString(desc);
-                }
-            } else {
-                text = QString("Script #%1").arg(*programIndex);
+
+    // Shared with the Ctrl+Shift+E path in MainWindow, so the two resolve the same script.
+    const std::optional<int> programIndex = attached
+        ? _map->scriptProgramIndexForSid(static_cast<uint32_t>(mapObject->map_scripts_pid))
+        : std::nullopt;
+    if (programIndex) {
+        _attachedScriptProgramIndex = *programIndex;
+        const auto scriptId = static_cast<size_t>(*programIndex);
+        auto* lst = _resources.repository().load<Lst>(ResourcePaths::Lst::SCRIPTS);
+        if (lst && scriptId < lst->list().size()) {
+            text = QString::fromStdString(lst->list().at(scriptId));
+            const std::string desc = resource::scriptDescription(_resources, *programIndex);
+            if (!desc.empty()) {
+                text += " — " + QString::fromStdString(desc);
             }
+        } else {
+            text = QString("Script #%1").arg(*programIndex);
         }
     }
 

--- a/src/ui/panels/SelectionPanel.cpp
+++ b/src/ui/panels/SelectionPanel.cpp
@@ -1221,7 +1221,7 @@ void SelectionPanel::updateScriptSection() {
     const std::optional<int> programIndex = attached
         ? _map->scriptProgramIndexForSid(static_cast<uint32_t>(mapObject->map_scripts_pid))
         : std::nullopt;
-    if (programIndex) {
+    if (programIndex.has_value()) {
         _attachedScriptProgramIndex = *programIndex;
         const auto scriptId = static_cast<size_t>(*programIndex);
         auto* lst = _resources.repository().load<Lst>(ResourcePaths::Lst::SCRIPTS);

--- a/src/ui/widgets/KeybindingsWidget.cpp
+++ b/src/ui/widgets/KeybindingsWidget.cpp
@@ -1,0 +1,331 @@
+#include "KeybindingsWidget.h"
+
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QKeySequenceEdit>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QTreeWidget>
+#include <QVBoxLayout>
+
+#include "ui/input/ActionSpec.h"
+#include "ui/input/KeyBindingRegistry.h"
+#include "ui/theme/ThemeManager.h"
+
+namespace geck {
+
+namespace {
+
+    constexpr int COLUMN_ACTION = 0;
+    constexpr int COLUMN_SHORTCUT = 1;
+    constexpr int COLUMN_DEFAULT = 2;
+
+    // The action id a row stands for; category rows carry none.
+    constexpr int ACTION_ID_ROLE = Qt::UserRole + 1;
+
+    QString actionIdOf(const QTreeWidgetItem* item) {
+        return item ? item->data(COLUMN_ACTION, ACTION_ID_ROLE).toString() : QString();
+    }
+
+    QString displayKeys(const QKeySequence& keys) {
+        // Native text ("⌘S" on macOS, "Ctrl+S" elsewhere): this column is read, never parsed.
+        return keys.isEmpty() ? QObject::tr("Unbound") : keys.toString(QKeySequence::NativeText);
+    }
+
+} // namespace
+
+KeybindingsWidget::KeybindingsWidget(KeyBindingRegistry* registry, QWidget* parent)
+    : QGroupBox(tr("Keyboard Shortcuts"), parent)
+    , _registry(registry) {
+    setupUI();
+    reload();
+}
+
+void KeybindingsWidget::setupUI() {
+    auto* layout = new QVBoxLayout(this);
+    layout->setContentsMargins(ui::theme::spacing::LOOSE, ui::theme::spacing::LOOSE,
+        ui::theme::spacing::LOOSE, ui::theme::spacing::LOOSE);
+    layout->setSpacing(ui::theme::spacing::NORMAL);
+
+    _filterEdit = new QLineEdit(this);
+    _filterEdit->setPlaceholderText(tr("Filter by action, category or key..."));
+    _filterEdit->setClearButtonEnabled(true);
+    layout->addWidget(_filterEdit);
+
+    _tree = new QTreeWidget(this);
+    _tree->setColumnCount(3);
+    _tree->setHeaderLabels({ tr("Action"), tr("Shortcut"), tr("Default") });
+    _tree->setRootIsDecorated(false);
+    _tree->setIndentation(ui::theme::spacing::LOOSE);
+    _tree->setAllColumnsShowFocus(true);
+    _tree->setMinimumHeight(ui::constants::LIST_MIN_HEIGHT);
+    _tree->header()->setSectionResizeMode(COLUMN_ACTION, QHeaderView::Stretch);
+    _tree->header()->setSectionResizeMode(COLUMN_SHORTCUT, QHeaderView::ResizeToContents);
+    _tree->header()->setSectionResizeMode(COLUMN_DEFAULT, QHeaderView::ResizeToContents);
+    layout->addWidget(_tree, /*stretch=*/1);
+
+    auto* buttons = new QHBoxLayout();
+    buttons->setSpacing(ui::theme::spacing::NORMAL);
+    _resetButton = new QPushButton(tr("Reset"), this);
+    _resetButton->setToolTip(tr("Put the selected shortcut back to its default"));
+    _resetButton->setEnabled(false);
+    _resetAllButton = new QPushButton(tr("Reset All"), this);
+    _resetAllButton->setToolTip(tr("Put every shortcut back to its default"));
+    buttons->addWidget(_resetButton);
+    buttons->addWidget(_resetAllButton);
+    buttons->addStretch();
+    layout->addLayout(buttons);
+
+    connect(_filterEdit, &QLineEdit::textChanged, this, &KeybindingsWidget::onFilterChanged);
+    connect(_tree, &QTreeWidget::itemSelectionChanged, this, &KeybindingsWidget::onSelectionChanged);
+    connect(_resetButton, &QPushButton::clicked, this, &KeybindingsWidget::onResetSelected);
+    connect(_resetAllButton, &QPushButton::clicked, this, &KeybindingsWidget::onResetAll);
+
+    // Double-clicking the Shortcut cell opens a one-chord capture in place.
+    connect(_tree, &QTreeWidget::itemDoubleClicked, this, [this](QTreeWidgetItem* item, int column) {
+        if (column != COLUMN_SHORTCUT || actionIdOf(item).isEmpty()) {
+            return;
+        }
+
+        // QKeySequenceEdit captures the chord itself (modifiers included) and emits
+        // editingFinished on focus-out or after its own short idle timeout. One chord only:
+        // multi-chord sequences are not wanted for editor commands.
+        auto* editor = new QKeySequenceEdit(_tree);
+        editor->setMaximumSequenceLength(1);
+        editor->setKeySequence(pendingShortcut(actionIdOf(item)));
+        _tree->setItemWidget(item, COLUMN_SHORTCUT, editor);
+        editor->setFocus();
+
+        connect(editor, &QKeySequenceEdit::editingFinished, this, [this, item, editor]() {
+            const QKeySequence keys = editor->keySequence();
+            _tree->removeItemWidget(item, COLUMN_SHORTCUT);
+            editor->deleteLater();
+            onEditFinished(item, keys);
+        });
+    });
+}
+
+void KeybindingsWidget::reload() {
+    _pending.clear();
+    populate();
+    Q_EMIT statusChanged(QString(), QStringLiteral("normal"));
+}
+
+void KeybindingsWidget::populate() {
+    _tree->clear();
+    if (!_registry) {
+        return;
+    }
+
+    QHash<QString, QTreeWidgetItem*> categories;
+    for (const ActionSpec& spec : actionSpecs()) {
+        const QString category = QString::fromLatin1(spec.category);
+        QTreeWidgetItem*& group = categories[category];
+        if (group == nullptr) {
+            group = new QTreeWidgetItem(_tree, { category });
+            group->setFirstColumnSpanned(true);
+            group->setFlags(Qt::ItemIsEnabled); // a heading, not a target
+            QFont bold = group->font(COLUMN_ACTION);
+            bold.setBold(true);
+            group->setFont(COLUMN_ACTION, bold);
+            group->setExpanded(true);
+        }
+
+        auto* row = new QTreeWidgetItem(group, { QString::fromLatin1(spec.label) });
+        row->setData(COLUMN_ACTION, ACTION_ID_ROLE, QString::fromLatin1(spec.id));
+        row->setToolTip(COLUMN_ACTION, tr("%1 — %2 scope").arg(QString::fromLatin1(spec.id), spec.scope == ActionScope::Canvas ? tr("map view") : tr("application")));
+        refreshRow(row);
+    }
+}
+
+void KeybindingsWidget::refreshRow(QTreeWidgetItem* item) {
+    const QString id = actionIdOf(item);
+    if (id.isEmpty() || !_registry) {
+        return;
+    }
+
+    const QKeySequence keys = pendingShortcut(id);
+    item->setText(COLUMN_SHORTCUT, displayKeys(keys));
+    item->setText(COLUMN_DEFAULT, displayKeys(_registry->defaultShortcut(id)));
+
+    // Bold marks a row that no longer sits on its default, whether the user moved it in this
+    // sitting or in an earlier one.
+    const bool customized = (keys != _registry->defaultShortcut(id));
+    QFont font = item->font(COLUMN_SHORTCUT);
+    font.setBold(customized);
+    item->setFont(COLUMN_SHORTCUT, font);
+
+    const QString conflict = pendingConflict(id, keys);
+    item->setForeground(COLUMN_SHORTCUT,
+        conflict.isEmpty() ? QBrush() : QBrush(QColor(ui::theme::colors::STATUS_ERROR)));
+}
+
+QKeySequence KeybindingsWidget::pendingShortcut(const QString& id) const {
+    const auto pending = _pending.constFind(id);
+    if (pending != _pending.constEnd()) {
+        return pending.value();
+    }
+    return _registry ? _registry->shortcut(id) : QKeySequence();
+}
+
+QString KeybindingsWidget::pendingConflict(const QString& id, const QKeySequence& keys) const {
+    if (keys.isEmpty()) {
+        return {}; // any number of actions may be unbound
+    }
+
+    for (const ActionSpec& candidate : actionSpecs()) {
+        const QString candidateId = QString::fromLatin1(candidate.id);
+        if (candidateId == id) {
+            continue;
+        }
+        if (pendingShortcut(candidateId) == keys) {
+            return candidateId;
+        }
+    }
+
+    return {};
+}
+
+QTreeWidgetItem* KeybindingsWidget::itemForAction(const QString& id) const {
+    for (int group = 0; group < _tree->topLevelItemCount(); ++group) {
+        QTreeWidgetItem* category = _tree->topLevelItem(group);
+        for (int row = 0; row < category->childCount(); ++row) {
+            if (actionIdOf(category->child(row)) == id) {
+                return category->child(row);
+            }
+        }
+    }
+    return nullptr;
+}
+
+void KeybindingsWidget::onEditFinished(QTreeWidgetItem* item, const QKeySequence& keys) {
+    const QString id = actionIdOf(item);
+    if (id.isEmpty() || !_registry) {
+        return;
+    }
+    if (keys == pendingShortcut(id)) {
+        return; // nothing typed, or the same chord again
+    }
+
+    const QString conflict = pendingConflict(id, keys);
+    if (!conflict.isEmpty()) {
+        // Reported rather than refused: the user can still see what they typed, and clearing the
+        // other action's key resolves it. Applying a conflicting pair would make Qt fire neither.
+        const ActionSpec* other = KeyBindingRegistry::spec(conflict);
+        Q_EMIT statusChanged(tr("%1 is already assigned to %2 — clear that one first")
+                                 .arg(displayKeys(keys), other ? QString::fromLatin1(other->label) : conflict),
+            QStringLiteral("error"));
+    } else {
+        Q_EMIT statusChanged(QString(), QStringLiteral("normal"));
+    }
+
+    _pending.insert(id, keys);
+    refreshRow(item);
+    // The other row's colour changes too: it is now half of a conflict, or no longer part of one.
+    if (QTreeWidgetItem* otherItem = itemForAction(conflict)) {
+        refreshRow(otherItem);
+    }
+    onSelectionChanged();
+    Q_EMIT changed();
+}
+
+void KeybindingsWidget::onFilterChanged(const QString& text) {
+    const QString needle = text.trimmed();
+
+    for (int group = 0; group < _tree->topLevelItemCount(); ++group) {
+        QTreeWidgetItem* category = _tree->topLevelItem(group);
+        int visibleRows = 0;
+
+        for (int row = 0; row < category->childCount(); ++row) {
+            QTreeWidgetItem* item = category->child(row);
+            const bool matches = needle.isEmpty()
+                || item->text(COLUMN_ACTION).contains(needle, Qt::CaseInsensitive)
+                || item->text(COLUMN_SHORTCUT).contains(needle, Qt::CaseInsensitive)
+                || category->text(COLUMN_ACTION).contains(needle, Qt::CaseInsensitive);
+            item->setHidden(!matches);
+            visibleRows += matches ? 1 : 0;
+        }
+
+        category->setHidden(visibleRows == 0);
+    }
+}
+
+void KeybindingsWidget::onSelectionChanged() {
+    const QList<QTreeWidgetItem*> selected = _tree->selectedItems();
+    const QString id = selected.isEmpty() ? QString() : actionIdOf(selected.first());
+    _resetButton->setEnabled(!id.isEmpty() && _registry
+        && pendingShortcut(id) != _registry->defaultShortcut(id));
+}
+
+void KeybindingsWidget::onResetSelected() {
+    const QList<QTreeWidgetItem*> selected = _tree->selectedItems();
+    if (selected.isEmpty() || !_registry) {
+        return;
+    }
+
+    QTreeWidgetItem* item = selected.first();
+    const QString id = actionIdOf(item);
+    if (id.isEmpty()) {
+        return;
+    }
+
+    _pending.insert(id, _registry->defaultShortcut(id));
+    refreshRow(item);
+    onSelectionChanged();
+    Q_EMIT statusChanged(QString(), QStringLiteral("normal"));
+    Q_EMIT changed();
+}
+
+void KeybindingsWidget::onResetAll() {
+    if (!_registry) {
+        return;
+    }
+
+    for (const ActionSpec& spec : actionSpecs()) {
+        const QString id = QString::fromLatin1(spec.id);
+        _pending.insert(id, _registry->defaultShortcut(id));
+    }
+
+    for (int group = 0; group < _tree->topLevelItemCount(); ++group) {
+        QTreeWidgetItem* category = _tree->topLevelItem(group);
+        for (int row = 0; row < category->childCount(); ++row) {
+            refreshRow(category->child(row));
+        }
+    }
+
+    onSelectionChanged();
+    Q_EMIT statusChanged(QString(), QStringLiteral("normal"));
+    Q_EMIT changed();
+}
+
+bool KeybindingsWidget::hasPendingChanges() const {
+    if (!_registry) {
+        return false;
+    }
+    for (auto it = _pending.constBegin(); it != _pending.constEnd(); ++it) {
+        if (it.value() != _registry->shortcut(it.key())) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void KeybindingsWidget::applyChanges() {
+    if (!_registry) {
+        return;
+    }
+
+    // A conflicting pair would leave Qt firing neither shortcut, so those edits are dropped here
+    // rather than written through; the status line already said so when they were typed.
+    for (auto it = _pending.constBegin(); it != _pending.constEnd(); ++it) {
+        if (pendingConflict(it.key(), it.value()).isEmpty()) {
+            _registry->setShortcut(it.key(), it.value());
+        }
+    }
+
+    _registry->save();
+    _pending.clear();
+    populate();
+}
+
+} // namespace geck

--- a/src/ui/widgets/KeybindingsWidget.cpp
+++ b/src/ui/widgets/KeybindingsWidget.cpp
@@ -136,6 +136,23 @@ void KeybindingsWidget::populate() {
         row->setToolTip(COLUMN_ACTION, tr("%1 — %2 scope").arg(QString::fromLatin1(spec.id), spec.scope == ActionScope::Canvas ? tr("map view") : tr("application")));
         refreshRow(row);
     }
+
+    // The tree was rebuilt: without this, a reload/apply would show every row while the filter
+    // box still holds the text that was hiding most of them.
+    if (_filterEdit != nullptr) {
+        onFilterChanged(_filterEdit->text());
+    }
+}
+
+void KeybindingsWidget::refreshAllRows() {
+    // One edit can change two rows' colours — the one typed into and whichever was conflicting
+    // with it before or after — so the whole (small) tree is repainted rather than guessing which.
+    for (int group = 0; group < _tree->topLevelItemCount(); ++group) {
+        QTreeWidgetItem* category = _tree->topLevelItem(group);
+        for (int row = 0; row < category->childCount(); ++row) {
+            refreshRow(category->child(row));
+        }
+    }
 }
 
 void KeybindingsWidget::refreshRow(QTreeWidgetItem* item) {
@@ -186,18 +203,6 @@ QString KeybindingsWidget::pendingConflict(const QString& id, const QKeySequence
     return {};
 }
 
-QTreeWidgetItem* KeybindingsWidget::itemForAction(const QString& id) const {
-    for (int group = 0; group < _tree->topLevelItemCount(); ++group) {
-        QTreeWidgetItem* category = _tree->topLevelItem(group);
-        for (int row = 0; row < category->childCount(); ++row) {
-            if (actionIdOf(category->child(row)) == id) {
-                return category->child(row);
-            }
-        }
-    }
-    return nullptr;
-}
-
 void KeybindingsWidget::onEditFinished(QTreeWidgetItem* item, const QKeySequence& keys) {
     const QString id = actionIdOf(item);
     if (id.isEmpty() || !_registry) {
@@ -220,11 +225,7 @@ void KeybindingsWidget::onEditFinished(QTreeWidgetItem* item, const QKeySequence
     }
 
     _pending.insert(id, keys);
-    refreshRow(item);
-    // The other row's colour changes too: it is now half of a conflict, or no longer part of one.
-    if (QTreeWidgetItem* otherItem = itemForAction(conflict)) {
-        refreshRow(otherItem);
-    }
+    refreshAllRows();
     onSelectionChanged();
     Q_EMIT changed();
 }
@@ -270,7 +271,8 @@ void KeybindingsWidget::onResetSelected() {
     }
 
     _pending.insert(id, _registry->defaultShortcut(id));
-    refreshRow(item);
+    // Resetting can resolve a conflict, which recolours the row on the other side of it too.
+    refreshAllRows();
     onSelectionChanged();
     Q_EMIT statusChanged(QString(), QStringLiteral("normal"));
     Q_EMIT changed();
@@ -286,13 +288,7 @@ void KeybindingsWidget::onResetAll() {
         _pending.insert(id, _registry->defaultShortcut(id));
     }
 
-    for (int group = 0; group < _tree->topLevelItemCount(); ++group) {
-        QTreeWidgetItem* category = _tree->topLevelItem(group);
-        for (int row = 0; row < category->childCount(); ++row) {
-            refreshRow(category->child(row));
-        }
-    }
-
+    refreshAllRows();
     onSelectionChanged();
     Q_EMIT statusChanged(QString(), QStringLiteral("normal"));
     Q_EMIT changed();

--- a/src/ui/widgets/KeybindingsWidget.cpp
+++ b/src/ui/widgets/KeybindingsWidget.cpp
@@ -148,7 +148,7 @@ void KeybindingsWidget::refreshAllRows() {
     // One edit can change two rows' colours — the one typed into and whichever was conflicting
     // with it before or after — so the whole (small) tree is repainted rather than guessing which.
     for (int group = 0; group < _tree->topLevelItemCount(); ++group) {
-        QTreeWidgetItem* category = _tree->topLevelItem(group);
+        const QTreeWidgetItem* category = _tree->topLevelItem(group);
         for (int row = 0; row < category->childCount(); ++row) {
             refreshRow(category->child(row));
         }
@@ -178,8 +178,7 @@ void KeybindingsWidget::refreshRow(QTreeWidgetItem* item) {
 }
 
 QKeySequence KeybindingsWidget::pendingShortcut(const QString& id) const {
-    const auto pending = _pending.constFind(id);
-    if (pending != _pending.constEnd()) {
+    if (const auto pending = _pending.constFind(id); pending != _pending.constEnd()) {
         return pending.value();
     }
     return _registry ? _registry->shortcut(id) : QKeySequence();
@@ -212,8 +211,7 @@ void KeybindingsWidget::onEditFinished(QTreeWidgetItem* item, const QKeySequence
         return; // nothing typed, or the same chord again
     }
 
-    const QString conflict = pendingConflict(id, keys);
-    if (!conflict.isEmpty()) {
+    if (const QString conflict = pendingConflict(id, keys); !conflict.isEmpty()) {
         // Reported rather than refused: the user can still see what they typed, and clearing the
         // other action's key resolves it. Applying a conflicting pair would make Qt fire neither.
         const ActionSpec* other = KeyBindingRegistry::spec(conflict);
@@ -264,7 +262,7 @@ void KeybindingsWidget::onResetSelected() {
         return;
     }
 
-    QTreeWidgetItem* item = selected.first();
+    const QTreeWidgetItem* item = selected.first();
     const QString id = actionIdOf(item);
     if (id.isEmpty()) {
         return;

--- a/src/ui/widgets/KeybindingsWidget.h
+++ b/src/ui/widgets/KeybindingsWidget.h
@@ -52,12 +52,14 @@ private:
     void setupUI();
     void populate();
     void refreshRow(QTreeWidgetItem* item);
+    /// Repaint every row. One edit can change two rows (both sides of a conflict), so this is the
+    /// honest granularity for a table this size.
+    void refreshAllRows();
     /// The pending key for an action: the edit in progress if there is one, else the registry's.
     QKeySequence pendingShortcut(const QString& id) const;
     /// The action `keys` is pending on, or an empty string. Mirrors the registry's rule, but over
     /// the uncommitted edits — otherwise a swap made in one sitting would look conflict-free.
     QString pendingConflict(const QString& id, const QKeySequence& keys) const;
-    QTreeWidgetItem* itemForAction(const QString& id) const;
 
     KeyBindingRegistry* _registry = nullptr;
     QLineEdit* _filterEdit = nullptr;

--- a/src/ui/widgets/KeybindingsWidget.h
+++ b/src/ui/widgets/KeybindingsWidget.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <QGroupBox>
+#include <QKeySequence>
+#include <QMap>
+#include <QString>
+
+QT_BEGIN_NAMESPACE
+class QLineEdit;
+class QPushButton;
+class QTreeWidget;
+class QTreeWidgetItem;
+QT_END_NAMESPACE
+
+namespace geck {
+
+class KeyBindingRegistry;
+
+/**
+ * @brief The Preferences page for rebinding keyboard shortcuts.
+ *
+ * Edits an in-memory copy of the bindings and commits it on Apply/OK, like the other Preferences
+ * sections, so Cancel really does cancel. Conflicts are reported live while typing a chord: the
+ * row turns red and the status line names the action already holding that key, with a Reassign
+ * button that unbinds the other one.
+ */
+class KeybindingsWidget : public QGroupBox {
+    Q_OBJECT
+
+public:
+    explicit KeybindingsWidget(KeyBindingRegistry* registry, QWidget* parent = nullptr);
+
+    /// Re-read the registry, discarding anything not yet applied.
+    void reload();
+    /// Push the pending edits into the registry (the dialog saves Settings afterwards).
+    void applyChanges();
+    /// True when there is anything to apply.
+    bool hasPendingChanges() const;
+
+signals:
+    void changed();
+    void statusChanged(const QString& message, const QString& styleClass);
+
+private slots:
+    void onFilterChanged(const QString& text);
+    void onSelectionChanged();
+    void onResetSelected();
+    void onResetAll();
+    void onEditFinished(QTreeWidgetItem* item, const QKeySequence& keys);
+
+private:
+    void setupUI();
+    void populate();
+    void refreshRow(QTreeWidgetItem* item);
+    /// The pending key for an action: the edit in progress if there is one, else the registry's.
+    QKeySequence pendingShortcut(const QString& id) const;
+    /// The action `keys` is pending on, or an empty string. Mirrors the registry's rule, but over
+    /// the uncommitted edits — otherwise a swap made in one sitting would look conflict-free.
+    QString pendingConflict(const QString& id, const QKeySequence& keys) const;
+    QTreeWidgetItem* itemForAction(const QString& id) const;
+
+    KeyBindingRegistry* _registry = nullptr;
+    QLineEdit* _filterEdit = nullptr;
+    QTreeWidget* _tree = nullptr;
+    QPushButton* _resetButton = nullptr;
+    QPushButton* _resetAllButton = nullptr;
+    /// Edits not yet applied: action id -> key (an empty sequence is a deliberate unbind).
+    QMap<QString, QKeySequence> _pending;
+};
+
+} // namespace geck

--- a/src/viewport/ViewportController.cpp
+++ b/src/viewport/ViewportController.cpp
@@ -52,8 +52,8 @@ sf::FloatRect ViewportController::mapWorldBounds() {
 
     for (const TileCoordinates& corner : corners) {
         const auto topLeft = coordinatesToScreenPosition(corner);
-        const float x = static_cast<float>(topLeft.x);
-        const float y = static_cast<float>(topLeft.y);
+        const auto x = static_cast<float>(topLeft.x);
+        const auto y = static_cast<float>(topLeft.y);
         minX = std::min(minX, x);
         minY = std::min(minY, y);
         maxX = std::max(maxX, x + static_cast<float>(TILE_WIDTH));

--- a/src/viewport/ViewportController.cpp
+++ b/src/viewport/ViewportController.cpp
@@ -1,9 +1,12 @@
 #include "ViewportController.h"
 #include "editor/Hex.h"
 #include "util/Constants.h"
+#include "util/TileUtils.h"
 #include <spdlog/spdlog.h>
 #include <algorithm>
+#include <array>
 #include <cmath>
+#include <limits>
 
 using namespace geck;
 
@@ -31,6 +34,57 @@ void ViewportController::centerViewOnMap() {
 
     _view.setCenter(sf::Vector2f(centerX, centerY));
     spdlog::debug("ViewportController: Centered view on ({:.1f}, {:.1f})", centerX, centerY);
+}
+
+sf::FloatRect ViewportController::mapWorldBounds() {
+    // The projection is affine, so the grid's four corner tiles bound every tile between them.
+    const std::array<TileCoordinates, 4> corners = { {
+        TileCoordinates(0u, 0u),
+        TileCoordinates(0u, static_cast<unsigned int>(MAP_WIDTH - 1)),
+        TileCoordinates(static_cast<unsigned int>(MAP_HEIGHT - 1), 0u),
+        TileCoordinates(static_cast<unsigned int>(MAP_HEIGHT - 1), static_cast<unsigned int>(MAP_WIDTH - 1)),
+    } };
+
+    float minX = std::numeric_limits<float>::max();
+    float minY = std::numeric_limits<float>::max();
+    float maxX = std::numeric_limits<float>::lowest();
+    float maxY = std::numeric_limits<float>::lowest();
+
+    for (const TileCoordinates& corner : corners) {
+        const auto topLeft = coordinatesToScreenPosition(corner);
+        const float x = static_cast<float>(topLeft.x);
+        const float y = static_cast<float>(topLeft.y);
+        minX = std::min(minX, x);
+        minY = std::min(minY, y);
+        maxX = std::max(maxX, x + static_cast<float>(TILE_WIDTH));
+        maxY = std::max(maxY, y + static_cast<float>(TILE_HEIGHT));
+    }
+
+    return sf::FloatRect({ minX, minY }, { maxX - minX, maxY - minY });
+}
+
+void ViewportController::fitMapInView() {
+    if (_windowSize.x == 0 || _windowSize.y == 0) {
+        spdlog::warn("ViewportController: Cannot fit the map into a {}x{} window", _windowSize.x, _windowSize.y);
+        return;
+    }
+
+    const sf::FloatRect bounds = mapWorldBounds();
+    if (bounds.size.x <= 0.f || bounds.size.y <= 0.f) {
+        return;
+    }
+
+    // The tighter of the two axes decides, so the whole grid fits rather than just one dimension.
+    const float fitZoom = std::min(
+        static_cast<float>(_windowSize.x) / bounds.size.x,
+        static_cast<float>(_windowSize.y) / bounds.size.y);
+
+    setZoomLevel(fitZoom); // clamps, and resizes the view to match
+    // After the zoom: setZoomLevel keeps the old centre, and the map centre is what we want.
+    _view.setCenter(bounds.position + bounds.size / 2.0f);
+
+    spdlog::debug("ViewportController: Fit map ({:.0f}x{:.0f}) into {}x{} at zoom {:.2f}",
+        bounds.size.x, bounds.size.y, _windowSize.x, _windowSize.y, _zoomLevel);
 }
 
 void ViewportController::panBy(sf::Vector2f worldDelta) {

--- a/src/viewport/ViewportController.h
+++ b/src/viewport/ViewportController.h
@@ -45,6 +45,23 @@ public:
     void centerViewOnMap();
 
     /**
+     * @brief World-space bounds of the whole tile grid.
+     *
+     * Derived from the authoritative forward projection (coordinatesToScreenPosition) at the
+     * grid's four corners, which bound it because the projection is affine — so this cannot
+     * drift from where the tiles are actually drawn.
+     */
+    static sf::FloatRect mapWorldBounds();
+
+    /**
+     * @brief Zoom out far enough to show the whole tile grid, then centre it.
+     *
+     * The zoom is clamped like any other (MIN_ZOOM..MAX_ZOOM); at the clamp the map is centred
+     * but still overflows the view.
+     */
+    void fitMapInView();
+
+    /**
      * @brief Pan the view by a delta expressed in world units.
      *
      * The single place that moves the camera; both the drag-pan and the

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -113,6 +113,7 @@ add_executable(qt_tests
     qt/test_pattern_serializer.cpp
     # InputHandler is Qt-free but lives in gecko_app; its dispatch test needs SFML.
     qt/test_input_handler.cpp
+    qt/test_keybindings.cpp
     qt/test_tool_registry.cpp
     qt/test_fill_brush_tool.cpp
     qt/test_plugin_ui_registration.cpp

--- a/tests/general/test_viewport_controller.cpp
+++ b/tests/general/test_viewport_controller.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
 
 #include <SFML/System/Vector2.hpp>
 
@@ -111,4 +112,51 @@ TEST_CASE("Tile placement uses the render projection, not hex-snapping", "[viewp
     // Zero divergences would mean the two algorithms are equivalent and the fix a no-op.
     // The whole point of WP-10 is that they are NOT: placement diverged from hover.
     CHECK(divergences > 0);
+}
+
+// "F" fits the whole map in view. The grid's extent comes from the same forward projection the
+// tiles are drawn with, so the two cannot drift apart.
+TEST_CASE("ViewportController fits the whole tile grid in view", "[viewport][zoom]") {
+    const sf::FloatRect bounds = ViewportController::mapWorldBounds();
+
+    // Every tile in the grid lands inside the reported bounds.
+    for (int index : { 0, MAP_WIDTH - 1, (MAP_HEIGHT - 1) * MAP_WIDTH, MAP_WIDTH * MAP_HEIGHT - 1, 5050 }) {
+        const auto topLeft = indexToScreenPosition(index);
+        CHECK(static_cast<float>(topLeft.x) >= bounds.position.x);
+        CHECK(static_cast<float>(topLeft.y) >= bounds.position.y);
+        CHECK(static_cast<float>(topLeft.x) + TILE_WIDTH <= bounds.position.x + bounds.size.x);
+        CHECK(static_cast<float>(topLeft.y) + TILE_HEIGHT <= bounds.position.y + bounds.size.y);
+    }
+
+    HexagonGrid grid;
+    ViewportController viewport(&grid);
+    viewport.initialize({ 1600u, 900u });
+    viewport.fitMapInView();
+
+    // The view now covers the grid on both axes, centred on it.
+    const sf::View& view = viewport.getView();
+    const sf::Vector2f half = view.getSize() / 2.0f;
+    CHECK(view.getCenter().x == Catch::Approx(bounds.position.x + bounds.size.x / 2.0f));
+    CHECK(view.getCenter().y == Catch::Approx(bounds.position.y + bounds.size.y / 2.0f));
+    CHECK(view.getCenter().x - half.x <= bounds.position.x);
+    CHECK(view.getCenter().x + half.x >= bounds.position.x + bounds.size.x);
+    CHECK(view.getCenter().y - half.y <= bounds.position.y);
+    CHECK(view.getCenter().y + half.y >= bounds.position.y + bounds.size.y);
+
+    // A 1600x900 viewport needs about 0.20x, comfortably inside the zoom clamp.
+    CHECK(viewport.getZoomLevel() > 0.1f);
+    CHECK(viewport.getZoomLevel() < 1.0f);
+}
+
+// A viewport far too small to ever show the map still ends centred on it, at the zoom floor
+// rather than at some unreachable value.
+TEST_CASE("ViewportController fit stops at the minimum zoom", "[viewport][zoom]") {
+    HexagonGrid grid;
+    ViewportController viewport(&grid);
+    viewport.initialize({ 64u, 64u });
+    viewport.fitMapInView();
+
+    const sf::FloatRect bounds = ViewportController::mapWorldBounds();
+    CHECK(viewport.getZoomLevel() == Catch::Approx(0.1f)); // MIN_ZOOM
+    CHECK(viewport.getView().getCenter().x == Catch::Approx(bounds.position.x + bounds.size.x / 2.0f));
 }

--- a/tests/qt/test_keybindings.cpp
+++ b/tests/qt/test_keybindings.cpp
@@ -1,0 +1,317 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <QAction>
+#include <QApplication>
+#include <QDir>
+#include <QKeySequence>
+#include <QShortcut>
+#include <QStandardPaths>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QTabWidget>
+#include <QTreeWidget>
+#include <QWidget>
+
+#include <memory>
+#include <set>
+#include <string>
+
+#include "ui/Settings.h"
+#include "ui/input/ActionSpec.h"
+#include "ui/input/KeyBindingRegistry.h"
+#include "ui/dialogs/SettingsDialog.h"
+#include "ui/widgets/KeybindingsWidget.h"
+
+using namespace geck;
+
+namespace {
+
+// Settings write to the platform config location; each case starts from a clean one so a stale
+// override from an earlier run cannot leak in.
+void removeTestSettings() {
+    const QString configRoot = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation);
+    QDir().mkpath(configRoot);
+    QDir geckoDir(configRoot + "/gecko");
+    if (geckoDir.exists()) {
+        geckoDir.removeRecursively();
+    }
+    QDir().mkpath(configRoot + "/gecko");
+}
+
+} // namespace
+
+// The table is what every menu, toolbar and canvas binding reads, and what settings.json points
+// at, so its invariants are worth asserting directly: a duplicate id would make one row
+// unreachable, and two actions sharing a key would make Qt fire neither.
+TEST_CASE("The shipped keybinding table is internally consistent", "[qt][keybindings]") {
+    std::set<std::string> ids;
+    std::set<std::string> keys;
+
+    for (const ActionSpec& spec : actionSpecs()) {
+        REQUIRE(spec.id != nullptr);
+        REQUIRE(spec.label != nullptr);
+        REQUIRE(spec.category != nullptr);
+
+        INFO("action id: " << spec.id);
+        CHECK(ids.insert(spec.id).second); // ids are unique
+
+        // Exactly one of the two ways of naming a default is used.
+        const bool hasText = (spec.defaultKeys != nullptr && *spec.defaultKeys != '\0');
+        const bool hasStandardKey = (spec.standardKey != QKeySequence::UnknownKey);
+        CHECK_FALSE((hasText && hasStandardKey));
+
+        if (hasText) {
+            // A typo'd default would silently parse to an empty sequence and leave the action
+            // unbound rather than failing anywhere visible.
+            CHECK_FALSE(QKeySequence::fromString(QString::fromLatin1(spec.defaultKeys),
+                QKeySequence::PortableText)
+                    .isEmpty());
+        }
+    }
+
+    // Defaults do not collide — across both scopes, since an Application shortcut fires while the
+    // canvas has focus too. A platform where a standard key resolves to nothing (Quit on Windows)
+    // legitimately yields several empty sequences, so only bound ones are compared.
+    removeTestSettings();
+    KeyBindingRegistry registry(std::make_shared<Settings>());
+    for (const ActionSpec& spec : actionSpecs()) {
+        const QKeySequence keySequence = registry.defaultShortcut(QString::fromLatin1(spec.id));
+        if (keySequence.isEmpty()) {
+            continue;
+        }
+        INFO("action id: " << spec.id << ", key: " << keySequence.toString().toStdString());
+        CHECK(keys.insert(keySequence.toString().toStdString()).second);
+    }
+}
+
+TEST_CASE("An override is stored, reloaded and dropped again on reset", "[qt][keybindings]") {
+    removeTestSettings();
+
+    auto settings = std::make_shared<Settings>();
+    const QKeySequence rebound("Ctrl+Alt+K");
+
+    {
+        KeyBindingRegistry registry(settings);
+        REQUIRE(registry.shortcut(actions::PANEL_SELECTION) == QKeySequence("Alt+2"));
+        REQUIRE_FALSE(registry.isCustomized(actions::PANEL_SELECTION));
+
+        registry.setShortcut(actions::PANEL_SELECTION, rebound);
+        CHECK(registry.shortcut(actions::PANEL_SELECTION) == rebound);
+        CHECK(registry.isCustomized(actions::PANEL_SELECTION));
+        registry.save();
+    }
+
+    // Only the changed action is written: everything still on its default stays absent, so a
+    // later release is free to move those defaults.
+    const QMap<QString, QString> stored = settings->getKeyBindings();
+    CHECK(stored.size() == 1);
+    CHECK(stored.value(actions::PANEL_SELECTION) == rebound.toString(QKeySequence::PortableText));
+
+    {
+        KeyBindingRegistry reloaded(settings);
+        CHECK(reloaded.shortcut(actions::PANEL_SELECTION) == rebound);
+        CHECK(reloaded.shortcut(actions::PANEL_MAP_INFO) == QKeySequence("Alt+1")); // untouched
+
+        reloaded.resetToDefault(actions::PANEL_SELECTION);
+        CHECK_FALSE(reloaded.isCustomized(actions::PANEL_SELECTION));
+        reloaded.save();
+    }
+
+    CHECK(settings->getKeyBindings().isEmpty());
+}
+
+// Unbinding is a real state, distinct from "never changed": it has to survive a round trip, or a
+// reload would hand the key back.
+TEST_CASE("An unbound action persists as unbound", "[qt][keybindings]") {
+    removeTestSettings();
+
+    auto settings = std::make_shared<Settings>();
+    {
+        KeyBindingRegistry registry(settings);
+        registry.setShortcut(actions::TOOL_ROTATE, QKeySequence());
+        registry.save();
+    }
+
+    CHECK(settings->getKeyBindings().value(actions::TOOL_ROTATE) == QString(""));
+
+    KeyBindingRegistry reloaded(settings);
+    CHECK(reloaded.shortcut(actions::TOOL_ROTATE).isEmpty());
+    CHECK(reloaded.isCustomized(actions::TOOL_ROTATE));
+}
+
+TEST_CASE("Conflicts are found across scopes and ignore unbound actions", "[qt][keybindings]") {
+    removeTestSettings();
+    KeyBindingRegistry registry(std::make_shared<Settings>());
+
+    // Alt+2 belongs to the Selection panel.
+    CHECK(registry.conflictingActionId(actions::PANEL_MAP_INFO, QKeySequence("Alt+2"))
+        == QString(actions::PANEL_SELECTION));
+    // An action never conflicts with itself.
+    CHECK(registry.conflictingActionId(actions::PANEL_SELECTION, QKeySequence("Alt+2")).isEmpty());
+    // A free key is free.
+    CHECK(registry.conflictingActionId(actions::PANEL_MAP_INFO, QKeySequence("Ctrl+Alt+J")).isEmpty());
+    // Any number of actions may be unbound.
+    CHECK(registry.conflictingActionId(actions::PANEL_MAP_INFO, QKeySequence()).isEmpty());
+
+    // The two scopes are one namespace: a window-scoped shortcut fires while the canvas has focus,
+    // so a canvas action must not be allowed to shadow one.
+    CHECK(registry.conflictingActionId(actions::TOOL_SELECT, QKeySequence("Ctrl+A"))
+        == QString(actions::SELECT_ALL));
+}
+
+// The point of the sink registration: a rebind reaches the live UI without a restart and without
+// re-walking the menu bar.
+TEST_CASE("Bound actions and shortcuts follow a rebind", "[qt][keybindings]") {
+    removeTestSettings();
+    KeyBindingRegistry registry(std::make_shared<Settings>());
+
+    QWidget host;
+    QAction action(&host);
+    auto* shortcut = new QShortcut(&host);
+
+    registry.bind(actions::PANEL_SELECTION, &action);
+    registry.bind(actions::TOOL_ROTATE, shortcut);
+
+    // bind() applies the current key straight away.
+    CHECK(action.shortcut() == QKeySequence("Alt+2"));
+    CHECK(shortcut->key() == QKeySequence("R"));
+
+    registry.setShortcut(actions::PANEL_SELECTION, QKeySequence("Ctrl+Alt+2"));
+    registry.setShortcut(actions::TOOL_ROTATE, QKeySequence("Ctrl+Alt+R"));
+
+    CHECK(action.shortcut() == QKeySequence("Ctrl+Alt+2"));
+    CHECK(shortcut->key() == QKeySequence("Ctrl+Alt+R"));
+
+    registry.resetAllToDefaults();
+    CHECK(action.shortcut() == QKeySequence("Alt+2"));
+    CHECK(shortcut->key() == QKeySequence("R"));
+}
+
+// A sink dies with the map view it hangs off; the registry must not touch it afterwards.
+TEST_CASE("A destroyed sink is dropped instead of dangling", "[qt][keybindings]") {
+    removeTestSettings();
+    KeyBindingRegistry registry(std::make_shared<Settings>());
+
+    {
+        QWidget host;
+        registry.bind(actions::TOOL_ROTATE, new QShortcut(&host));
+    }
+
+    registry.setShortcut(actions::TOOL_ROTATE, QKeySequence("Ctrl+Alt+R")); // must not crash
+    CHECK(registry.shortcut(actions::TOOL_ROTATE) == QKeySequence("Ctrl+Alt+R"));
+}
+
+// A settings file naming an action the table no longer has (renamed, retired) must not resurrect
+// a key that nothing listens for.
+TEST_CASE("An override for an unknown action is discarded", "[qt][keybindings]") {
+    removeTestSettings();
+
+    auto settings = std::make_shared<Settings>();
+    settings->setKeyBindings({ { "panel.thatNeverExisted", "Ctrl+Alt+Z" } });
+
+    KeyBindingRegistry registry(settings);
+    registry.save();
+
+    CHECK(settings->getKeyBindings().isEmpty());
+    CHECK(registry.shortcut("panel.thatNeverExisted").isEmpty());
+}
+
+// The Preferences page: one row per table entry, a filter over them, and edits that only reach the
+// registry on apply — so Cancel really cancels.
+TEST_CASE("The keybindings page lists the table and commits only on apply", "[qt][keybindings]") {
+    removeTestSettings();
+
+    auto settings = std::make_shared<Settings>();
+    KeyBindingRegistry registry(settings);
+    KeybindingsWidget widget(&registry);
+
+    auto* tree = widget.findChild<QTreeWidget*>();
+    REQUIRE(tree != nullptr);
+
+    int rows = 0;
+    for (int group = 0; group < tree->topLevelItemCount(); ++group) {
+        rows += tree->topLevelItem(group)->childCount();
+    }
+    CHECK(rows == static_cast<int>(actionSpecs().size()));
+    CHECK(tree->topLevelItemCount() > 1); // grouped by category, not one flat list
+
+    // Nothing edited yet.
+    CHECK_FALSE(widget.hasPendingChanges());
+
+    // The filter hides non-matching rows and the categories left empty by them.
+    auto* filter = widget.findChild<QLineEdit*>();
+    REQUIRE(filter != nullptr);
+    filter->setText("Selection Panel");
+    QApplication::processEvents();
+
+    int visibleRows = 0;
+    for (int group = 0; group < tree->topLevelItemCount(); ++group) {
+        QTreeWidgetItem* category = tree->topLevelItem(group);
+        for (int row = 0; row < category->childCount(); ++row) {
+            visibleRows += category->child(row)->isHidden() ? 0 : 1;
+        }
+    }
+    CHECK(visibleRows == 1);
+
+    // Applying with nothing pending leaves the bindings — and the settings file — untouched.
+    widget.applyChanges();
+    CHECK(registry.shortcut(actions::PANEL_SELECTION) == QKeySequence("Alt+2"));
+    CHECK(settings->getKeyBindings().isEmpty());
+}
+
+// Reset All is the page's escape hatch, so it has to clear an override made in an earlier sitting,
+// not just the edits typed in this one.
+TEST_CASE("Reset All on the keybindings page clears a stored override", "[qt][keybindings]") {
+    removeTestSettings();
+
+    auto settings = std::make_shared<Settings>();
+    KeyBindingRegistry registry(settings);
+    registry.setShortcut(actions::PANEL_SELECTION, QKeySequence("Ctrl+Alt+K"));
+    registry.save();
+
+    KeybindingsWidget widget(&registry);
+
+    // By text rather than by order, so adding a button next to it doesn't silently move this test.
+    QPushButton* resetAllButton = nullptr;
+    for (QPushButton* button : widget.findChildren<QPushButton*>()) {
+        if (button->text() == "Reset All") {
+            resetAllButton = button;
+        }
+    }
+    REQUIRE(resetAllButton != nullptr);
+
+    resetAllButton->click();
+    CHECK(widget.hasPendingChanges());
+
+    widget.applyChanges();
+    CHECK(registry.shortcut(actions::PANEL_SELECTION) == QKeySequence("Alt+2"));
+    CHECK_FALSE(registry.isCustomized(actions::PANEL_SELECTION));
+    CHECK(settings->getKeyBindings().isEmpty());
+}
+
+// The tab is optional: a dialog built without a registry (the first-run one, and a bare-constructed
+// one in a test) must still build, just without the page.
+TEST_CASE("The Preferences dialog gains a shortcuts tab only with a registry", "[qt][keybindings]") {
+    removeTestSettings();
+
+    auto settings = std::make_shared<Settings>();
+    KeyBindingRegistry registry(settings);
+
+    const auto tabTitles = [](const SettingsDialog& dialog) {
+        QStringList titles;
+        for (QTabWidget* tabs : dialog.findChildren<QTabWidget*>()) {
+            for (int index = 0; index < tabs->count(); ++index) {
+                titles.append(tabs->tabText(index));
+            }
+        }
+        return titles;
+    };
+
+    SettingsDialog withRegistry(settings, &registry);
+    CHECK(tabTitles(withRegistry).contains("Keyboard Shortcuts"));
+    CHECK(withRegistry.findChild<KeybindingsWidget*>() != nullptr);
+
+    SettingsDialog withoutRegistry(settings, nullptr);
+    CHECK_FALSE(tabTitles(withoutRegistry).contains("Keyboard Shortcuts"));
+    CHECK(withoutRegistry.findChild<KeybindingsWidget*>() == nullptr);
+}

--- a/tests/qt/test_keybindings.cpp
+++ b/tests/qt/test_keybindings.cpp
@@ -31,8 +31,7 @@ namespace {
 void removeTestSettings() {
     const QString configRoot = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation);
     QDir().mkpath(configRoot);
-    QDir geckoDir(configRoot + "/gecko");
-    if (geckoDir.exists()) {
+    if (QDir geckoDir(configRoot + "/gecko"); geckoDir.exists()) {
         geckoDir.removeRecursively();
     }
     QDir().mkpath(configRoot + "/gecko");
@@ -44,8 +43,8 @@ void removeTestSettings() {
 // at, so its invariants are worth asserting directly: a duplicate id would make one row
 // unreachable, and two actions sharing a key would make Qt fire neither.
 TEST_CASE("The shipped keybinding table is internally consistent", "[qt][keybindings]") {
-    std::set<std::string> ids;
-    std::set<std::string> keys;
+    std::set<std::string, std::less<>> ids;
+    std::set<std::string, std::less<>> keys;
 
     for (const ActionSpec& spec : actionSpecs()) {
         REQUIRE(spec.id != nullptr);
@@ -266,7 +265,7 @@ TEST_CASE("The keybindings page lists the table and commits only on apply", "[qt
 
     int visibleRows = 0;
     for (int group = 0; group < tree->topLevelItemCount(); ++group) {
-        QTreeWidgetItem* category = tree->topLevelItem(group);
+        const QTreeWidgetItem* category = tree->topLevelItem(group);
         for (int row = 0; row < category->childCount(); ++row) {
             visibleRows += category->child(row)->isHidden() ? 0 : 1;
         }
@@ -319,7 +318,7 @@ TEST_CASE("The Preferences dialog gains a shortcuts tab only with a registry", "
 
     const auto tabTitles = [](const SettingsDialog& dialog) {
         QStringList titles;
-        for (QTabWidget* tabs : dialog.findChildren<QTabWidget*>()) {
+        for (const QTabWidget* tabs : dialog.findChildren<QTabWidget*>()) {
             for (int index = 0; index < tabs->count(); ++index) {
                 titles.append(tabs->tabText(index));
             }
@@ -350,7 +349,7 @@ TEST_CASE("The keybindings page repaints both sides of a conflict", "[qt][keybin
 
     const auto rowFor = [tree](const QString& label) -> QTreeWidgetItem* {
         for (int group = 0; group < tree->topLevelItemCount(); ++group) {
-            QTreeWidgetItem* category = tree->topLevelItem(group);
+            const QTreeWidgetItem* category = tree->topLevelItem(group);
             for (int row = 0; row < category->childCount(); ++row) {
                 if (category->child(row)->text(0) == label) {
                     return category->child(row);
@@ -403,7 +402,7 @@ TEST_CASE("The keybindings page keeps its filter across a rebuild", "[qt][keybin
     const auto visibleRows = [tree]() {
         int count = 0;
         for (int group = 0; group < tree->topLevelItemCount(); ++group) {
-            QTreeWidgetItem* category = tree->topLevelItem(group);
+            const QTreeWidgetItem* category = tree->topLevelItem(group);
             for (int row = 0; row < category->childCount(); ++row) {
                 count += category->child(row)->isHidden() ? 0 : 1;
             }

--- a/tests/qt/test_keybindings.cpp
+++ b/tests/qt/test_keybindings.cpp
@@ -201,6 +201,26 @@ TEST_CASE("A destroyed sink is dropped instead of dangling", "[qt][keybindings]"
     CHECK(registry.shortcut(actions::TOOL_ROTATE) == QKeySequence("Ctrl+Alt+R"));
 }
 
+// Canvas shortcuts are re-bound on every map load, so binding the same id again has to drop the
+// sinks that died with the previous map rather than piling nulls up for the session's lifetime.
+TEST_CASE("Re-binding an action drops sinks that have been destroyed", "[qt][keybindings]") {
+    removeTestSettings();
+    KeyBindingRegistry registry(std::make_shared<Settings>());
+
+    for (int round = 0; round < 3; ++round) {
+        QWidget host;
+        registry.bind(actions::TOOL_ROTATE, new QShortcut(&host));
+        registry.setShortcut(actions::TOOL_ROTATE, QKeySequence(round % 2 == 0 ? "Ctrl+Alt+R" : "R"));
+    }
+
+    // The survivor of the last round is gone too; rebinding must still be safe.
+    QWidget host;
+    auto* live = new QShortcut(&host);
+    registry.bind(actions::TOOL_ROTATE, live);
+    registry.setShortcut(actions::TOOL_ROTATE, QKeySequence("Ctrl+Alt+T"));
+    CHECK(live->key() == QKeySequence("Ctrl+Alt+T"));
+}
+
 // A settings file naming an action the table no longer has (renamed, retired) must not resurrect
 // a key that nothing listens for.
 TEST_CASE("An override for an unknown action is discarded", "[qt][keybindings]") {
@@ -314,4 +334,88 @@ TEST_CASE("The Preferences dialog gains a shortcuts tab only with a registry", "
     SettingsDialog withoutRegistry(settings, nullptr);
     CHECK_FALSE(tabTitles(withoutRegistry).contains("Keyboard Shortcuts"));
     CHECK(withoutRegistry.findChild<KeybindingsWidget*>() == nullptr);
+}
+
+// Resolving a conflict changes two rows, not one: the row typed into and whichever was holding
+// that key before. Both have to lose the error colour.
+TEST_CASE("The keybindings page repaints both sides of a conflict", "[qt][keybindings]") {
+    removeTestSettings();
+
+    auto settings = std::make_shared<Settings>();
+    KeyBindingRegistry registry(settings);
+    KeybindingsWidget widget(&registry);
+
+    auto* tree = widget.findChild<QTreeWidget*>();
+    REQUIRE(tree != nullptr);
+
+    const auto rowFor = [tree](const QString& label) -> QTreeWidgetItem* {
+        for (int group = 0; group < tree->topLevelItemCount(); ++group) {
+            QTreeWidgetItem* category = tree->topLevelItem(group);
+            for (int row = 0; row < category->childCount(); ++row) {
+                if (category->child(row)->text(0) == label) {
+                    return category->child(row);
+                }
+            }
+        }
+        return nullptr;
+    };
+
+    QTreeWidgetItem* mapInfo = rowFor("Map Information Panel");
+    QTreeWidgetItem* selection = rowFor("Selection Panel");
+    REQUIRE(mapInfo != nullptr);
+    REQUIRE(selection != nullptr);
+
+    const QBrush plain = mapInfo->foreground(1);
+
+    // Put Map Info on the Selection panel's key: both rows are now half of a conflict.
+    QMetaObject::invokeMethod(&widget, "onEditFinished", Q_ARG(QTreeWidgetItem*, mapInfo),
+        Q_ARG(QKeySequence, QKeySequence("Alt+2")));
+    CHECK(mapInfo->foreground(1) != plain);
+    CHECK(selection->foreground(1) != plain);
+
+    // Move it somewhere free: neither row is conflicting any more.
+    QMetaObject::invokeMethod(&widget, "onEditFinished", Q_ARG(QTreeWidgetItem*, mapInfo),
+        Q_ARG(QKeySequence, QKeySequence("Ctrl+Alt+J")));
+    CHECK(mapInfo->foreground(1) == plain);
+    CHECK(selection->foreground(1) == plain);
+
+    // A conflicting edit is never committed — it would leave Qt firing neither shortcut.
+    QMetaObject::invokeMethod(&widget, "onEditFinished", Q_ARG(QTreeWidgetItem*, mapInfo),
+        Q_ARG(QKeySequence, QKeySequence("Alt+2")));
+    widget.applyChanges();
+    CHECK(registry.shortcut(actions::PANEL_SELECTION) == QKeySequence("Alt+2"));
+    CHECK(registry.shortcut(actions::PANEL_MAP_INFO) == QKeySequence("Alt+1"));
+}
+
+// The tree is rebuilt on reload/apply, so a filter left in the box has to survive it.
+TEST_CASE("The keybindings page keeps its filter across a rebuild", "[qt][keybindings]") {
+    removeTestSettings();
+
+    auto settings = std::make_shared<Settings>();
+    KeyBindingRegistry registry(settings);
+    KeybindingsWidget widget(&registry);
+
+    auto* tree = widget.findChild<QTreeWidget*>();
+    auto* filter = widget.findChild<QLineEdit*>();
+    REQUIRE(tree != nullptr);
+    REQUIRE(filter != nullptr);
+
+    const auto visibleRows = [tree]() {
+        int count = 0;
+        for (int group = 0; group < tree->topLevelItemCount(); ++group) {
+            QTreeWidgetItem* category = tree->topLevelItem(group);
+            for (int row = 0; row < category->childCount(); ++row) {
+                count += category->child(row)->isHidden() ? 0 : 1;
+            }
+        }
+        return count;
+    };
+
+    filter->setText("Selection Panel");
+    QApplication::processEvents();
+    REQUIRE(visibleRows() == 1);
+
+    widget.reload(); // rebuilds the tree
+    CHECK(filter->text() == "Selection Panel");
+    CHECK(visibleRows() == 1);
 }

--- a/tests/qt/test_ui_regressions.cpp
+++ b/tests/qt/test_ui_regressions.cpp
@@ -10,6 +10,7 @@
 #include <QGroupBox>
 #include <QLabel>
 #include <QStackedWidget>
+#include <QShortcut>
 #include <QSignalSpy>
 #include <QStandardPaths>
 #include <QTemporaryDir>
@@ -38,6 +39,7 @@
 #include "ui/dialogs/ScriptSelectorDialog.h"
 #include "ui/widgets/DataPathsWidget.h"
 #include "ui/widgets/ObjectPreviewWidget.h"
+#include "ui/widgets/SFMLWidget.h"
 #include "ui/widgets/ProInfoPanelWidget.h"
 #include "ui/widgets/ProPreviewPanelWidget.h"
 #include "ui/widgets/WelcomeWidget.h"
@@ -790,6 +792,84 @@ TEST_CASE("MainWindow panel toggles stay wired in the no-map layout", "[qt][main
     REQUIRE_FALSE(selectionAction->isChecked());
 }
 
+// The panel shortcut family: Alt+1..6 on the six managed panels, Alt+` on the Log dock
+// (docs/keybindings-plan.md). Alt+digit rather than Ctrl+digit so Ctrl+1..3 stays free for the
+// elevations and a panel's filter box never swallows the key.
+TEST_CASE("Panel menu actions carry their Alt shortcuts", "[qt][mainwindow][keys]") {
+    removeTestSettings();
+
+    auto resources = std::make_shared<geck::resource::GameResources>();
+    geck::MainWindow window(resources, std::make_shared<geck::Settings>());
+    window.show();
+    QTest::qWait(250);
+
+    struct ExpectedShortcut {
+        const char* actionText;
+        QKeySequence keys;
+    };
+
+    const std::array<ExpectedShortcut, 7> expected = { {
+        { "Map Information", QKeySequence(Qt::ALT | Qt::Key_1) },
+        { "Selection", QKeySequence(Qt::ALT | Qt::Key_2) },
+        { "Scripts", QKeySequence(Qt::ALT | Qt::Key_3) },
+        { "Tile Palette", QKeySequence(Qt::ALT | Qt::Key_4) },
+        { "Object Palette", QKeySequence(Qt::ALT | Qt::Key_5) },
+        { "Virtual File System Browser", QKeySequence(Qt::ALT | Qt::Key_6) },
+        { "Log", QKeySequence(Qt::ALT | Qt::Key_QuoteLeft) },
+    } };
+
+    for (const ExpectedShortcut& entry : expected) {
+        QAction* action = findAction(window, entry.actionText);
+        REQUIRE(action != nullptr);
+        CHECK(action->shortcut() == entry.keys);
+    }
+}
+
+// The reason the panel keys reveal rather than plain-toggle: panels are tabbed, so a dock Qt calls
+// visible may be sitting behind another tab. Toggling would take it away exactly when the user asked
+// to see it.
+TEST_CASE("A panel action raises a tabbed-behind dock instead of hiding it", "[qt][mainwindow][keys]") {
+    removeTestSettings();
+
+    auto resources = std::make_shared<geck::resource::GameResources>();
+    geck::MainWindow window(resources, std::make_shared<geck::Settings>());
+    window.show();
+    QTest::qWait(250);
+
+    auto* mapInfoDock = window.findChild<QDockWidget*>("MapInfoDock");
+    auto* selectionDock = window.findChild<QDockWidget*>("SelectionDock");
+    auto* selectionAction = findAction(window, "Selection");
+    REQUIRE(mapInfoDock != nullptr);
+    REQUIRE(selectionDock != nullptr);
+    REQUIRE(selectionAction != nullptr);
+
+    window.tabifyDockWidget(mapInfoDock, selectionDock);
+    mapInfoDock->show();
+    selectionDock->show();
+    mapInfoDock->raise(); // Map Info is the tab on top, Selection is behind it
+    QApplication::processEvents();
+    QTest::qWait(50);
+
+    REQUIRE_FALSE(selectionDock->isHidden());          // visible to Qt...
+    REQUIRE(selectionDock->visibleRegion().isEmpty()); // ...but not on screen
+
+    selectionAction->trigger();
+    QApplication::processEvents();
+    QTest::qWait(50);
+
+    CHECK_FALSE(selectionDock->isHidden());
+    CHECK_FALSE(selectionDock->visibleRegion().isEmpty()); // raised to the front tab
+    CHECK(selectionAction->isChecked());
+
+    // Now that it is the tab on top, the same action puts it away.
+    selectionAction->trigger();
+    QApplication::processEvents();
+    QTest::qWait(50);
+
+    CHECK(selectionDock->isHidden());
+    CHECK_FALSE(selectionAction->isChecked());
+}
+
 // File > Close Map returns to the welcome screen. It must exist with the standard Close shortcut,
 // and triggering it with nothing open must be a safe no-op (no editor spawned, no crash) — the
 // handler guards on hasActiveMap() before touching the teardown path.
@@ -1322,6 +1402,64 @@ TEST_CASE("EditorWidget switches between the two exit-grid sub-modes", "[qt][exi
 
     editor->setMode(geck::EditorMode::Select);
     CHECK(editor->currentMode() == geck::EditorMode::Select);
+}
+
+// "Inspect the selection": Return (and numpad Enter, a distinct key code) reveals the Selection
+// panel. Both are scoped to the canvas so a Return typed in a panel's filter box is left alone, and
+// both must stand down in MarkExits mode, where Enter finalizes the in-progress Draw-edge polyline
+// (InputHandler). Constructing an EditorWidget eagerly loads art/misc/HEX.frm, so this needs game
+// data mounted; without it we skip.
+TEST_CASE("Inspect-selection keys live on the canvas and stand down in Draw-edge mode", "[qt][mainwindow][keys]") {
+    removeTestSettings();
+
+    auto resources = std::make_shared<geck::resource::GameResources>();
+    geck::MainWindow window(resources, std::make_shared<geck::Settings>());
+    window.show();
+    QTest::qWait(250);
+
+    std::unique_ptr<geck::EditorWidget> editor;
+    try {
+        editor = std::make_unique<geck::EditorWidget>(*resources, makeMap("inspect.map"));
+    } catch (const std::exception& e) {
+        SKIP(std::string("EditorWidget needs mounted game data (HEX.frm): ") + e.what());
+    }
+    window.setEditorWidget(std::move(editor));
+    QApplication::processEvents();
+
+    auto* editorWidget = window.findChild<geck::EditorWidget*>();
+    REQUIRE(editorWidget != nullptr);
+    geck::SFMLWidget* canvas = editorWidget->getSFMLWidget();
+    REQUIRE(canvas != nullptr);
+
+    // The keys hang off the canvas, not the window: WidgetWithChildrenShortcut is what keeps them
+    // out of the panels' text fields.
+    const QList<QShortcut*> canvasShortcuts = canvas->findChildren<QShortcut*>();
+    QList<QKeySequence> keys;
+    for (const QShortcut* shortcut : canvasShortcuts) {
+        CHECK(shortcut->context() == Qt::WidgetWithChildrenShortcut);
+        keys.append(shortcut->key());
+    }
+    CHECK(keys.contains(QKeySequence(Qt::Key_Return)));
+    CHECK(keys.contains(QKeySequence(Qt::Key_Enter)));
+
+    for (const QShortcut* shortcut : canvasShortcuts) {
+        CHECK(shortcut->isEnabled());
+    }
+
+    // Draw edge: Enter belongs to the polyline, so the reveal keys step aside.
+    editorWidget->setMarkExitsMode(true);
+    QApplication::processEvents();
+    REQUIRE(editorWidget->currentMode() == geck::EditorMode::MarkExits);
+    for (const QShortcut* shortcut : canvasShortcuts) {
+        CHECK_FALSE(shortcut->isEnabled());
+    }
+
+    // Leaving the mode hands them back.
+    editorWidget->setMode(geck::EditorMode::Select);
+    QApplication::processEvents();
+    for (const QShortcut* shortcut : canvasShortcuts) {
+        CHECK(shortcut->isEnabled());
+    }
 }
 
 TEST_CASE("MapInfoPanel edits a global variable value and persists it to the map's .gam", "[qt][mapinfo]") {

--- a/tests/qt/test_ui_regressions.cpp
+++ b/tests/qt/test_ui_regressions.cpp
@@ -1442,24 +1442,36 @@ TEST_CASE("Inspect-selection keys live on the canvas and stand down in Draw-edge
     CHECK(keys.contains(QKeySequence(Qt::Key_Return)));
     CHECK(keys.contains(QKeySequence(Qt::Key_Enter)));
 
-    for (const QShortcut* shortcut : canvasShortcuts) {
-        CHECK(shortcut->isEnabled());
-    }
+    // Only these two are asserted on by key rather than sweeping every canvas shortcut, so a
+    // shortcut added later for something else cannot fail this test.
+    const auto shortcutFor = [&canvasShortcuts](const QKeySequence& wanted) -> const QShortcut* {
+        for (const QShortcut* shortcut : canvasShortcuts) {
+            if (shortcut->key() == wanted) {
+                return shortcut;
+            }
+        }
+        return nullptr;
+    };
+
+    const QShortcut* inspectReturn = shortcutFor(QKeySequence(Qt::Key_Return));
+    const QShortcut* inspectEnter = shortcutFor(QKeySequence(Qt::Key_Enter));
+    REQUIRE(inspectReturn != nullptr);
+    REQUIRE(inspectEnter != nullptr);
+    CHECK(inspectReturn->isEnabled());
+    CHECK(inspectEnter->isEnabled());
 
     // Draw edge: Enter belongs to the polyline, so the reveal keys step aside.
     editorWidget->setMarkExitsMode(true);
     QApplication::processEvents();
     REQUIRE(editorWidget->currentMode() == geck::EditorMode::MarkExits);
-    for (const QShortcut* shortcut : canvasShortcuts) {
-        CHECK_FALSE(shortcut->isEnabled());
-    }
+    CHECK_FALSE(inspectReturn->isEnabled());
+    CHECK_FALSE(inspectEnter->isEnabled());
 
     // Leaving the mode hands them back.
     editorWidget->setMode(geck::EditorMode::Select);
     QApplication::processEvents();
-    for (const QShortcut* shortcut : canvasShortcuts) {
-        CHECK(shortcut->isEnabled());
-    }
+    CHECK(inspectReturn->isEnabled());
+    CHECK(inspectEnter->isEnabled());
 }
 
 TEST_CASE("MapInfoPanel edits a global variable value and persists it to the map's .gam", "[qt][mapinfo]") {

--- a/tests/qt/test_ui_regressions.cpp
+++ b/tests/qt/test_ui_regressions.cpp
@@ -40,6 +40,8 @@
 #include "ui/widgets/DataPathsWidget.h"
 #include "ui/widgets/ObjectPreviewWidget.h"
 #include "ui/widgets/SFMLWidget.h"
+#include "ui/input/ActionSpec.h"
+#include "ui/input/KeyBindingRegistry.h"
 #include "ui/widgets/ProInfoPanelWidget.h"
 #include "ui/widgets/ProPreviewPanelWidget.h"
 #include "ui/widgets/WelcomeWidget.h"
@@ -1578,6 +1580,19 @@ TEST_CASE("Inspect-selection keys live on the canvas and stand down in Draw-edge
     QApplication::processEvents();
     CHECK(inspectReturn->isEnabled());
     CHECK(inspectEnter->isEnabled());
+
+    // Numpad Enter is a companion of the reveal key, not a binding of its own: rebind reveal
+    // elsewhere and it clears, so numpad Enter never keeps working a key the user moved away.
+    auto* registry = window.findChild<geck::KeyBindingRegistry*>();
+    REQUIRE(registry != nullptr);
+
+    registry->setShortcut(geck::actions::PANEL_SELECTION_REVEAL, QKeySequence("Ctrl+Alt+I"));
+    CHECK(inspectReturn->key() == QKeySequence("Ctrl+Alt+I"));
+    CHECK(inspectEnter->key().isEmpty());
+
+    registry->resetToDefault(geck::actions::PANEL_SELECTION_REVEAL);
+    CHECK(inspectReturn->key() == QKeySequence(Qt::Key_Return));
+    CHECK(inspectEnter->key() == QKeySequence(Qt::Key_Enter));
 }
 
 TEST_CASE("MapInfoPanel edits a global variable value and persists it to the map's .gam", "[qt][mapinfo]") {

--- a/tests/qt/test_ui_regressions.cpp
+++ b/tests/qt/test_ui_regressions.cpp
@@ -1404,6 +1404,59 @@ TEST_CASE("EditorWidget switches between the two exit-grid sub-modes", "[qt][exi
     CHECK(editor->currentMode() == geck::EditorMode::Select);
 }
 
+// The editor-navigation keys. Elevation is the everyday one: Ctrl+digit, the counterpart of the
+// panels' Alt+digit. They start disabled and updateElevationMenu() enables only what the open map
+// has, so the key is a no-op on a map without that elevation rather than a switch to nothing.
+TEST_CASE("Elevation actions carry Ctrl+digit and stay no-ops until a map has that elevation", "[qt][mainwindow][keys]") {
+    removeTestSettings();
+
+    auto resources = std::make_shared<geck::resource::GameResources>();
+    geck::MainWindow window(resources, std::make_shared<geck::Settings>());
+    window.show();
+    QTest::qWait(250);
+
+    struct ExpectedShortcut {
+        const char* actionText;
+        QKeySequence keys;
+    };
+
+    const std::array<ExpectedShortcut, 3> expected = { {
+        { "Elevation 1", QKeySequence(Qt::CTRL | Qt::Key_1) },
+        { "Elevation 2", QKeySequence(Qt::CTRL | Qt::Key_2) },
+        { "Elevation 3", QKeySequence(Qt::CTRL | Qt::Key_3) },
+    } };
+
+    for (const ExpectedShortcut& entry : expected) {
+        QAction* action = findAction(window, entry.actionText);
+        REQUIRE(action != nullptr);
+        CHECK(action->shortcut() == entry.keys);
+        CHECK_FALSE(action->isEnabled()); // no map open
+    }
+}
+
+// B and R used to be window-scoped QAction shortcuts, which fired while a palette grid or a tree
+// had focus — typing "b" in such a place started placing scroll blockers. Both now live on the
+// canvas, so the actions themselves must carry no shortcut.
+TEST_CASE("Single-letter tool keys are off the window-scoped actions", "[qt][mainwindow][keys]") {
+    removeTestSettings();
+
+    auto resources = std::make_shared<geck::resource::GameResources>();
+    geck::MainWindow window(resources, std::make_shared<geck::Settings>());
+    window.show();
+    QTest::qWait(250);
+
+    for (const char* text : { "Scroll Blocker Rectangle", "Rotate" }) {
+        QAction* action = findAction(window, text);
+        REQUIRE(action != nullptr);
+        CHECK(action->shortcut().isEmpty());
+    }
+
+    // Ctrl+Shift+E is a command, not a single letter, so it stays window-scoped.
+    QAction* editSource = findAction(window, "Edit Script Source");
+    REQUIRE(editSource != nullptr);
+    CHECK(editSource->shortcut() == QKeySequence("Ctrl+Shift+E"));
+}
+
 // "Inspect the selection": Return (and numpad Enter, a distinct key code) reveals the Selection
 // panel. Both are scoped to the canvas so a Return typed in a panel's filter box is left alone, and
 // both must stand down in MarkExits mode, where Enter finalizes the in-progress Draw-edge polyline
@@ -1439,11 +1492,14 @@ TEST_CASE("Inspect-selection keys live on the canvas and stand down in Draw-edge
         CHECK(shortcut->context() == Qt::WidgetWithChildrenShortcut);
         keys.append(shortcut->key());
     }
-    CHECK(keys.contains(QKeySequence(Qt::Key_Return)));
-    CHECK(keys.contains(QKeySequence(Qt::Key_Enter)));
+    for (const QKeySequence& expected : { QKeySequence(Qt::Key_Return), QKeySequence(Qt::Key_Enter),
+             QKeySequence(Qt::Key_S), QKeySequence(Qt::Key_G), QKeySequence(Qt::Key_B),
+             QKeySequence(Qt::Key_R), QKeySequence(Qt::Key_Home), QKeySequence(Qt::Key_F) }) {
+        CHECK(keys.contains(expected));
+    }
 
-    // Only these two are asserted on by key rather than sweeping every canvas shortcut, so a
-    // shortcut added later for something else cannot fail this test.
+    // Shortcuts are looked up by key rather than swept as a group, so one added later for
+    // something else cannot fail this test.
     const auto shortcutFor = [&canvasShortcuts](const QKeySequence& wanted) -> const QShortcut* {
         for (const QShortcut* shortcut : canvasShortcuts) {
             if (shortcut->key() == wanted) {
@@ -1460,12 +1516,37 @@ TEST_CASE("Inspect-selection keys live on the canvas and stand down in Draw-edge
     CHECK(inspectReturn->isEnabled());
     CHECK(inspectEnter->isEnabled());
 
-    // Draw edge: Enter belongs to the polyline, so the reveal keys step aside.
+    // Stamping: R belongs to the viewport, where it cycles the pattern's orientation variants, so
+    // the canvas shortcut stands down and the key falls through to InputHandler. The toolbar
+    // button stays enabled — only the key steps aside.
+    const QShortcut* rotate = shortcutFor(QKeySequence(Qt::Key_R));
+    REQUIRE(rotate != nullptr);
+    QAction* rotateAction = findAction(window, "Rotate");
+    REQUIRE(rotateAction != nullptr);
+
+    editorWidget->setMode(geck::EditorMode::StampPattern);
+    QApplication::processEvents();
+    CHECK_FALSE(rotate->isEnabled());
+    CHECK(rotateAction->isEnabled());
+
+    editorWidget->setMode(geck::EditorMode::Select);
+    QApplication::processEvents();
+    CHECK(rotate->isEnabled());
+
+    // Draw edge: Enter belongs to the polyline, so the two reveal keys step aside.
     editorWidget->setMarkExitsMode(true);
     QApplication::processEvents();
     REQUIRE(editorWidget->currentMode() == geck::EditorMode::MarkExits);
     CHECK_FALSE(inspectReturn->isEnabled());
     CHECK_FALSE(inspectEnter->isEnabled());
+
+    // ...and only those two: the navigation keys are unaffected by the mode.
+    const QShortcut* centerOnPlayer = shortcutFor(QKeySequence(Qt::Key_Home));
+    const QShortcut* fitMap = shortcutFor(QKeySequence(Qt::Key_F));
+    REQUIRE(centerOnPlayer != nullptr);
+    REQUIRE(fitMap != nullptr);
+    CHECK(centerOnPlayer->isEnabled());
+    CHECK(fitMap->isEnabled());
 
     // Leaving the mode hands them back.
     editorWidget->setMode(geck::EditorMode::Select);

--- a/tests/qt/test_ui_regressions.cpp
+++ b/tests/qt/test_ui_regressions.cpp
@@ -1404,6 +1404,31 @@ TEST_CASE("EditorWidget switches between the two exit-grid sub-modes", "[qt][exi
     CHECK(editor->currentMode() == geck::EditorMode::Select);
 }
 
+// Two enabled actions on one key make Qt fire neither and warn about an ambiguous overload, and
+// nothing else notices — the menus and the toolbar both hand out shortcuts, so this sweeps the
+// whole live window rather than just the shipped table.
+TEST_CASE("No two actions in the window share a shortcut", "[qt][mainwindow][keys]") {
+    removeTestSettings();
+
+    auto resources = std::make_shared<geck::resource::GameResources>();
+    geck::MainWindow window(resources, std::make_shared<geck::Settings>());
+    window.show();
+    QTest::qWait(250);
+
+    QHash<QString, QString> owners; // key text -> the action already holding it
+    for (const QAction* action : window.findChildren<QAction*>()) {
+        const QKeySequence keys = action->shortcut();
+        if (keys.isEmpty()) {
+            continue;
+        }
+        const QString text = keys.toString();
+        INFO("key " << text.toStdString() << " wanted by " << normalizeActionText(action->text()).toStdString()
+                    << " and " << owners.value(text).toStdString());
+        CHECK_FALSE(owners.contains(text));
+        owners.insert(text, normalizeActionText(action->text()));
+    }
+}
+
 // The editor-navigation keys. Elevation is the everyday one: Ctrl+digit, the counterpart of the
 // panels' Alt+digit. They start disabled and updateElevationMenu() enables only what the open map
 // has, so the key is a no-op on a map without that elevation rather than a switch to nothing.


### PR DESCRIPTION
Keyboard shortcuts, end to end: the keys the editor was missing, and one table that makes every
one of them remappable. This is `docs/keybindings-plan.md` in full, and `PLAN.md`
"Editor limitations §7".

Previously split across #137, #138 and #139 as a review stack; folded into this one PR. The commits
still read as the three slices, in order.

## The keys

| Key | Action | Scope |
|---|---|---|
| `Alt+1` … `Alt+6` | Map Information / Selection / Scripts / Tile Palette / Object Palette / File Browser | App |
| `` Alt+` `` | Log panel | App |
| `Return`, numpad `Enter` | Inspect the selection (reveal the Selection panel) | Canvas |
| `Ctrl+1` / `Ctrl+2` / `Ctrl+3` | Switch elevation | App |
| `S` | Return to Select mode | Canvas |
| `G` | Toggle hex grid | Canvas |
| `Home` | Centre on player start | Canvas |
| `F` | Fit the whole map in view | Canvas |
| `Ctrl+Shift+E` | Edit the selected object's script source | App |

There was no shortcut to show or focus any panel at all before this, only `View › Panels`, and no
shortcut for elevation — the biggest everyday gap. `Alt+digit` rather than `Ctrl+digit` for panels
so `Ctrl+1..3` stays free for the elevations, and because `Alt+digit` is not text, so a panel's
filter box never swallows it.

## Reveal, not toggle

Panels are tabbed, so "visible" is not the same as "on screen". A plain toggle on a dock sitting
behind another tab would hide the panel just as the user asked to see it. So: hidden → show + raise
+ focus; visible but tabbed behind → raise + focus; visible and on top → hide.

Two details this forced:

- The check state Qt flips before the handler runs is only a *request* — a raise fires no
  `visibilityChanged`, which is the only thing that re-syncs the checkmark. `revealPanel()`
  re-asserts it under a `QSignalBlocker`, and the handler moved from `toggled` to `triggered`.
- Deliberately **no "is it focused" test**. With one, a menu click on a ticked item (focus is
  elsewhere by then) would raise-and-focus instead of hiding, so putting a panel away from the menu
  would take two clicks. Menu behaviour is therefore unchanged, and its existing regression test
  passes untouched.

The Log dock gets its own checkable action rather than Qt's `toggleViewAction()`, which only
plain-toggles.

## `B` and `R` move to the canvas

Both were window-scoped `QAction` shortcuts, so they fired while a palette grid or a tree had focus
— typing "b" in one started placing scroll blockers. They are canvas shortcuts now.

One correction to the plan doc, noted inline: the `_rotateAction->setEnabled(...)` guard **cannot be
deleted, only moved**. A canvas `QShortcut` consumes the key exactly as a window-scoped action
shortcut does, so `R` still has to stand down in `StampPattern` / `PluginTool` for the viewport to
see it (there it cycles a stamp's orientation variants). What the move buys is that the *shortcut*
is disabled instead of the action, so the toolbar button no longer greys out.

## The table

`src/ui/input/ActionSpec.h` — 34 rows of `id / label / category / default / scope`, read by the
menus, the toolbar, the canvas shortcuts and a new Preferences page. `KeyBindingRegistry` holds the
defaults plus the user's overrides and re-keys every registered sink the moment one changes, so a
rebind takes effect with no restart and without walking the menu bar. Sinks are `QPointer`s, since a
canvas shortcut dies with the map view it hangs off.

Decisions worth a look:

- **Ids are strings, not an enum**, because they are what lands in `settings.json`: a reordered enum
  would silently repoint every user's overrides.
- **Only overrides are persisted.** An action left on its default is absent from the file, so
  changing a default in a later release still reaches everyone who never touched it. An action the
  user deliberately unbound persists as an empty string, which is not the same as absent. No
  `SETTINGS_VERSION` bump — an absent `"keyBindings"` already means "no overrides", and moving the
  constant would re-run the 1.0→1.1 data-path migration on every existing install.
- **Platform defaults stay `QKeySequence::StandardKey`** rather than being frozen into the table as
  one platform's answer (`Preferences` is `Ctrl+,` only on macOS; `Quit` is unbound on Windows).
- **Conflicts are checked across both scopes**, not per scope: a window-scoped shortcut fires while
  the canvas has focus too, so two actions on one key would leave Qt firing neither. The Preferences
  page reports one live while the chord is typed and drops it rather than committing it.

## Preferences page

Filter box, tree grouped by category with Action / Shortcut / Default columns, double-click to
capture one chord, customized rows bold, live conflict reporting, Reset and Reset All. Edits are
in-memory until Apply/OK, like the other sections, so Cancel really cancels. Given no registry (the
first-run dialog) the tab is simply omitted.

## Also

- `ViewportController::fitMapInView()` derives the grid's extent from the four corner tiles through
  `coordinatesToScreenPosition()` — the same forward projection the tiles are drawn with, so the two
  cannot drift. The zoom is clamped like any other; at the clamp the map is centred but still
  overflows.
- Resolving an object's SID to its `scripts.lst` program index is now one method on `Map`, shared by
  `Ctrl+Shift+E` and the Selection panel's "Edit Source..." button, so the two cannot disagree about
  which script an object owns.
- The **eyedropper** moves out of `InputHandler`'s tool-key switch to a canvas shortcut — it is a
  canvas command wearing a tool key's clothes. The rest stay: `Esc`, `Space`, `Delete`, the
  Draw-edge `Enter` and the stamp `R` are meaningful only inside their mode, arrive as SFML key
  codes rather than `QKeySequence`, and would produce incoherent states if rebound apart from it.
- **Status-bar hints** take a key lookup, so they name the key that is actually bound instead of the
  shipped one.
- **Help › Keyboard Shortcuts…** opens the page — a jump to the same table rather than a second
  read-only view, so there is nothing to drift. A printable/exportable list was not built.
- `CLAUDE.md` gains a Keyboard Shortcuts section: add a row and bind a sink, never a `QKeySequence`
  literal.

## Tests

`tests/qt/test_keybindings.cpp` (10 cases): table integrity (unique ids, parseable defaults, no
default collisions across scopes); override round-trip, with only the changed entry written and
reset removing it; unbind persisting as unbind; conflicts across scopes and the empty-sequence
exemption; live rebind reaching a bound `QAction` and `QShortcut`; a destroyed sink dropped rather
than dangling; an override for an unknown action discarded; the page listing and filtering the table
and committing only on apply; Reset All clearing a stored override; the dialog tab appearing only
with a registry. Plus a sweep over the live window asserting no two actions share a shortcut — the
failure Qt only reports as a runtime warning.

`tests/general/test_viewport_controller.cpp`: every tile is inside the reported bounds, the fitted
view covers the grid on both axes centred on it, and a viewport too small to ever show the map stops
at `MIN_ZOOM` still centred.

`tests/qt/test_ui_regressions.cpp`: the Alt family is on the actions; a tabbed-behind dock is raised
rather than hidden, and hidden once it is the tab on top; canvas shortcuts are asserted by key
rather than swept as a group, so one added later cannot fail the test; the elevation actions carry
`Ctrl+digit` and are disabled with no map; `B` / `R` carry no window-scoped shortcut while
`Ctrl+Shift+E` does; the canvas `R` stands down while stamping and the toolbar button does not; the
reveal keys stand down in Draw-edge mode and the navigation keys do not.

`qt_tests` 133 cases green, `general_tests` 470 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ogRbvUeVZ5qm3Xck1udrX
