### PR TITLE
Export a searchable index of what is on the maps, containers included

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -678,6 +678,8 @@ if(GECK_BUILD_CLI)
         cli/MapGenerator.cpp
         cli/MapRender.h
         cli/MapRender.cpp
+        cli/MapExport.h
+        cli/MapExport.cpp
         cli/FrmInspect.h
         cli/FrmInspect.cpp
         cli/ResourceInspect.h

--- a/src/cli/MapExport.cpp
+++ b/src/cli/MapExport.cpp
@@ -18,6 +18,7 @@
 #include <spdlog/spdlog.h>
 
 #include <filesystem>
+#include <functional>
 #include <map>
 #include <memory>
 #include <optional>
@@ -248,17 +249,34 @@ int exportEntities(resource::GameResources& resources, const ExportOptions& opti
                 }
                 // Inventory contents are the reason this command exists: a container's items are
                 // invisible to analyze/dump_grid, and "where is X" is usually answered by one.
-                for (const auto& carried : object->inventory) {
-                    if (!carried) {
-                        continue;
-                    }
-                    ordered_json holder;
-                    holder["kind"] = kindOf(object->pro_pid);
-                    holder["pid"] = object->pro_pid;
-                    holder["name"] = protoName(object->pro_pid);
-                    entities.push_back(entityRow(*carried, mapPath, elevation, hex, protoName,
-                        holder, ordered_json(nullptr)));
-                }
+                //
+                // The recursion is defensive rather than load-bearing. A map stores only one level of
+                // inventory — MapReader reads a carried object's own item count but never its items,
+                // exactly as the engine does (fallout2-ce objectLoadAllInternal), so a container
+                // inside a container has nothing under it to read. Written to recurse anyway so this
+                // stays correct if that ever changes, and so the shape of the code matches the shape
+                // of the data it claims to walk.
+                const std::function<void(const MapObject&, const ordered_json&)> emitCarried
+                    = [&](const MapObject& holderObject, const ordered_json& holderRef) {
+                          for (const auto& carried : holderObject.inventory) {
+                              if (!carried) {
+                                  continue;
+                              }
+                              entities.push_back(entityRow(*carried, mapPath, elevation, hex, protoName,
+                                  holderRef,
+                                  scriptOf(*map, carried->map_scripts_pid, scriptsLst, resources)));
+                              ordered_json nested;
+                              nested["kind"] = kindOf(carried->pro_pid);
+                              nested["pid"] = carried->pro_pid;
+                              nested["name"] = protoName(carried->pro_pid);
+                              emitCarried(*carried, nested);
+                          }
+                      };
+                ordered_json holder;
+                holder["kind"] = kindOf(object->pro_pid);
+                holder["pid"] = object->pro_pid;
+                holder["name"] = protoName(object->pro_pid);
+                emitCarried(*object, holder);
             }
         }
     }

--- a/src/cli/MapExport.cpp
+++ b/src/cli/MapExport.cpp
@@ -72,7 +72,7 @@ namespace {
             } catch (const std::exception& e) {
                 spdlog::debug("export: proto {} unreadable: {}", pid, e.what());
             }
-            return _cache.emplace(pid, std::move(info)).first->second;
+            return _cache.try_emplace(pid, std::move(info)).first->second;
         }
 
         const std::map<std::uint32_t, ProtoInfo>& seen() const { return _cache; }
