### PR TITLE
Report the world-to-pixel mapping a render was drawn with

### DIFF
--- a/src/cli/MapRender.cpp
+++ b/src/cli/MapRender.cpp
@@ -78,13 +78,19 @@ int renderMap(resource::GameResources& resources, const RenderOptions& options, 
     try {
         MapRenderer renderer(resources);
         MapRenderer::Legend legend;
-        const sf::Image image = renderer.renderToImage(*map, renderOptions, wantLegend ? &legend : nullptr);
+        MapRenderer::Projection projection;
+        const sf::Image image
+            = renderer.renderToImage(*map, renderOptions, wantLegend ? &legend : nullptr, &projection);
         if (!image.saveToFile(options.outPath)) {
             out << "render: failed to write image: " << options.outPath << "\n";
             return 1;
         }
         const sf::Vector2u size = image.getSize();
         out << "wrote " << options.outPath << " (" << size.x << "x" << size.y << ")\n";
+        // The world->pixel mapping, so an overlay can place a marker on a hex without re-deriving
+        // the framing: px = (hex.x - originX) * scale, py = (hex.y - originY) * scale.
+        out << "projection origin=" << projection.originX << "," << projection.originY
+            << " scale=" << projection.scale << "\n";
         if (wantLegend) {
             printLegend(legend, out);
         }

--- a/src/rendering/MapRenderer.cpp
+++ b/src/rendering/MapRenderer.cpp
@@ -440,7 +440,8 @@ MapRenderer::MapRenderer(resource::GameResources& resources)
 
 sf::Image MapRenderer::renderToImage(Map& map, const Options& options, Legend* legend,
     Projection* projection) {
-    if (options.style == Style::Schematic || options.style == Style::Objects || options.style == Style::Semantic) {
+    using enum Style;
+    if (options.style == Schematic || options.style == Objects || options.style == Semantic) {
         return renderSchematic(map, options, legend, projection);
     }
     return renderNatural(map, options, projection);

--- a/src/rendering/MapRenderer.cpp
+++ b/src/rendering/MapRenderer.cpp
@@ -58,6 +58,9 @@ namespace {
         unsigned int width = 1;
         unsigned int height = 1;
         sf::View view;
+        float originX = 0.0f; // world-space top-left, and the world->pixel factor: the overlay
+        float originY = 0.0f; // needs both to place a marker, and only this function knows them
+        float scale = 1.0f;
     };
     Frame computeFrame(Bounds bounds, unsigned int maxDimension, bool allowUpscale = false) {
         constexpr float pad = 8.0f;
@@ -72,7 +75,18 @@ namespace {
         frame.width = static_cast<unsigned int>(std::max(1.0f, bboxWidth * scale));
         frame.height = static_cast<unsigned int>(std::max(1.0f, bboxHeight * scale));
         frame.view = sf::View(sf::FloatRect({ bounds.minX, bounds.minY }, { bboxWidth, bboxHeight }));
+        frame.originX = bounds.minX;
+        frame.originY = bounds.minY;
+        frame.scale = scale;
         return frame;
+    }
+
+    void reportProjection(MapRenderer::Projection* out, const Frame& frame) {
+        if (out != nullptr) {
+            out->originX = frame.originX;
+            out->originY = frame.originY;
+            out->scale = frame.scale;
+        }
     }
 
     // An off-screen render target sized to `frame`, or a runtime_error when no GL context is available.
@@ -424,14 +438,15 @@ MapRenderer::MapRenderer(resource::GameResources& resources)
     : _resources(resources) {
 }
 
-sf::Image MapRenderer::renderToImage(Map& map, const Options& options, Legend* legend) {
+sf::Image MapRenderer::renderToImage(Map& map, const Options& options, Legend* legend,
+    Projection* projection) {
     if (options.style == Style::Schematic || options.style == Style::Objects || options.style == Style::Semantic) {
-        return renderSchematic(map, options, legend);
+        return renderSchematic(map, options, legend, projection);
     }
-    return renderNatural(map, options);
+    return renderNatural(map, options, projection);
 }
 
-sf::Image MapRenderer::renderNatural(Map& map, const Options& options) {
+sf::Image MapRenderer::renderNatural(Map& map, const Options& options, Projection* projection) {
     // Build the map's sprites headlessly — the same loader the editor uses.
     HexagonGrid hexgrid;
     MapSpriteLoader loader(_resources, hexgrid);
@@ -472,7 +487,9 @@ sf::Image MapRenderer::renderNatural(Map& map, const Options& options) {
         }
     }
 
-    const std::unique_ptr<sf::RenderTexture> target = makeTarget(computeFrame(bounds, options.maxDimension, options.hasCrop));
+    const auto frame = computeFrame(bounds, options.maxDimension, options.hasCrop);
+    reportProjection(projection, frame);
+    const std::unique_ptr<sf::RenderTexture> target = makeTarget(frame);
     target->clear(options.background);
 
     RenderingEngine engine(_resources);
@@ -519,7 +536,8 @@ sf::Image MapRenderer::renderNatural(Map& map, const Options& options) {
     return target->getTexture().copyToImage();
 }
 
-sf::Image MapRenderer::renderSchematic(Map& map, const Options& options, Legend* legend) {
+sf::Image MapRenderer::renderSchematic(Map& map, const Options& options, Legend* legend,
+    Projection* projection) {
     const auto& allTiles = map.getMapFile().tiles;
     const auto tilesIt = allTiles.find(options.elevation);
     const std::vector<Tile> noTiles;
@@ -556,7 +574,9 @@ sf::Image MapRenderer::renderSchematic(Map& map, const Options& options, Legend*
         throw std::runtime_error("map has nothing to render at elevation " + std::to_string(options.elevation));
     }
 
-    const std::unique_ptr<sf::RenderTexture> target = makeTarget(computeFrame(bounds, options.maxDimension));
+    const auto frame = computeFrame(bounds, options.maxDimension);
+    reportProjection(projection, frame);
+    const std::unique_ptr<sf::RenderTexture> target = makeTarget(frame);
     target->clear(options.background);
     target->draw(floor);
     if (semantic) {

--- a/src/rendering/MapRenderer.h
+++ b/src/rendering/MapRenderer.h
@@ -96,11 +96,24 @@ public:
     /// Render `map` at `options.elevation` to an RGBA image. In Schematic style, `legend` (when
     /// non-null) is filled with the colour key. Throws std::runtime_error when the map has nothing
     /// to draw at that elevation, or when no off-screen GL context is available.
-    sf::Image renderToImage(Map& map, const Options& options, Legend* legend = nullptr);
+    /// How the rendered pixels relate to the map's hexes. A hex's world position (Hex::x/y, the
+    /// space sprites are placed in) becomes a pixel in the output as
+    ///     px = (worldX - originX) * scale,  py = (worldY - originY) * scale
+    /// which is what an overlay needs in order to put a marker on a hex without re-deriving the
+    /// framing. Reported rather than inferred, so a change to the framing cannot silently move
+    /// everyone's markers.
+    struct Projection {
+        float originX = 0.0f;
+        float originY = 0.0f;
+        float scale = 1.0f;
+    };
+
+    sf::Image renderToImage(Map& map, const Options& options, Legend* legend = nullptr,
+        Projection* projection = nullptr);
 
 private:
-    sf::Image renderNatural(Map& map, const Options& options);
-    sf::Image renderSchematic(Map& map, const Options& options, Legend* legend);
+    sf::Image renderNatural(Map& map, const Options& options, Projection* projection);
+    sf::Image renderSchematic(Map& map, const Options& options, Legend* legend, Projection* projection);
 
     resource::GameResources& _resources;
 };


### PR DESCRIPTION
A render reports the file it wrote and its size. It does not report **how the map got onto those pixels**, so anything wanting to draw on top of one — mark where an item is, point at an NPC — has to reconstruct the framing from outside.

That is worth avoiding, because there is no way to get it slightly wrong and notice. `computeFrame` pads the bounds by 8, fits them to the longest side, and refuses to upscale a whole-map view. A consumer reimplementing that arithmetic ends up a few pixels out — or silently wrong the day the framing changes.

`renderToImage` now takes an optional `Projection`, and the CLI prints it:

```
wrote klamall.png (1600x735)
projection origin=632,256 scale=0.236407
```

A hex's world position — the same space sprites are placed in, per the existing comment in `MapRender.cpp` — becomes a pixel as `(x - originX) * scale`. Both render paths report it; nothing else changes, and the parameter defaults to `nullptr`.

Found while overlaying item and NPC markers on semantic renders for a guide's object database. With the projection reported, per-map framing stops mattering: each render carries its own, so content-cropped renders work as well as `--full` ones and are about a tenth the size.

`ctest`: 478/478.