### PR TITLE
frm render --transparent, for extracting a sprite rather than looking at it

### DIFF
--- a/src/cli/FrmInspect.cpp
+++ b/src/cli/FrmInspect.cpp
@@ -227,14 +227,17 @@ namespace {
         return plan;
     }
 
-    // Draw one frame's sprite (a sub-rect of the stitched sheet) into its cell, on a checkerboard.
+    // Draw one frame's sprite (a sub-rect of the stitched sheet) into its cell, on a checkerboard
+    // unless the caller wants the sprite on its own.
     void drawFrameCell(sf::RenderTarget& target, const sf::Texture& sheet, const Frm& frm,
-        std::size_t dir, std::size_t frameIdx, float cellX, float cellY) {
+        std::size_t dir, std::size_t frameIdx, float cellX, float cellY, bool checkerboard) {
         const int maxW = frm.maxFrameWidth();
         const int maxH = frm.maxFrameHeight();
-        sf::VertexArray bg(sf::PrimitiveType::Triangles);
-        appendCheckerboard(bg, cellX, cellY, static_cast<float>(maxW), static_cast<float>(maxH));
-        target.draw(bg);
+        if (checkerboard) {
+            sf::VertexArray bg(sf::PrimitiveType::Triangles);
+            appendCheckerboard(bg, cellX, cellY, static_cast<float>(maxW), static_cast<float>(maxH));
+            target.draw(bg);
+        }
 
         const auto& dirFrames = frm.directions()[dir].frames();
         if (frameIdx >= dirFrames.size()) {
@@ -254,7 +257,7 @@ namespace {
     };
 
     GridImage renderGrid(resource::GameResources& resources, const std::string& artPath,
-        const Frm& frm, const GridPlan& plan) {
+        const Frm& frm, const GridPlan& plan, bool checkerboard) {
         const int maxW = frm.maxFrameWidth();
         const int maxH = frm.maxFrameHeight();
         constexpr int pad = 4;
@@ -266,7 +269,9 @@ namespace {
             throw std::runtime_error("could not create a " + std::to_string(width) + "x" + std::to_string(height)
                 + " off-screen render target — no GL context (headless without a display?)");
         }
-        target->clear(sf::Color(40, 40, 40));
+        // Clearing to transparent rather than grey is what makes the extracted sprite usable as an
+        // asset; with the checkerboard on, the grey is what you want behind it.
+        target->clear(checkerboard ? sf::Color(40, 40, 40) : sf::Color::Transparent);
 
         // The stitched sheet (every direction x frame) — slice per-frame sub-rects out of it. Keyed by
         // the full art path so the TextureManager finds the same parsed FRM and palette the editor uses.
@@ -276,7 +281,7 @@ namespace {
             for (std::size_t col = 0; col < plan.frames.size(); ++col) {
                 const float cellX = static_cast<float>(pad + static_cast<int>(col) * (maxW + pad));
                 const float cellY = static_cast<float>(pad + static_cast<int>(row) * (maxH + pad));
-                drawFrameCell(*target, sheet, frm, plan.dirs[row], plan.frames[col], cellX, cellY);
+                drawFrameCell(*target, sheet, frm, plan.dirs[row], plan.frames[col], cellX, cellY, checkerboard);
             }
         }
         target->display();
@@ -407,7 +412,7 @@ int frmRender(resource::GameResources& resources, const FrmRenderOptions& option
             out << "frm render: nothing to draw (direction/frame filter out of range)\n";
             return 1;
         }
-        const GridImage grid = renderGrid(resources, *artPath, *loaded.frm, plan);
+        const GridImage grid = renderGrid(resources, *artPath, *loaded.frm, plan, options.checkerboard);
         if (!grid.image.saveToFile(options.outPath)) {
             out << "frm render: failed to write image: " << options.outPath << "\n";
             return 1;

--- a/src/cli/FrmInspect.cpp
+++ b/src/cli/FrmInspect.cpp
@@ -230,7 +230,9 @@ namespace {
     // Draw one frame's sprite (a sub-rect of the stitched sheet) into its cell, on a checkerboard
     // unless the caller wants the sprite on its own.
     void drawFrameCell(sf::RenderTarget& target, const sf::Texture& sheet, const Frm& frm,
-        std::size_t dir, std::size_t frameIdx, float cellX, float cellY, bool checkerboard) {
+        std::size_t dir, std::size_t frameIdx, sf::Vector2f cell, bool checkerboard) {
+        const float cellX = cell.x;
+        const float cellY = cell.y;
         const int maxW = frm.maxFrameWidth();
         const int maxH = frm.maxFrameHeight();
         if (checkerboard) {
@@ -281,7 +283,7 @@ namespace {
             for (std::size_t col = 0; col < plan.frames.size(); ++col) {
                 const float cellX = static_cast<float>(pad + static_cast<int>(col) * (maxW + pad));
                 const float cellY = static_cast<float>(pad + static_cast<int>(row) * (maxH + pad));
-                drawFrameCell(*target, sheet, frm, plan.dirs[row], plan.frames[col], cellX, cellY, checkerboard);
+                drawFrameCell(*target, sheet, frm, plan.dirs[row], plan.frames[col], { cellX, cellY }, checkerboard);
             }
         }
         target->display();

--- a/src/cli/FrmInspect.h
+++ b/src/cli/FrmInspect.h
@@ -22,6 +22,10 @@ namespace cli {
         int direction = -1;
         /// Render a single frame index only; <0 means every frame of each rendered direction.
         int frame = -1;
+        /// Draw the sprite on a checkerboard so its transparent edges are visible. On by default,
+        /// which is what you want when inspecting art. Turn it off to extract the sprite as an asset:
+        /// the output then keeps real alpha instead of a baked-in grey background.
+        bool checkerboard = true;
     };
 
     /// Parse a numeric FID written as hex (0x...) or decimal. nullopt when the whole token is not a

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -145,6 +145,8 @@ void printUsage(const char* program) {
               << "      Render the sprite to a PNG (needs an off-screen GL context). Default: a grid of all\n"
               << "      6 directions x all frames on a checkerboard. --dir N renders one direction; --frame N\n"
               << "      one frame index. Reports the output path, image size, and grid layout (DxF).\n"
+              << "      --transparent drops the checkerboard and keeps real alpha, for extracting a sprite\n"
+              << "      as an asset rather than looking at it.\n"
               << "  " << program << " frm resolve <fid> --data <dir-or-.dat> [--data <...>]\n"
               << "      Decode a FID (0x.. hex or decimal) to JSON {fid, type, index, artPath}.\n"
               << "  " << program << " frm list <glob> --data <dir-or-.dat> [--data <...>]\n"

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -140,7 +140,7 @@ void printUsage(const char* program) {
               << "      FRM metadata as JSON: resolvedArtPath, fid, directionCount, framesPerDirection, and a\n"
               << "      per-frame array of {direction,frame,width,height,offsetX,offsetY}. Accepts an art name\n"
               << "      (ext2grd1 or art/misc/ext2grd1.frm) or a FID (0x05000021 / decimal).\n"
-              << "  " << program << " frm render <name-or-fid> --out <file.png> [--dir N] [--frame N]\n"
+              << "  " << program << " frm render <name-or-fid> --out <file.png> [--dir N] [--frame N] [--transparent]\n"
               << "      --data <dir-or-.dat> [--data <...>]\n"
               << "      Render the sprite to a PNG (needs an off-screen GL context). Default: a grid of all\n"
               << "      6 directions x all frames on a checkerboard. --dir N renders one direction; --frame N\n"
@@ -613,6 +613,7 @@ struct FrmArgs {
     std::string outPath;
     int direction = -1;
     int frame = -1;
+    bool checkerboard = true;
     std::vector<std::string> dataPaths;
 };
 
@@ -640,6 +641,11 @@ bool applyFrmValueFlag(const std::string& flag, const std::string& value, FrmArg
 bool parseFrmArgs(const std::vector<std::string>& args, const char* program, FrmArgs& out) {
     for (std::size_t i = 2; i < args.size();) {
         const std::string& arg = args[i];
+        if (arg == "--transparent") {
+            out.checkerboard = false;
+            ++i;
+            continue;
+        }
         const bool valueFlag = arg == "--data" || arg == "--out" || arg == "--dir" || arg == "--frame";
         if (valueFlag && i + 1 >= args.size()) {
             std::cerr << "error: " << arg << " needs a value\n";
@@ -692,6 +698,7 @@ int dispatchFrm(geck::resource::GameResources& resources, const FrmArgs& fa) {
     opts.outPath = fa.outPath;
     opts.direction = fa.direction;
     opts.frame = fa.frame;
+    opts.checkerboard = fa.checkerboard;
     return geck::cli::frmRender(resources, opts, std::cout);
 }
 


### PR DESCRIPTION
`frm render` draws every sprite on a checkerboard so its transparent edges are visible. That is the right default while inspecting art — but it is *drawn*, not alpha, so it ends up **baked into the PNG**:

```
frm render 0x0100000F --dir 0 --frame 0 --out brahmin.png
  -> first pixel RGBA = (40, 40, 40, 255)     a grey checkerboard square

frm render 0x0100000F --dir 0 --frame 0 --transparent --out brahmin.png
  -> first pixel RGBA = (0, 0, 0, 0)          actual transparency
```

So anyone extracting sprites as assets — icons for a page, art for a tool — gets a chequered rectangle behind every one, with no way to ask for otherwise.

`--transparent` skips the checkerboard and clears the render target to transparent instead of grey. The default is unchanged, so inspection keeps the background that makes edges readable.

Found while pulling 799 item and critter sprites for a guide's object database, where every icon had arrived with a grey background.

`ctest`: 478/478.