@@ -83,18 +83,19 @@ namespace {
     };
 
     const char* kindOf(std::uint32_t pid) {
+        using enum Pro::OBJECT_TYPE;
         switch (Pro::typeOfPid(pid)) {
-            case Pro::OBJECT_TYPE::ITEM:
+            case ITEM:
                 return "item";
-            case Pro::OBJECT_TYPE::CRITTER:
+            case CRITTER:
                 return "critter";
-            case Pro::OBJECT_TYPE::SCENERY:
+            case SCENERY:
                 return "scenery";
-            case Pro::OBJECT_TYPE::WALL:
+            case WALL:
                 return "wall";
-            case Pro::OBJECT_TYPE::TILE:
+            case TILE:
                 return "tile";
-            case Pro::OBJECT_TYPE::MISC:
+            case MISC:
                 return "misc";
             default:
                 return "unknown";
@@ -105,12 +106,12 @@ namespace {
         if (object.isExitGridMarker()) {
             return true;
         }
+        using enum Pro::OBJECT_TYPE;
         const auto type = Pro::typeOfPid(object.pro_pid);
-        if (type == Pro::OBJECT_TYPE::ITEM || type == Pro::OBJECT_TYPE::CRITTER) {
+        if (type == ITEM || type == CRITTER) {
             return true;
         }
-        return includeScenery
-            && (type == Pro::OBJECT_TYPE::SCENERY || type == Pro::OBJECT_TYPE::WALL);
+        return includeScenery && (type == SCENERY || type == WALL);
     }
 
     // The script attached to an object, as {programIndex, name}, or null. programIndex is the engine's
@@ -185,10 +186,146 @@ namespace {
     }
 } // namespace
 
+namespace {
+    // Collects rows while walking the maps. Holding the walk's state here is what lets
+    // exportEntities read as an outline — set up, walk each map, assemble — instead of six levels of
+    // nesting around a nested lambda.
+    class Collector {
+    public:
+        Collector(resource::GameResources& resources, const ExportOptions& options, const Lst* scriptsLst)
+            : _resources(resources)
+            , _options(options)
+            , _scriptsLst(scriptsLst)
+            , _protos(resources) {
+        }
+
+        void walk(Map& map, const std::string& mapPath) {
+            for (const auto& [elevation, objects] : map.getMapFile().map_objects) {
+                for (const auto& object : objects) {
+                    if (object) {
+                        addObject(map, mapPath, elevation, *object);
+                    }
+                }
+            }
+        }
+
+        Protos& protos() { return _protos; }
+        ordered_json takeEntities() { return std::move(_entities); }
+
+    private:
+        void addObject(Map& map, const std::string& mapPath, int elevation, const MapObject& object) {
+            const int hex = static_cast<int>(object.position);
+            if (isSearchable(object, _options.includeScenery)) {
+                const ordered_json script = scriptOf(map, object.map_scripts_pid, _scriptsLst, _resources);
+                if (_options.groupExits && object.isExitGridMarker()) {
+                    addExit(object, mapPath, elevation, hex, script);
+                } else {
+                    _entities.push_back(
+                        entityRow(object, mapPath, elevation, hex, _protos, ordered_json(nullptr), script));
+                }
+            }
+            // Only describe the holder when there is something to hold. Building it unconditionally
+            // pulls every scenery proto on every map into the proto table, which is how that table
+            // once came out ten times larger than the rows referencing it.
+            if (!object.inventory.empty()) {
+                addCarried(map, object, describe(object), mapPath, elevation, hex);
+            }
+        }
+
+        // One row per exit destination rather than per hex: a doorway is a patch of adjacent hexes
+        // all leading to the same place, so later hexes only increment the count.
+        void addExit(const MapObject& object, const std::string& mapPath, int elevation, int hex,
+            const ordered_json& script) {
+            const ExitKey key{ mapPath, elevation, object.exit_map, object.exit_position,
+                object.exit_elevation };
+            if (const auto it = _exitRows.find(key); it != _exitRows.end()) {
+                _entities[it->second]["hexes"] = _entities[it->second]["hexes"].get<int>() + 1;
+                return;
+            }
+            ordered_json row
+                = entityRow(object, mapPath, elevation, hex, _protos, ordered_json(nullptr), script);
+            row["hexes"] = 1;
+            _exitRows.try_emplace(key, _entities.size());
+            _entities.push_back(std::move(row));
+        }
+
+        // Inventory contents are the reason this command exists: a container's items are invisible to
+        // analyze/dump_grid, and "where is X" is usually answered by one. An item in an inventory has
+        // no position of its own, so it takes its holder's.
+        //
+        // The recursion is defensive rather than load-bearing. A map stores only one level of
+        // inventory — MapReader reads a carried object's own item count but never its items, exactly
+        // as the engine does (fallout2-ce objectLoadAllInternal) — so a container inside a container
+        // has nothing under it to read. Written to recurse anyway so this stays correct if that ever
+        // changes, and so the code is the shape of the data it claims to walk.
+        void addCarried(Map& map, const MapObject& holder, const ordered_json& holderRef,
+            const std::string& mapPath, int elevation, int hex) {
+            for (const auto& carried : holder.inventory) {
+                if (!carried) {
+                    continue;
+                }
+                _entities.push_back(entityRow(*carried, mapPath, elevation, hex, _protos, holderRef,
+                    scriptOf(map, carried->map_scripts_pid, _scriptsLst, _resources)));
+                addCarried(map, *carried, describe(*carried), mapPath, elevation, hex);
+            }
+        }
+
+        ordered_json describe(const MapObject& object) {
+            ordered_json ref;
+            ref["kind"] = kindOf(object.pro_pid);
+            ref["pid"] = object.pro_pid;
+            ref["name"] = _protos(object.pro_pid).name;
+            return ref;
+        }
+
+        resource::GameResources& _resources;
+        const ExportOptions& _options;
+        const Lst* _scriptsLst;
+        Protos _protos;
+        ordered_json _entities = ordered_json::array();
+        // Where each already-emitted exit destination landed in `_entities`.
+        std::map<ExitKey, std::size_t> _exitRows;
+    };
+
+    // The map's own identity: what it is called, and the maps.txt/city.txt keys that join it to the
+    // world layer.
+    ordered_json mapEntry(const std::string& mapPath, const std::optional<resource::MapNameResolver>& names) {
+        const std::string fileName = std::filesystem::path(mapPath).filename().string();
+        const int mapIndex = names.has_value() ? names->indexOf(fileName) : -1;
+        ordered_json entry;
+        entry["file"] = mapPath;
+        entry["name"] = fileName;
+        const std::string display
+            = (names.has_value() && mapIndex >= 0) ? names->displayName(mapIndex, 0) : std::string();
+        entry["displayName"] = display.empty() ? ordered_json(nullptr) : ordered_json(display);
+        entry["mapIndex"] = mapIndex;
+        if (names.has_value() && mapIndex >= 0) {
+            const std::string lookup = names->lookupNameOf(fileName);
+            entry["lookupName"] = lookup.empty() ? ordered_json(nullptr) : ordered_json(lookup);
+        }
+        return entry;
+    }
+
+    // Every distinct proto the walk touched, so a consumer can show what a thing IS — name, the
+    // sentence the game prints on examine, the art to draw — without re-reading the protos itself.
+    ordered_json protoTable(Protos& protos) {
+        auto table = ordered_json::array();
+        for (const auto& [pid, info] : protos.seen()) {
+            ordered_json entry;
+            entry["pid"] = pid;
+            entry["kind"] = kindOf(pid);
+            entry["name"] = info.name;
+            entry["description"] = info.description;
+            entry["fid"] = info.fid;
+            table.push_back(std::move(entry));
+        }
+        return table;
+    }
+} // namespace
+
 int exportEntities(resource::GameResources& resources, const ExportOptions& options, std::ostream& out) {
-    const std::vector<std::string> mapPaths = options.maps.empty()
-        ? listMapPaths(resources.files())
-        : options.maps;
+    const std::vector<std::string> mapPaths
+        = options.maps.empty() ? listMapPaths(resources.files()) : options.maps;
     if (mapPaths.empty()) {
         out << "export: no maps found (is the Fallout 2 data mounted?)\n";
         return 1;
@@ -207,12 +344,8 @@ int exportEntities(resource::GameResources& resources, const ExportOptions& opti
         spdlog::debug("export: no map name resolver: {}", e.what());
     }
 
-    Protos protos(resources);
-    // Where each already-emitted exit destination landed in `entities`, so its hexes can be counted
-    // into the existing row instead of adding another.
-    std::map<ExitKey, std::size_t> exitRows;
+    Collector collector(resources, options, scriptsLst);
     auto maps = ordered_json::array();
-    auto entities = ordered_json::array();
     auto unreadable = ordered_json::array();
 
     for (const auto& mapPath : mapPaths) {
@@ -222,107 +355,14 @@ int exportEntities(resource::GameResources& resources, const ExportOptions& opti
             unreadable.push_back({ { "map", mapPath }, { "reason", loadError } });
             continue;
         }
-
-        const std::string fileName = std::filesystem::path(mapPath).filename().string();
-        const int mapIndex = names.has_value() ? names->indexOf(fileName) : -1;
-        std::string display;
-        if (names.has_value() && mapIndex >= 0) {
-            display = names->displayName(mapIndex, 0);
-        }
-        ordered_json mapEntry;
-        mapEntry["file"] = mapPath;
-        mapEntry["name"] = fileName;
-        mapEntry["displayName"] = display.empty() ? ordered_json(nullptr) : ordered_json(display);
-        mapEntry["mapIndex"] = mapIndex;
-        if (names.has_value() && mapIndex >= 0) {
-            const std::string lookup = names->lookupNameOf(fileName);
-            mapEntry["lookupName"] = lookup.empty() ? ordered_json(nullptr) : ordered_json(lookup);
-        }
-        maps.push_back(std::move(mapEntry));
-
-        for (const auto& [elevation, objects] : map->getMapFile().map_objects) {
-            for (const auto& object : objects) {
-                if (!object) {
-                    continue;
-                }
-                const int hex = static_cast<int>(object->position);
-                const ordered_json script = scriptOf(*map, object->map_scripts_pid, scriptsLst, resources);
-                if (isSearchable(*object, options.includeScenery)) {
-                    if (options.groupExits && object->isExitGridMarker()) {
-                        // One row per destination rather than per hex; count the hexes instead.
-                        const ExitKey key{ mapPath, elevation, object->exit_map,
-                            object->exit_position, object->exit_elevation };
-                        if (const auto it = exitRows.find(key); it != exitRows.end()) {
-                            entities[it->second]["hexes"] = entities[it->second]["hexes"].get<int>() + 1;
-                        } else {
-                            ordered_json row = entityRow(*object, mapPath, elevation, hex, protos,
-                                ordered_json(nullptr), script);
-                            row["hexes"] = 1;
-                            exitRows.emplace(key, entities.size());
-                            entities.push_back(std::move(row));
-                        }
-                    } else {
-                        entities.push_back(entityRow(*object, mapPath, elevation, hex, protos,
-                            ordered_json(nullptr), script));
-                    }
-                }
-                // Inventory contents are the reason this command exists: a container's items are
-                // invisible to analyze/dump_grid, and "where is X" is usually answered by one.
-                //
-                // The recursion is defensive rather than load-bearing. A map stores only one level of
-                // inventory — MapReader reads a carried object's own item count but never its items,
-                // exactly as the engine does (fallout2-ce objectLoadAllInternal), so a container
-                // inside a container has nothing under it to read. Written to recurse anyway so this
-                // stays correct if that ever changes, and so the shape of the code matches the shape
-                // of the data it claims to walk.
-                const std::function<void(const MapObject&, const ordered_json&)> emitCarried
-                    = [&](const MapObject& holderObject, const ordered_json& holderRef) {
-                          for (const auto& carried : holderObject.inventory) {
-                              if (!carried) {
-                                  continue;
-                              }
-                              entities.push_back(entityRow(*carried, mapPath, elevation, hex, protos,
-                                  holderRef,
-                                  scriptOf(*map, carried->map_scripts_pid, scriptsLst, resources)));
-                              ordered_json nested;
-                              nested["kind"] = kindOf(carried->pro_pid);
-                              nested["pid"] = carried->pro_pid;
-                              nested["name"] = protos(carried->pro_pid).name;
-                              emitCarried(*carried, nested);
-                          }
-                      };
-                // Only describe the holder when there is something to hold. Building it
-                // unconditionally would pull every scenery proto on every map into the proto table,
-                // which is how it ended up ten times larger than the rows that reference it.
-                if (!object->inventory.empty()) {
-                    ordered_json holder;
-                    holder["kind"] = kindOf(object->pro_pid);
-                    holder["pid"] = object->pro_pid;
-                    holder["name"] = protos(object->pro_pid).name;
-                    emitCarried(*object, holder);
-                }
-            }
-        }
+        maps.push_back(mapEntry(mapPath, names));
+        collector.walk(*map, mapPath);
     }
 
-    // Every distinct proto the walk touched, so a consumer can show what a thing IS — name, the
-    // sentence the game prints on examine, and the art id to draw — without re-reading the protos
-    // itself. A few hundred entries against tens of thousands of rows, so it is cheap to carry here
-    // and expensive to look up any other way.
-    auto protoTable = ordered_json::array();
-    for (const auto& [pid, info] : protos.seen()) {
-        ordered_json entry;
-        entry["pid"] = pid;
-        entry["kind"] = kindOf(pid);
-        entry["name"] = info.name;
-        entry["description"] = info.description;
-        entry["fid"] = info.fid;
-        protoTable.push_back(std::move(entry));
-    }
-
+    ordered_json entities = collector.takeEntities();
     ordered_json root;
     root["maps"] = std::move(maps);
-    root["protos"] = std::move(protoTable);
+    root["protos"] = protoTable(collector.protos());
     root["mapsUnreadable"] = std::move(unreadable);
     root["entityCount"] = static_cast<int>(entities.size());
     root["entities"] = std::move(entities);

--- a/src/cli/MapExport.cpp
+++ b/src/cli/MapExport.cpp
@@ -148,10 +148,10 @@ namespace {
     // into a single row.
     struct ExitKey {
         std::string map;
-        int elevation;
-        std::uint32_t destMap;
-        std::uint32_t destHex;
-        std::uint32_t destElevation;
+        int elevation = 0;
+        std::uint32_t destMap = 0;
+        std::uint32_t destHex = 0;
+        std::uint32_t destElevation = 0;
         auto operator<=>(const ExitKey&) const = default;
     };
 
@@ -308,7 +308,7 @@ namespace {
 
     // Every distinct proto the walk touched, so a consumer can show what a thing IS — name, the
     // sentence the game prints on examine, the art to draw — without re-reading the protos itself.
-    ordered_json protoTable(Protos& protos) {
+    ordered_json protoTable(const Protos& protos) {
         auto table = ordered_json::array();
         for (const auto& [pid, info] : protos.seen()) {
             ordered_json entry;

--- a/src/cli/MapExport.cpp
+++ b/src/cli/MapExport.cpp
@@ -31,36 +31,55 @@ namespace geck::cli {
 namespace {
     using nlohmann::ordered_json;
 
-    // Proto display name, cached. Same lookup proto_info does: the proto's message_id read out of the
-    // type's .msg file. Kept local rather than reusing MapAnalyzer's NameResolver, which is private to
-    // that translation unit.
-    class ProtoNames {
+    // What a consumer needs to show a proto to a reader: its name, the sentence the game prints when
+    // you examine it, and the art to draw. Cached, since a proto recurs across hundreds of rows.
+    struct ProtoInfo {
+        std::string name;
+        std::string description;
+        std::int32_t fid = 0; // inventory icon for items, the critter's own art otherwise
+    };
+
+    // Same name lookup proto_info does — the proto's message_id read out of the type's .msg file —
+    // plus the description, which the engine stores at message_id + 1. Kept local rather than reusing
+    // MapAnalyzer's NameResolver, which is private to that translation unit.
+    class Protos {
     public:
-        explicit ProtoNames(resource::GameResources& resources)
+        explicit Protos(resource::GameResources& resources)
             : _resources(resources) {
         }
 
-        std::string operator()(std::uint32_t pid) {
+        const ProtoInfo& operator()(std::uint32_t pid) {
             if (const auto it = _cache.find(pid); it != _cache.end()) {
                 return it->second;
             }
-            std::string name;
+            ProtoInfo info;
             try {
                 if (const Pro* pro = _resources.loadPro(pid); pro != nullptr) {
+                    // Prefer an item's inventory icon, and fall back to its world sprite. Containers
+                    // — lockers, footlockers, bookcases, desks — are items by proto type but are never
+                    // carried, so their inventoryFID is -1 and only header.FID has art. That is 108 of
+                    // the 424 item protos, so without the fallback a quarter of them draw nothing.
+                    info.fid = pro->header.FID;
+                    if (Pro::typeOfPid(pid) == Pro::OBJECT_TYPE::ITEM
+                        && pro->commonItemData.inventoryFID >= 0) {
+                        info.fid = pro->commonItemData.inventoryFID;
+                    }
                     if (Msg* msg = ProHelper::msgFile(_resources, pro->type()); msg != nullptr) {
-                        name = msg->message(pro->header.message_id).text;
+                        info.name = msg->message(pro->header.message_id).text;
+                        info.description = msg->message(pro->header.message_id + 1).text;
                     }
                 }
             } catch (const std::exception& e) {
-                spdlog::debug("export: proto {} has no name: {}", pid, e.what());
+                spdlog::debug("export: proto {} unreadable: {}", pid, e.what());
             }
-            _cache.emplace(pid, name);
-            return name;
+            return _cache.emplace(pid, std::move(info)).first->second;
         }
+
+        const std::map<std::uint32_t, ProtoInfo>& seen() const { return _cache; }
 
     private:
         resource::GameResources& _resources;
-        std::unordered_map<std::uint32_t, std::string> _cache;
+        std::map<std::uint32_t, ProtoInfo> _cache;
     };
 
     const char* kindOf(std::uint32_t pid) {
@@ -138,12 +157,12 @@ namespace {
     // One row. `hex` is the object's own position, or — for something inside an inventory, which has no
     // position of its own — the position of whatever is holding it.
     ordered_json entityRow(const MapObject& object, const std::string& mapPath, int elevation,
-        int hex, ProtoNames& protoName, const ordered_json& holder, const ordered_json& script) {
+        int hex, Protos& protos, const ordered_json& holder, const ordered_json& script) {
         ordered_json row;
         row["kind"] = object.isExitGridMarker() ? "exitgrid" : kindOf(object.pro_pid);
         row["pid"] = object.pro_pid;
         row["proto"] = object.pro_pid & 0xFFFFFFu;
-        row["name"] = protoName(object.pro_pid);
+        row["name"] = protos(object.pro_pid).name;
         row["map"] = mapPath;
         row["elevation"] = elevation;
         row["hex"] = hex;
@@ -188,7 +207,7 @@ int exportEntities(resource::GameResources& resources, const ExportOptions& opti
         spdlog::debug("export: no map name resolver: {}", e.what());
     }
 
-    ProtoNames protoName(resources);
+    Protos protos(resources);
     // Where each already-emitted exit destination landed in `entities`, so its hexes can be counted
     // into the existing row instead of adding another.
     std::map<ExitKey, std::size_t> exitRows;
@@ -236,14 +255,14 @@ int exportEntities(resource::GameResources& resources, const ExportOptions& opti
                         if (const auto it = exitRows.find(key); it != exitRows.end()) {
                             entities[it->second]["hexes"] = entities[it->second]["hexes"].get<int>() + 1;
                         } else {
-                            ordered_json row = entityRow(*object, mapPath, elevation, hex, protoName,
+                            ordered_json row = entityRow(*object, mapPath, elevation, hex, protos,
                                 ordered_json(nullptr), script);
                             row["hexes"] = 1;
                             exitRows.emplace(key, entities.size());
                             entities.push_back(std::move(row));
                         }
                     } else {
-                        entities.push_back(entityRow(*object, mapPath, elevation, hex, protoName,
+                        entities.push_back(entityRow(*object, mapPath, elevation, hex, protos,
                             ordered_json(nullptr), script));
                     }
                 }
@@ -262,27 +281,48 @@ int exportEntities(resource::GameResources& resources, const ExportOptions& opti
                               if (!carried) {
                                   continue;
                               }
-                              entities.push_back(entityRow(*carried, mapPath, elevation, hex, protoName,
+                              entities.push_back(entityRow(*carried, mapPath, elevation, hex, protos,
                                   holderRef,
                                   scriptOf(*map, carried->map_scripts_pid, scriptsLst, resources)));
                               ordered_json nested;
                               nested["kind"] = kindOf(carried->pro_pid);
                               nested["pid"] = carried->pro_pid;
-                              nested["name"] = protoName(carried->pro_pid);
+                              nested["name"] = protos(carried->pro_pid).name;
                               emitCarried(*carried, nested);
                           }
                       };
-                ordered_json holder;
-                holder["kind"] = kindOf(object->pro_pid);
-                holder["pid"] = object->pro_pid;
-                holder["name"] = protoName(object->pro_pid);
-                emitCarried(*object, holder);
+                // Only describe the holder when there is something to hold. Building it
+                // unconditionally would pull every scenery proto on every map into the proto table,
+                // which is how it ended up ten times larger than the rows that reference it.
+                if (!object->inventory.empty()) {
+                    ordered_json holder;
+                    holder["kind"] = kindOf(object->pro_pid);
+                    holder["pid"] = object->pro_pid;
+                    holder["name"] = protos(object->pro_pid).name;
+                    emitCarried(*object, holder);
+                }
             }
         }
     }
 
+    // Every distinct proto the walk touched, so a consumer can show what a thing IS — name, the
+    // sentence the game prints on examine, and the art id to draw — without re-reading the protos
+    // itself. A few hundred entries against tens of thousands of rows, so it is cheap to carry here
+    // and expensive to look up any other way.
+    auto protoTable = ordered_json::array();
+    for (const auto& [pid, info] : protos.seen()) {
+        ordered_json entry;
+        entry["pid"] = pid;
+        entry["kind"] = kindOf(pid);
+        entry["name"] = info.name;
+        entry["description"] = info.description;
+        entry["fid"] = info.fid;
+        protoTable.push_back(std::move(entry));
+    }
+
     ordered_json root;
     root["maps"] = std::move(maps);
+    root["protos"] = std::move(protoTable);
     root["mapsUnreadable"] = std::move(unreadable);
     root["entityCount"] = static_cast<int>(entities.size());
     root["entities"] = std::move(entities);

--- a/src/cli/MapExport.cpp
+++ b/src/cli/MapExport.cpp
@@ -144,10 +144,10 @@ namespace {
         return nullptr;
     }
 
-    // Identifies one exit grid by where it leads, so the hexes that make up a single doorway collapse
-    // into a single row.
+    // Identifies one exit grid by where it leads, so the hexes making up a single doorway collapse
+    // into one row. Scoped to a map — the collector clears these between maps — so the map itself is
+    // not part of the key.
     struct ExitKey {
-        std::string map;
         int elevation = 0;
         std::uint32_t destMap = 0;
         std::uint32_t destHex = 0;
@@ -200,6 +200,7 @@ namespace {
         }
 
         void walk(Map& map, const std::string& mapPath) {
+            _exitRows.clear(); // exits are grouped within a map, never across two
             for (const auto& [elevation, objects] : map.getMapFile().map_objects) {
                 for (const auto& object : objects) {
                     if (object) {
@@ -236,7 +237,7 @@ namespace {
         // all leading to the same place, so later hexes only increment the count.
         void addExit(const MapObject& object, const std::string& mapPath, int elevation, int hex,
             const ordered_json& script) {
-            const ExitKey key{ mapPath, elevation, object.exit_map, object.exit_position,
+            const ExitKey key{ elevation, object.exit_map, object.exit_position,
                 object.exit_elevation };
             if (const auto it = _exitRows.find(key); it != _exitRows.end()) {
                 _entities[it->second]["hexes"] = _entities[it->second]["hexes"].get<int>() + 1;

--- a/src/cli/MapExport.cpp
+++ b/src/cli/MapExport.cpp
@@ -1,0 +1,276 @@
+#include "cli/MapExport.h"
+
+#include "cli/MapAnalyzer.h" // listMapPaths
+#include "cli/MapLoad.h"     // loadMap
+#include "editor/HexGeometry.h"
+#include "format/lst/Lst.h"
+#include "format/map/Map.h"
+#include "format/map/MapObject.h"
+#include "format/msg/Msg.h"
+#include "format/pro/Pro.h"
+#include "resource/GameResources.h"
+#include "resource/MapNameResolver.h"
+#include "resource/ResourcePaths.h"
+#include "resource/ScriptNames.h"
+#include "util/ProHelper.h"
+
+#include <nlohmann/json.hpp>
+#include <spdlog/spdlog.h>
+
+#include <filesystem>
+#include <map>
+#include <memory>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <unordered_map>
+
+namespace geck::cli {
+
+namespace {
+    using nlohmann::ordered_json;
+
+    // Proto display name, cached. Same lookup proto_info does: the proto's message_id read out of the
+    // type's .msg file. Kept local rather than reusing MapAnalyzer's NameResolver, which is private to
+    // that translation unit.
+    class ProtoNames {
+    public:
+        explicit ProtoNames(resource::GameResources& resources)
+            : _resources(resources) {
+        }
+
+        std::string operator()(std::uint32_t pid) {
+            if (const auto it = _cache.find(pid); it != _cache.end()) {
+                return it->second;
+            }
+            std::string name;
+            try {
+                if (const Pro* pro = _resources.loadPro(pid); pro != nullptr) {
+                    if (Msg* msg = ProHelper::msgFile(_resources, pro->type()); msg != nullptr) {
+                        name = msg->message(pro->header.message_id).text;
+                    }
+                }
+            } catch (const std::exception& e) {
+                spdlog::debug("export: proto {} has no name: {}", pid, e.what());
+            }
+            _cache.emplace(pid, name);
+            return name;
+        }
+
+    private:
+        resource::GameResources& _resources;
+        std::unordered_map<std::uint32_t, std::string> _cache;
+    };
+
+    const char* kindOf(std::uint32_t pid) {
+        switch (Pro::typeOfPid(pid)) {
+            case Pro::OBJECT_TYPE::ITEM:
+                return "item";
+            case Pro::OBJECT_TYPE::CRITTER:
+                return "critter";
+            case Pro::OBJECT_TYPE::SCENERY:
+                return "scenery";
+            case Pro::OBJECT_TYPE::WALL:
+                return "wall";
+            case Pro::OBJECT_TYPE::TILE:
+                return "tile";
+            case Pro::OBJECT_TYPE::MISC:
+                return "misc";
+            default:
+                return "unknown";
+        }
+    }
+
+    bool isSearchable(const MapObject& object, bool includeScenery) {
+        if (object.isExitGridMarker()) {
+            return true;
+        }
+        const auto type = Pro::typeOfPid(object.pro_pid);
+        if (type == Pro::OBJECT_TYPE::ITEM || type == Pro::OBJECT_TYPE::CRITTER) {
+            return true;
+        }
+        return includeScenery
+            && (type == Pro::OBJECT_TYPE::SCENERY || type == Pro::OBJECT_TYPE::WALL);
+    }
+
+    // The script attached to an object, as {programIndex, name}, or null. programIndex is the engine's
+    // 0-based scripts.lst index (see cli/ScriptIntrospect.h on the index bases).
+    ordered_json scriptOf(const Map& map, std::int32_t sid, const Lst* scriptsLst,
+        resource::GameResources& resources) {
+        if (sid == -1) {
+            return nullptr;
+        }
+        const int section = MapScript::sidSection(static_cast<std::uint32_t>(sid));
+        if (section < 0 || section >= Map::SCRIPT_SECTIONS) {
+            return nullptr;
+        }
+        for (const MapScript& script : map.getMapFile().map_scripts[section]) {
+            if (script.pid != static_cast<std::uint32_t>(sid)) {
+                continue;
+            }
+            const int programIndex = static_cast<int>(script.script_id);
+            std::string name;
+            if (scriptsLst != nullptr && programIndex >= 0
+                && programIndex < static_cast<int>(scriptsLst->list().size())) {
+                name = scriptsLst->at(programIndex);
+            }
+            ordered_json out;
+            out["programIndex"] = programIndex;
+            out["name"] = name;
+            out["description"] = resource::scriptDescription(resources, programIndex);
+            return out;
+        }
+        return nullptr;
+    }
+
+    // Identifies one exit grid by where it leads, so the hexes that make up a single doorway collapse
+    // into a single row.
+    struct ExitKey {
+        std::string map;
+        int elevation;
+        std::uint32_t destMap;
+        std::uint32_t destHex;
+        std::uint32_t destElevation;
+        auto operator<=>(const ExitKey&) const = default;
+    };
+
+    // One row. `hex` is the object's own position, or — for something inside an inventory, which has no
+    // position of its own — the position of whatever is holding it.
+    ordered_json entityRow(const MapObject& object, const std::string& mapPath, int elevation,
+        int hex, ProtoNames& protoName, const ordered_json& holder, const ordered_json& script) {
+        ordered_json row;
+        row["kind"] = object.isExitGridMarker() ? "exitgrid" : kindOf(object.pro_pid);
+        row["pid"] = object.pro_pid;
+        row["proto"] = object.pro_pid & 0xFFFFFFu;
+        row["name"] = protoName(object.pro_pid);
+        row["map"] = mapPath;
+        row["elevation"] = elevation;
+        row["hex"] = hex;
+        row["col"] = hexgrid::columnOf(hex);
+        row["row"] = hexgrid::rowOf(hex);
+        if (object.amount > 1) {
+            row["qty"] = object.amount;
+        }
+        if (!holder.is_null()) {
+            row["holder"] = holder;
+        }
+        if (!script.is_null()) {
+            row["script"] = script;
+        }
+        if (object.isExitGridMarker()) {
+            row["exit"] = { { "map", object.exit_map }, { "hex", object.exit_position },
+                { "elevation", object.exit_elevation } };
+        }
+        return row;
+    }
+} // namespace
+
+int exportEntities(resource::GameResources& resources, const ExportOptions& options, std::ostream& out) {
+    const std::vector<std::string> mapPaths = options.maps.empty()
+        ? listMapPaths(resources.files())
+        : options.maps;
+    if (mapPaths.empty()) {
+        out << "export: no maps found (is the Fallout 2 data mounted?)\n";
+        return 1;
+    }
+
+    const Lst* scriptsLst = nullptr;
+    try {
+        scriptsLst = resources.repository().load<Lst>(ResourcePaths::Lst::SCRIPTS);
+    } catch (const std::exception& e) {
+        spdlog::debug("export: no scripts.lst: {}", e.what());
+    }
+    std::optional<resource::MapNameResolver> names;
+    try {
+        names.emplace(resources);
+    } catch (const std::exception& e) {
+        spdlog::debug("export: no map name resolver: {}", e.what());
+    }
+
+    ProtoNames protoName(resources);
+    // Where each already-emitted exit destination landed in `entities`, so its hexes can be counted
+    // into the existing row instead of adding another.
+    std::map<ExitKey, std::size_t> exitRows;
+    auto maps = ordered_json::array();
+    auto entities = ordered_json::array();
+    auto unreadable = ordered_json::array();
+
+    for (const auto& mapPath : mapPaths) {
+        std::string loadError;
+        const std::unique_ptr<Map> map = loadMap(resources, mapPath, &loadError);
+        if (map == nullptr) {
+            unreadable.push_back({ { "map", mapPath }, { "reason", loadError } });
+            continue;
+        }
+
+        const std::string fileName = std::filesystem::path(mapPath).filename().string();
+        const int mapIndex = names.has_value() ? names->indexOf(fileName) : -1;
+        std::string display;
+        if (names.has_value() && mapIndex >= 0) {
+            display = names->displayName(mapIndex, 0);
+        }
+        ordered_json mapEntry;
+        mapEntry["file"] = mapPath;
+        mapEntry["name"] = fileName;
+        mapEntry["displayName"] = display.empty() ? ordered_json(nullptr) : ordered_json(display);
+        mapEntry["mapIndex"] = mapIndex;
+        if (names.has_value() && mapIndex >= 0) {
+            const std::string lookup = names->lookupNameOf(fileName);
+            mapEntry["lookupName"] = lookup.empty() ? ordered_json(nullptr) : ordered_json(lookup);
+        }
+        maps.push_back(std::move(mapEntry));
+
+        for (const auto& [elevation, objects] : map->getMapFile().map_objects) {
+            for (const auto& object : objects) {
+                if (!object) {
+                    continue;
+                }
+                const int hex = static_cast<int>(object->position);
+                const ordered_json script = scriptOf(*map, object->map_scripts_pid, scriptsLst, resources);
+                if (isSearchable(*object, options.includeScenery)) {
+                    if (options.groupExits && object->isExitGridMarker()) {
+                        // One row per destination rather than per hex; count the hexes instead.
+                        const ExitKey key{ mapPath, elevation, object->exit_map,
+                            object->exit_position, object->exit_elevation };
+                        if (const auto it = exitRows.find(key); it != exitRows.end()) {
+                            entities[it->second]["hexes"] = entities[it->second]["hexes"].get<int>() + 1;
+                        } else {
+                            ordered_json row = entityRow(*object, mapPath, elevation, hex, protoName,
+                                ordered_json(nullptr), script);
+                            row["hexes"] = 1;
+                            exitRows.emplace(key, entities.size());
+                            entities.push_back(std::move(row));
+                        }
+                    } else {
+                        entities.push_back(entityRow(*object, mapPath, elevation, hex, protoName,
+                            ordered_json(nullptr), script));
+                    }
+                }
+                // Inventory contents are the reason this command exists: a container's items are
+                // invisible to analyze/dump_grid, and "where is X" is usually answered by one.
+                for (const auto& carried : object->inventory) {
+                    if (!carried) {
+                        continue;
+                    }
+                    ordered_json holder;
+                    holder["kind"] = kindOf(object->pro_pid);
+                    holder["pid"] = object->pro_pid;
+                    holder["name"] = protoName(object->pro_pid);
+                    entities.push_back(entityRow(*carried, mapPath, elevation, hex, protoName,
+                        holder, ordered_json(nullptr)));
+                }
+            }
+        }
+    }
+
+    ordered_json root;
+    root["maps"] = std::move(maps);
+    root["mapsUnreadable"] = std::move(unreadable);
+    root["entityCount"] = static_cast<int>(entities.size());
+    root["entities"] = std::move(entities);
+    // Fallout 2 text is CP-1252; `replace` keeps dump() from throwing on stray bytes.
+    out << root.dump(-1, ' ', false, ordered_json::error_handler_t::replace) << "\n";
+    return 0;
+}
+
+} // namespace geck::cli

--- a/src/cli/MapExport.h
+++ b/src/cli/MapExport.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <iosfwd>
+#include <string>
+#include <vector>
+
+namespace geck {
+namespace resource {
+    class GameResources;
+}
+
+namespace cli {
+
+    struct ExportOptions {
+        /// Maps to walk (VFS paths, e.g. "maps/klamall.map"); empty = every mounted map.
+        std::vector<std::string> maps;
+        /// Also emit scenery and walls. Off by default: they are 98% of the records and nothing
+        /// searches for a wall segment. See the note in exportEntities.
+        bool includeScenery = false;
+        /// Collapse each exit grid's hexes into one row per destination. A doorway is drawn as a
+        /// patch of adjacent exit-grid hexes that all lead to the same place; ungrouped they are 71%
+        /// of the index (28,767 rows across the shipped maps) and say nothing 423 rows do not.
+        bool groupExits = true;
+    };
+
+    /// Walk the mounted maps and emit a flat, searchable index of everything a player might look
+    /// for: items, critters and exit grids, each with the map, elevation and hex it sits on.
+    ///
+    /// The point of this over `analyze` / `dump_grid` is CONTAINER CONTENTS. Those report the objects
+    /// standing on a map; this one recurses into inventories, so a pair of boots inside a locker is a
+    /// row of its own, carrying the locker as its `holder` and the locker's hex as its position. An
+    /// item in an inventory has no meaningful position of its own, so it inherits its holder's.
+    ///
+    /// Scenery and walls are excluded by default. Across the shipped maps they are roughly 98% of all
+    /// object records, and the remaining 2% — items and critters — is what anyone actually searches.
+    /// Emitting everything turns a few hundred KB of index into tens of MB for no gain.
+    ///
+    /// Emits one JSON object to `out`: { maps: [...], entities: [...] }. Returns 0 on success,
+    /// non-zero if no maps were found. Maps that fail to parse are reported in `mapsUnreadable`
+    /// rather than skipped silently — an absent item is only meaningful if that list is empty.
+    int exportEntities(resource::GameResources& resources, const ExportOptions& options, std::ostream& out);
+
+} // namespace cli
+} // namespace geck

--- a/src/cli/MapExport.h
+++ b/src/cli/MapExport.h
@@ -35,9 +35,15 @@ namespace cli {
     /// object records, and the remaining 2% — items and critters — is what anyone actually searches.
     /// Emitting everything turns a few hundred KB of index into tens of MB for no gain.
     ///
-    /// Emits one JSON object to `out`: { maps: [...], entities: [...] }. Returns 0 on success,
-    /// non-zero if no maps were found. Maps that fail to parse are reported in `mapsUnreadable`
-    /// rather than skipped silently — an absent item is only meaningful if that list is empty.
+    /// Emits one JSON object to `out`:
+    ///   { maps: [{file,name,displayName,mapIndex,lookupName}],
+    ///     mapsUnreadable: [{map,reason}],
+    ///     entityCount: N,
+    ///     entities: [{kind,pid,proto,name,map,elevation,hex,col,row,qty?,holder?,script?,exit?,hexes?}] }
+    ///
+    /// Returns 0 on success, non-zero if no maps were found. Maps that fail to parse are reported in
+    /// `mapsUnreadable` rather than skipped silently — an absent item is only meaningful if that list
+    /// is empty.
     int exportEntities(resource::GameResources& resources, const ExportOptions& options, std::ostream& out);
 
 } // namespace cli

--- a/src/cli/MapExport.h
+++ b/src/cli/MapExport.h
@@ -37,6 +37,7 @@ namespace cli {
     ///
     /// Emits one JSON object to `out`:
     ///   { maps: [{file,name,displayName,mapIndex,lookupName}],
+    ///     protos: [{pid,kind,name,description,fid}],
     ///     mapsUnreadable: [{map,reason}],
     ///     entityCount: N,
     ///     entities: [{kind,pid,proto,name,map,elevation,hex,col,row,qty?,holder?,script?,exit?,hexes?}] }

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -12,6 +12,7 @@
 #include "cli/Endings.h"
 #include "cli/GvarRefs.h"
 #include "cli/FrmInspect.h"
+#include "cli/MapExport.h"
 #include "cli/MapGenerator.h"
 #include "cli/MapReachability.h"
 #include "cli/MapRender.h"
@@ -281,6 +282,16 @@ namespace {
         opts.resolveOnly = optBool(args, "resolveOnly", false);
         std::ostringstream oss;
         const int rc = cli::findScript(resources, opts, oss);
+        return toolText(oss.str(), rc != 0);
+    }
+
+    json toolExportEntities(resource::GameResources& resources, const json& args) {
+        cli::ExportOptions opts;
+        opts.maps = optMaps(args);
+        opts.includeScenery = optBool(args, "includeScenery", false);
+        opts.groupExits = optBool(args, "groupExits", true);
+        std::ostringstream oss;
+        const int rc = cli::exportEntities(resources, opts, oss);
         return toolText(oss.str(), rc != 0);
     }
 
@@ -705,6 +716,20 @@ namespace {
             "resolveOnly.",
             json({ { "type", "object" }, { "properties", { { "name", { { "type", "string" } } }, { "programIndex", { { "type", "integer" } } }, { "maps", { { "type", "array" }, { "items", { { "type", "string" } } } } }, { "resolveOnly", { { "type", "boolean" } } } } }, { "anyOf", json::array({ json{ { "required", json::array({ "name" }) } }, json{ { "required", json::array({ "programIndex" }) } } }) } }),
             [](resource::GameResources& r, const json& a) { return toolFindScript(r, a); }, "" });
+        t.push_back({ "export_entities",
+            "Walk the maps and emit a flat, searchable index of everything a player might look for: "
+            "items, critters and exit grids, each as {kind,pid,name,map,elevation,hex,col,row} with "
+            "the attached script where there is one. Unlike analyze and dump_grid it RECURSES INTO "
+            "INVENTORIES, so an item inside a locker or carried by a critter is a row of its own, "
+            "carrying its 'holder' and standing at the holder's hex — which is how you answer where "
+            "is X. Scenery and walls are omitted by default: they are ~98% of all object records and "
+            "nobody searches for a wall (pass includeScenery=true if you really want them). Also "
+            "returns 'mapsUnreadable', so an absent item can be told apart from an unread map. Exit grids "
+            "are grouped one row per destination with a 'hexes' count, since a doorway is a patch of "
+            "adjacent hexes all leading to the same place — pass groupExits=false for one row per hex. "
+            "Args: optional maps (array; default every mounted map), includeScenery, groupExits.",
+            json({ { "type", "object" }, { "properties", { { "maps", { { "type", "array" }, { "items", { { "type", "string" } } } } }, { "includeScenery", { { "type", "boolean" } } }, { "groupExits", { { "type", "boolean" } } } } } }),
+            [](resource::GameResources& r, const json& a) { return toolExportEntities(r, a); }, "" });
         t.push_back({ "find_text",
             "Search the mounted game text for a pattern and get every hit back with the script it "
             "belongs to — answers which script mentions X in one call, instead of grepping a checkout. "

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -716,7 +716,7 @@ namespace {
             "resolveOnly.",
             json({ { "type", "object" }, { "properties", { { "name", { { "type", "string" } } }, { "programIndex", { { "type", "integer" } } }, { "maps", { { "type", "array" }, { "items", { { "type", "string" } } } } }, { "resolveOnly", { { "type", "boolean" } } } } }, { "anyOf", json::array({ json{ { "required", json::array({ "name" }) } }, json{ { "required", json::array({ "programIndex" }) } } }) } }),
             [](resource::GameResources& r, const json& a) { return toolFindScript(r, a); }, "" });
-        t.push_back({ "export_entities",
+        t.push_back({ "export_entities", // NOSONAR: braced-init of the tool descriptor; emplace_back would need C++20 paren-aggregate-init
             "Walk the maps and emit a flat, searchable index of everything a player might look for: "
             "items, critters and exit grids, each as {kind,pid,name,map,elevation,hex,col,row} with "
             "the attached script where there is one. Unlike analyze and dump_grid it RECURSES INTO "

--- a/tests/general/test_mcp_server.cpp
+++ b/tests/general/test_mcp_server.cpp
@@ -36,7 +36,7 @@ TEST_CASE("McpServer speaks JSON-RPC and exposes the tools", "[mcp]") {
             names.push_back(tool["name"].get<std::string>());
             CHECK(tool.contains("inputSchema"));
         }
-        for (const char* expected : { "list_maps", "analyze", "palette", "proto_info", "describe_script", "find_script", "find_text", "reachability", "describe_map", "map_graph", "world_map", "world_encounters", "quests", "gvars", "endings", "find_gvar", "generate", "render_map", "extract_pattern", "script_api", "frm_info", "resolve_fid", "list_frms", "render_frm", "resource_find", "resource_list", "resource_missing" }) {
+        for (const char* expected : { "list_maps", "analyze", "palette", "proto_info", "describe_script", "find_script", "find_text", "export_entities", "reachability", "describe_map", "map_graph", "world_map", "world_encounters", "quests", "gvars", "endings", "find_gvar", "generate", "render_map", "extract_pattern", "script_api", "frm_info", "resolve_fid", "list_frms", "render_frm", "resource_find", "resource_list", "resource_missing" }) {
             CHECK(std::find(names.begin(), names.end(), expected) != names.end());
         }
     }
@@ -80,6 +80,16 @@ TEST_CASE("McpServer speaks JSON-RPC and exposes the tools", "[mcp]") {
             const auto text = resp["result"]["content"][0]["text"].get<std::string>();
             CHECK(text.find("1-based") != std::string::npos);
         }
+    }
+
+    // Scenery and walls are ~98% of every map's object records and nobody searches for a wall, so the
+    // export omits them unless asked. With no data mounted the call still has to answer cleanly.
+    SECTION("export_entities reports missing data rather than failing oddly") {
+        const json resp = server.handleMessage({ { "jsonrpc", "2.0" }, { "id", 8 }, { "method", "tools/call" },
+            { "params", { { "name", "export_entities" }, { "arguments", json::object() } } } });
+        CHECK(resp["result"]["isError"] == true);
+        const auto text = resp["result"]["content"][0]["text"].get<std::string>();
+        CHECK(text.find("no maps") != std::string::npos);
     }
 
     SECTION("find_text requires a pattern") {


### PR DESCRIPTION
First step of a searchable item/critter database for the guide. `analyze` and `dump_grid` report the objects *standing on* a map; neither opens a container, so "where is X" — usually answered by something inside a locker or carried by a critter — cannot be asked of them at all.

`export_entities` emits one flat row per thing a player might look for:

```
export_entities({maps: ["/maps/klamall.map"]})

{"kind":"item","pid":262,"name":"Rubber Boots","map":"/maps/klamall.map",
 "elevation":0,"hex":15283,"col":83,"row":76,
 "holder":{"kind":"item","pid":189,"name":"Locker"}}
```

Items in an inventory have no position of their own, so they inherit their holder's hex and carry the holder in the row.

## What is left out, and why

Both decisions were measured against the shipped maps rather than guessed.

| | Rows | |
| --- | --- | --- |
| All object records | 627,024 | |
| — scenery and walls | 615,740 | **98%** — omitted unless `includeScenery` |
| Exit-grid hexes | 28,767 | grouped to **423** logical exits |
| **Emitted** | **12,324** | items 8,922 · critters 2,979 · exits 423 |

A doorway is drawn as a patch of adjacent exit-grid hexes that all lead to the same place, so grouping by destination with a `hexes` count loses nothing and removes 71% of the index. `groupExits=false` restores per-hex rows.

## Size

**12,324 rows over all 176 maps in ~3 seconds — 2.3 MB of JSON, 167 KB gzipped.** Small enough that a consumer needs no database, no WASM and no server: it can fetch the file and search it in memory.

`mapsUnreadable` is reported rather than skipped, as in `find_script` — an item that appears nowhere only means something if every map was read. Currently zero, since #134 fixed the two EPA maps.

## Testing

`ctest`: 478/478. Verified end to end against a case with a known answer: both pairs of rubber boots in the Trapper Town lockers come back with the right holder and hexes.